### PR TITLE
ci: add pre-commit hooks for fmt, clippy, tests (#9)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-test
+        name: cargo test
+        entry: cargo test --all -- --test-threads=1
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/crates/cli/src/commands/analyze.rs
+++ b/crates/cli/src/commands/analyze.rs
@@ -62,7 +62,11 @@ async fn run_ai_analysis(
         default_pipeline()
     };
 
-    let stage_names: Vec<&str> = pipeline.stages.iter().map(|s| s.agent_name.as_str()).collect();
+    let stage_names: Vec<&str> = pipeline
+        .stages
+        .iter()
+        .map(|s| s.agent_name.as_str())
+        .collect();
 
     println!("Running AI vulnerability analysis...");
     println!("  Investigation: {inv_id}");
@@ -115,10 +119,7 @@ async fn run_ai_analysis(
         println!("No findings recorded.");
     } else {
         println!("{} finding(s) recorded:\n", findings.len());
-        println!(
-            "  {:<40} {:<10} {}",
-            "TITLE", "SEVERITY", "CATEGORY"
-        );
+        println!("  {:<40} {:<10} CATEGORY", "TITLE", "SEVERITY");
         println!("  {}", "-".repeat(70));
         for (title, severity, category, _evidence) in &findings {
             println!(
@@ -236,8 +237,8 @@ fn run_quick_analysis(investigation_id: Option<&str>) -> anyhow::Result<()> {
         if !active_findings.is_empty() {
             println!();
             println!(
-                "  {:<35} {:<15} {:<10} {}",
-                "FINDING", "CATEGORY", "SEVERITY", "STATUS"
+                "  {:<35} {:<15} {:<10} STATUS",
+                "FINDING", "CATEGORY", "SEVERITY"
             );
             println!("  {}", "-".repeat(85));
             for finding in &active_findings {

--- a/crates/cli/src/commands/checksec_cmd.rs
+++ b/crates/cli/src/commands/checksec_cmd.rs
@@ -10,7 +10,10 @@ pub fn run(binary: &Path) -> anyhow::Result<()> {
     let info = parse_binary(binary)?;
 
     println!("File: {}", binary.display());
-    println!("Format: {} ({}-bit, {})", info.format, info.bits, info.endianness);
+    println!(
+        "Format: {} ({}-bit, {})",
+        info.format, info.bits, info.endianness
+    );
     println!("Architecture: {}", info.architecture);
     println!();
     println!("{}", format_hardening(&info.hardening));

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -46,7 +46,10 @@ pub fn resolve_investigation(db: &GraphDb, explicit_id: Option<&str>) -> anyhow:
                 |row| row.get(0),
             )?;
             if count == 0 {
-                anyhow::bail!("Investigation '{}' not found. Run `skwaq investigate list`.", id);
+                anyhow::bail!(
+                    "Investigation '{}' not found. Run `skwaq investigate list`.",
+                    id
+                );
             }
             Ok(id.to_string())
         }

--- a/crates/cli/src/commands/config_cmd.rs
+++ b/crates/cli/src/commands/config_cmd.rs
@@ -55,9 +55,7 @@ pub fn run_show() -> anyhow::Result<()> {
 
     // Show config file location
     let candidates = ["skwaq.toml", ".skwaq/config.toml"];
-    let found = candidates
-        .iter()
-        .find(|p| std::path::Path::new(p).exists());
+    let found = candidates.iter().find(|p| std::path::Path::new(p).exists());
     match found {
         Some(path) => println!("\nLoaded from: {path}"),
         None => println!("\nUsing defaults (no skwaq.toml found)"),

--- a/crates/cli/src/commands/ingest.rs
+++ b/crates/cli/src/commands/ingest.rs
@@ -1,8 +1,8 @@
 //! `skwaq ingest` - ingest binary, source, or SARIF data.
 
 use super::IngestSub;
-use skwaq_core::analysis::DangerousApiDetector;
 use skwaq_core::analysis::surface::identify_attack_surface;
+use skwaq_core::analysis::DangerousApiDetector;
 use skwaq_core::binary::cache::AnalysisCache;
 use skwaq_core::binary::ghidra::GhidraRunner;
 use skwaq_core::binary::native::parse_binary;
@@ -19,7 +19,7 @@ pub async fn run(sub: &IngestSub) -> anyhow::Result<()> {
     }
 }
 
-async fn ingest_binary(path: &PathBuf) -> anyhow::Result<()> {
+async fn ingest_binary(path: &std::path::Path) -> anyhow::Result<()> {
     // 1. Parse the binary.
     let info = parse_binary(path)?;
 
@@ -102,7 +102,7 @@ async fn ingest_binary(path: &PathBuf) -> anyhow::Result<()> {
 /// Run Ghidra analysis if available, enriching the graph with decompiled code.
 /// Failures are non-fatal - Ghidra is optional.
 async fn run_ghidra_enrichment(
-    binary_path: &PathBuf,
+    binary_path: &std::path::Path,
     investigation_id: &str,
     builder: &GraphBuilder<'_>,
 ) {
@@ -143,7 +143,9 @@ async fn run_ghidra_enrichment(
 
     match runner.analyze(binary_path, timeout_secs).await {
         Ok(analysis) => {
-            let decompiled_count = analysis.functions.iter()
+            let decompiled_count = analysis
+                .functions
+                .iter()
                 .filter(|f| f.decompiled.is_some())
                 .count();
             println!(
@@ -161,7 +163,10 @@ async fn run_ghidra_enrichment(
             store_ghidra_results(builder, &analysis, investigation_id);
         }
         Err(e) => {
-            println!("[ghidra]  Analysis failed: {}. Continuing without decompilation.", e);
+            println!(
+                "[ghidra]  Analysis failed: {}. Continuing without decompilation.",
+                e
+            );
         }
     }
 }
@@ -176,9 +181,7 @@ fn store_ghidra_results(
         Ok(gcounts) => {
             println!(
                 "[ghidra]  Graph: {} functions updated, {} new functions, {} call edges",
-                gcounts.functions_updated,
-                gcounts.functions_added,
-                gcounts.calls_added,
+                gcounts.functions_updated, gcounts.functions_added, gcounts.calls_added,
             );
         }
         Err(e) => {
@@ -206,7 +209,8 @@ fn ingest_source(path: &PathBuf) -> anyhow::Result<()> {
     println!("[scan]    Found {} source file(s)", source_files.len());
 
     // Count files per language.
-    let mut lang_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut lang_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
     for f in &source_files {
         if let Some(lang) = detect_language(f.as_path()) {
             *lang_counts.entry(lang.to_string()).or_default() += 1;
@@ -278,10 +282,7 @@ fn ingest_source(path: &PathBuf) -> anyhow::Result<()> {
     let detector = DangerousApiDetector::new();
     let mut total_hits = 0;
     for parsed in &parsed_files {
-        match detector.detect_in_source(
-            std::path::Path::new(&parsed.path),
-            &parsed.language,
-        ) {
+        match detector.detect_in_source(std::path::Path::new(&parsed.path), &parsed.language) {
             Ok(hits) => {
                 for hit in &hits {
                     let finding_id = uuid::Uuid::new_v4().to_string();

--- a/crates/cli/src/commands/investigate.rs
+++ b/crates/cli/src/commands/investigate.rs
@@ -36,10 +36,7 @@ fn list_investigations() -> anyhow::Result<()> {
     }
 
     // Print table header.
-    println!(
-        "{:<20} {:<30} {:<10} {}",
-        "ID", "NAME", "STATUS", "CREATED"
-    );
+    println!("{:<20} {:<30} {:<10} CREATED", "ID", "NAME", "STATUS");
     println!("{}", "-".repeat(80));
 
     for (id, name, status, created) in &investigations {

--- a/crates/cli/src/commands/skills_cmd.rs
+++ b/crates/cli/src/commands/skills_cmd.rs
@@ -20,10 +20,7 @@ pub fn run_list() {
         return;
     }
 
-    println!(
-        "{:<22} {:<52} {:>6}",
-        "NAME", "DESCRIPTION", "FLAGS"
-    );
+    println!("{:<22} {:<52} {:>6}", "NAME", "DESCRIPTION", "FLAGS");
     println!("{}", "-".repeat(82));
 
     for skill in &skills {
@@ -41,10 +38,7 @@ pub fn run_list() {
             flags.push("noai");
         }
         let flags_str = flags.join(",");
-        println!(
-            "{:<22} {:<52} {:>6}",
-            skill.name, desc, flags_str,
-        );
+        println!("{:<22} {:<52} {:>6}", skill.name, desc, flags_str,);
     }
 
     println!("\n{} skill(s) found.", skills.len());

--- a/crates/cli/src/commands/surface_cmd.rs
+++ b/crates/cli/src/commands/surface_cmd.rs
@@ -27,7 +27,7 @@ pub fn run() -> anyhow::Result<()> {
         println!("  No data sources (entry points) found.");
     } else {
         println!("ENTRY POINTS (data sources):");
-        println!("  {:<30} {:<15} {}", "NAME", "TYPE", "LOCATION");
+        println!("  {:<30} {:<15} LOCATION", "NAME", "TYPE");
         println!("  {}", "-".repeat(65));
         for (name, stype, loc) in &sources {
             let loc_display = if loc.is_empty() { "-" } else { loc.as_str() };
@@ -56,14 +56,14 @@ pub fn run() -> anyhow::Result<()> {
         println!("  No data sinks (dangerous functions) found.");
     } else {
         println!("DANGEROUS SINKS:");
-        println!(
-            "  {:<30} {:<15} {:<10} {}",
-            "NAME", "TYPE", "DANGER", "LOCATION"
-        );
+        println!("  {:<30} {:<15} {:<10} LOCATION", "NAME", "TYPE", "DANGER");
         println!("  {}", "-".repeat(75));
         for (name, stype, danger, loc) in &sinks {
             let loc_display = if loc.is_empty() { "-" } else { loc.as_str() };
-            println!("  {:<30} {:<15} {:<10} {}", name, stype, danger, loc_display);
+            println!(
+                "  {:<30} {:<15} {:<10} {}",
+                name, stype, danger, loc_display
+            );
         }
         println!("\n  {} dangerous sink(s)", sinks.len());
     }

--- a/crates/cli/src/commands/symbols_cmd.rs
+++ b/crates/cli/src/commands/symbols_cmd.rs
@@ -9,13 +9,19 @@ pub fn run(binary: &Path) -> anyhow::Result<()> {
     let info = parse_binary(binary)?;
 
     if info.symbols.is_empty() && info.imports.is_empty() {
-        println!("No symbols found in {} (binary may be stripped)", binary.display());
+        println!(
+            "No symbols found in {} (binary may be stripped)",
+            binary.display()
+        );
         return Ok(());
     }
 
     if !info.symbols.is_empty() {
         println!("Symbols ({}):", info.symbols.len());
-        println!("  {:<18} {:<8} {:<10} {:<10} {}", "Address", "Size", "Type", "Bind", "Name");
+        println!(
+            "  {:<18} {:<8} {:<10} {:<10} Name",
+            "Address", "Size", "Type", "Bind"
+        );
         println!("  {}", "-".repeat(70));
         for sym in &info.symbols {
             println!(

--- a/crates/cli/src/commands/taint_cmd.rs
+++ b/crates/cli/src/commands/taint_cmd.rs
@@ -32,8 +32,8 @@ pub fn run(source_filter: Option<&str>, sink_filter: Option<&str>) -> anyhow::Re
     let filtered: Vec<_> = flows
         .iter()
         .filter(|(src, snk, _, _)| {
-            let src_match = source_filter.map_or(true, |f| src.contains(f));
-            let snk_match = sink_filter.map_or(true, |f| snk.contains(f));
+            let src_match = source_filter.is_none_or(|f| src.contains(f));
+            let snk_match = sink_filter.is_none_or(|f| snk.contains(f));
             src_match && snk_match
         })
         .collect();
@@ -43,10 +43,7 @@ pub fn run(source_filter: Option<&str>, sink_filter: Option<&str>) -> anyhow::Re
         flows.len(),
         filtered.len()
     );
-    println!(
-        "  {:<20} {:<20} {:<10} {}",
-        "SOURCE", "SINK", "SANITIZED", "PATH"
-    );
+    println!("  {:<20} {:<20} {:<10} PATH", "SOURCE", "SINK", "SANITIZED");
     println!("  {}", "-".repeat(80));
 
     for (src, snk, path, sanitized) in &filtered {

--- a/crates/cli/src/commands/viz_cmd.rs
+++ b/crates/cli/src/commands/viz_cmd.rs
@@ -31,10 +31,7 @@ pub fn run_findings() -> anyhow::Result<()> {
     }
 
     println!("Findings for investigation: {inv_id}\n");
-    println!(
-        "  {:<8} {:<40} {:<20} {}",
-        "ID", "TITLE", "AGENT", "EVIDENCE"
-    );
+    println!("  {:<8} {:<40} {:<20} EVIDENCE", "ID", "TITLE", "AGENT");
     println!("  {}", "-".repeat(100));
 
     for (id, title, agent, evidence) in &findings {
@@ -123,80 +120,77 @@ pub fn run_callgraph(root_filter: Option<&str>) -> anyhow::Result<()> {
     println!("Call graph for investigation: {inv_id}\n");
 
     for root in &roots {
-        let mut visited = HashSet::new();
-        print_tree(&children, root, "", true, &dangerous, &mut visited, 0, 5);
+        let mut ctx = TreePrintCtx {
+            children: &children,
+            dangerous: &dangerous,
+            visited: HashSet::new(),
+            max_depth: 5,
+        };
+        ctx.print_node(root, "", true, 0);
     }
 
     Ok(())
 }
 
-/// Recursively print a tree node with box-drawing characters.
-pub fn print_tree(
-    children: &HashMap<String, Vec<String>>,
-    node: &str,
-    prefix: &str,
-    is_last: bool,
-    dangerous: &HashSet<&str>,
-    visited: &mut HashSet<String>,
-    depth: usize,
+/// Shared context for recursive tree printing.
+struct TreePrintCtx<'a> {
+    children: &'a HashMap<String, Vec<String>>,
+    dangerous: &'a HashSet<&'a str>,
+    visited: HashSet<String>,
     max_depth: usize,
-) {
-    let base_name = node.split('@').next().unwrap_or(node);
-    let marker = if dangerous.contains(base_name) {
-        " [!]"
-    } else {
-        ""
-    };
+}
 
-    if depth == 0 {
-        println!("{}{}", node, marker);
-    } else {
-        let connector = if is_last {
-            "\u{2514}\u{2500}\u{2500} "
+impl TreePrintCtx<'_> {
+    /// Recursively print a tree node with box-drawing characters.
+    fn print_node(&mut self, node: &str, prefix: &str, is_last: bool, depth: usize) {
+        let base_name = node.split('@').next().unwrap_or(node);
+        let marker = if self.dangerous.contains(base_name) {
+            " [!]"
         } else {
-            "\u{251c}\u{2500}\u{2500} "
+            ""
         };
-        println!("{}{}{}{}", prefix, connector, node, marker);
-    }
 
-    if depth >= max_depth {
-        return;
-    }
-
-    if !visited.insert(node.to_string()) {
-        // Already visited -- avoid cycles
-        return;
-    }
-
-    if let Some(kids) = children.get(node) {
-        let mut sorted_kids = kids.clone();
-        sorted_kids.sort();
-        sorted_kids.dedup();
-        let count = sorted_kids.len();
-        for (i, kid) in sorted_kids.iter().enumerate() {
-            let is_last_child = i == count - 1;
-            let new_prefix = if depth == 0 {
-                if is_last_child {
-                    "    ".to_string()
-                } else {
-                    "\u{2502}   ".to_string()
-                }
+        if depth == 0 {
+            println!("{}{}", node, marker);
+        } else {
+            let connector = if is_last {
+                "\u{2514}\u{2500}\u{2500} "
             } else {
-                let ext = if is_last { "    " } else { "\u{2502}   " };
-                format!("{}{}", prefix, ext)
+                "\u{251c}\u{2500}\u{2500} "
             };
-            print_tree(
-                children,
-                kid,
-                &new_prefix,
-                is_last_child,
-                dangerous,
-                visited,
-                depth + 1,
-                max_depth,
-            );
+            println!("{}{}{}{}", prefix, connector, node, marker);
         }
-    }
 
-    visited.remove(node);
+        if depth >= self.max_depth {
+            return;
+        }
+
+        if !self.visited.insert(node.to_string()) {
+            // Already visited -- avoid cycles
+            return;
+        }
+
+        if let Some(kids) = self.children.get(node) {
+            let mut sorted_kids = kids.clone();
+            sorted_kids.sort();
+            sorted_kids.dedup();
+            let count = sorted_kids.len();
+            for (i, kid) in sorted_kids.iter().enumerate() {
+                let is_last_child = i == count - 1;
+                let new_prefix = if depth == 0 {
+                    if is_last_child {
+                        "    ".to_string()
+                    } else {
+                        "\u{2502}   ".to_string()
+                    }
+                } else {
+                    let ext = if is_last { "    " } else { "\u{2502}   " };
+                    format!("{}{}", prefix, ext)
+                };
+                self.print_node(kid, &new_prefix, is_last_child, depth + 1);
+            }
+        }
+
+        self.visited.remove(node);
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -167,9 +167,7 @@ async fn main() -> anyhow::Result<()> {
                     skwaq::commands::config_cmd::run_show()?;
                 }
                 ConfigSub::Set { key: _, value: _ } => {
-                    anyhow::bail!(
-                        "Config writing not implemented. Edit skwaq.toml directly."
-                    );
+                    anyhow::bail!("Config writing not implemented. Edit skwaq.toml directly.");
                 }
             }
         }

--- a/crates/core/src/agents/discovery.rs
+++ b/crates/core/src/agents/discovery.rs
@@ -47,10 +47,7 @@ pub fn discover_agents() -> Vec<AgentDefinition> {
                     agents.insert(def.name.clone(), def);
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Failed to parse agent file {}: {e}",
-                        entry.path().display()
-                    );
+                    tracing::warn!("Failed to parse agent file {}: {e}", entry.path().display());
                 }
             }
         }

--- a/crates/core/src/agents/pipeline.rs
+++ b/crates/core/src/agents/pipeline.rs
@@ -33,9 +33,7 @@ pub enum ContextMode {
     /// Build context from the graph database (attack surface, functions, taint flows).
     FromGraph,
     /// Use the output of previous stages as context, plus a preamble.
-    FromPreviousResults {
-        preamble: String,
-    },
+    FromPreviousResults { preamble: String },
 }
 
 impl AnalysisPipeline {
@@ -65,9 +63,7 @@ impl AnalysisPipeline {
             let agent = load_agent(&stage.agent_name)?;
 
             let context = match &stage.context_mode {
-                ContextMode::FromGraph => {
-                    build_analysis_context(target, investigation_id, db)
-                }
+                ContextMode::FromGraph => build_analysis_context(target, investigation_id, db),
                 ContextMode::FromPreviousResults { preamble } => {
                     let mut ctx = preamble.clone();
                     for prev in &results {
@@ -85,10 +81,7 @@ impl AnalysisPipeline {
                 }
             };
 
-            eprintln!(
-                "  Running agent: {} ({})",
-                agent.name, agent.description
-            );
+            eprintln!("  Running agent: {} ({})", agent.name, agent.description);
 
             let result = runner
                 .run_agent_with_db(&agent, investigation_id, &context, db, budget)

--- a/crates/core/src/agents/runner.rs
+++ b/crates/core/src/agents/runner.rs
@@ -102,9 +102,7 @@ pub fn build_analysis_context_with_limit(
     db: &GraphDb,
     max_context_chars: usize,
 ) -> String {
-    let mut parts = vec![format!(
-        "Analyze target: {target}\n\nGraph DB summary:\n"
-    )];
+    let mut parts = vec![format!("Analyze target: {target}\n\nGraph DB summary:\n")];
 
     // Summarize functions (reduced from 50 to 20)
     if let Ok(mut stmt) = db.conn().prepare(
@@ -113,9 +111,8 @@ pub fn build_analysis_context_with_limit(
         if let Ok(rows) = stmt.query_map([investigation_id], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         }) {
-            let funcs: Vec<(String, String)> = rows
-                .collect::<Result<Vec<_>, _>>()
-                .unwrap_or_default();
+            let funcs: Vec<(String, String)> =
+                rows.collect::<Result<Vec<_>, _>>().unwrap_or_default();
             if !funcs.is_empty() {
                 parts.push(format!("\n## Functions ({} shown):\n", funcs.len()));
                 for (name, addr) in &funcs {
@@ -139,14 +136,10 @@ pub fn build_analysis_context_with_limit(
                 row.get::<_, String>(2)?,
             ))
         }) {
-            let flows: Vec<(String, String, String)> = rows
-                .collect::<Result<Vec<_>, _>>()
-                .unwrap_or_default();
+            let flows: Vec<(String, String, String)> =
+                rows.collect::<Result<Vec<_>, _>>().unwrap_or_default();
             if !flows.is_empty() {
-                parts.push(format!(
-                    "\n## Unsanitized taint flows ({}):\n",
-                    flows.len()
-                ));
+                parts.push(format!("\n## Unsanitized taint flows ({}):\n", flows.len()));
                 for (src, sink, path) in &flows {
                     parts.push(format!("- {src} -> {sink}: {path}"));
                 }
@@ -181,14 +174,10 @@ pub fn build_analysis_context_with_limit(
         if let Ok(rows) = stmt.query_map(params_refs.as_slice(), |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         }) {
-            let calls: Vec<(String, String)> = rows
-                .collect::<Result<Vec<_>, _>>()
-                .unwrap_or_default();
+            let calls: Vec<(String, String)> =
+                rows.collect::<Result<Vec<_>, _>>().unwrap_or_default();
             if !calls.is_empty() {
-                parts.push(format!(
-                    "\n## Dangerous API calls ({}):\n",
-                    calls.len()
-                ));
+                parts.push(format!("\n## Dangerous API calls ({}):\n", calls.len()));
                 for (caller, callee) in &calls {
                     parts.push(format!("- {caller} -> {callee}"));
                 }

--- a/crates/core/src/agents/tool_executor.rs
+++ b/crates/core/src/agents/tool_executor.rs
@@ -2,8 +2,8 @@
 //!
 //! Every tool queries or mutates the actual database - no placeholder data.
 
+use super::tool_translate::{execute_read_query, translate_to_sql};
 use crate::graph::GraphDb;
-use super::tool_translate::{translate_to_sql, execute_read_query};
 
 /// Execute a single tool call against the real graph database.
 ///
@@ -21,8 +21,12 @@ pub fn execute_tool(
         "get_callers" => execute_get_callers(db, investigation_id, args),
         "get_callees" => execute_get_callees(db, investigation_id, args),
         "lookup_cwe" => execute_lookup_cwe(db, args),
-        "create_finding" => super::tool_translate::execute_create_finding(db, investigation_id, args),
-        "search_similar" => super::tool_translate::execute_search_similar(db, investigation_id, args),
+        "create_finding" => {
+            super::tool_translate::execute_create_finding(db, investigation_id, args)
+        }
+        "search_similar" => {
+            super::tool_translate::execute_search_similar(db, investigation_id, args)
+        }
         _ => {
             tracing::warn!("Unknown tool: {name}");
             Ok(serde_json::json!({
@@ -38,10 +42,7 @@ fn execute_query_graph(
     investigation_id: &str,
     args: &serde_json::Value,
 ) -> anyhow::Result<serde_json::Value> {
-    let query = args
-        .get("cypher")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let query = args.get("cypher").and_then(|v| v.as_str()).unwrap_or("");
     tracing::info!("Tool query_graph: {query}");
 
     if query.is_empty() {
@@ -254,10 +255,7 @@ fn execute_get_callees(
 }
 
 /// Look up a CWE entry by ID.
-fn execute_lookup_cwe(
-    db: &GraphDb,
-    args: &serde_json::Value,
-) -> anyhow::Result<serde_json::Value> {
+fn execute_lookup_cwe(db: &GraphDb, args: &serde_json::Value) -> anyhow::Result<serde_json::Value> {
     let cwe_id = args
         .get("cwe_id")
         .and_then(|v| v.as_str())
@@ -341,12 +339,22 @@ mod tests {
 
         db.execute(
             "INSERT INTO functions (id, name, address, investigation_id) VALUES (?1, ?2, ?3, ?4)",
-            &[&"f1" as &dyn rusqlite::types::ToSql, &"main", &"0x401000", &inv_id],
+            &[
+                &"f1" as &dyn rusqlite::types::ToSql,
+                &"main",
+                &"0x401000",
+                &inv_id,
+            ],
         )
         .unwrap();
         db.execute(
             "INSERT INTO functions (id, name, address, investigation_id) VALUES (?1, ?2, ?3, ?4)",
-            &[&"f2" as &dyn rusqlite::types::ToSql, &"strcpy", &"0x402000", &inv_id],
+            &[
+                &"f2" as &dyn rusqlite::types::ToSql,
+                &"strcpy",
+                &"0x402000",
+                &inv_id,
+            ],
         )
         .unwrap();
         db.execute(
@@ -370,12 +378,22 @@ mod tests {
 
         db.execute(
             "INSERT INTO functions (id, name, address, investigation_id) VALUES (?1, ?2, ?3, ?4)",
-            &[&"f1" as &dyn rusqlite::types::ToSql, &"main", &"0x401000", &inv_id],
+            &[
+                &"f1" as &dyn rusqlite::types::ToSql,
+                &"main",
+                &"0x401000",
+                &inv_id,
+            ],
         )
         .unwrap();
         db.execute(
             "INSERT INTO functions (id, name, address, investigation_id) VALUES (?1, ?2, ?3, ?4)",
-            &[&"f2" as &dyn rusqlite::types::ToSql, &"system", &"0x402000", &inv_id],
+            &[
+                &"f2" as &dyn rusqlite::types::ToSql,
+                &"system",
+                &"0x402000",
+                &inv_id,
+            ],
         )
         .unwrap();
         db.execute(
@@ -458,7 +476,12 @@ mod tests {
 
         db.execute(
             "INSERT INTO functions (id, name, address, investigation_id) VALUES (?1, ?2, ?3, ?4)",
-            &[&"f1" as &dyn rusqlite::types::ToSql, &"main", &"0x401000", &inv_id],
+            &[
+                &"f1" as &dyn rusqlite::types::ToSql,
+                &"main",
+                &"0x401000",
+                &inv_id,
+            ],
         )
         .unwrap();
 
@@ -518,7 +541,10 @@ mod tests {
         let result = execute_tool(&db, inv_id, "query_graph", &args).unwrap();
 
         assert_eq!(result["status"], "error");
-        assert!(result["error"].as_str().unwrap().contains("Unsupported query pattern"));
+        assert!(result["error"]
+            .as_str()
+            .unwrap()
+            .contains("Unsupported query pattern"));
 
         // Verify no data was actually inserted
         let count: i64 = db

--- a/crates/core/src/agents/tool_translate.rs
+++ b/crates/core/src/agents/tool_translate.rs
@@ -7,7 +7,10 @@ use crate::graph::GraphDb;
 /// Returns `(sql, params)` where params contains the investigation_id
 /// for the `?1` placeholder. Only predefined patterns are supported;
 /// arbitrary SQL (including raw SELECT from the LLM) is rejected.
-pub fn translate_to_sql(query: &str, investigation_id: &str) -> Result<(String, Vec<String>), String> {
+pub fn translate_to_sql(
+    query: &str,
+    investigation_id: &str,
+) -> Result<(String, Vec<String>), String> {
     let q = query.trim();
     let upper = q.to_uppercase();
 
@@ -56,7 +59,9 @@ pub fn execute_read_query(
 ) -> anyhow::Result<Vec<serde_json::Value>> {
     let stmt = db.conn().prepare(sql)?;
     if !stmt.readonly() {
-        return Ok(vec![serde_json::json!({"error": "Only read-only queries are allowed. Write operations are not permitted."})]);
+        return Ok(vec![
+            serde_json::json!({"error": "Only read-only queries are allowed. Write operations are not permitted."}),
+        ]);
     }
     let mut stmt = stmt;
     let column_count = stmt.column_count();
@@ -64,8 +69,10 @@ pub fn execute_read_query(
         .map(|i| stmt.column_name(i).unwrap_or("?").to_string())
         .collect();
 
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-        params.iter().map(|s| s as &dyn rusqlite::types::ToSql).collect();
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
 
     let rows = stmt.query_map(param_refs.as_slice(), |row| {
         let mut obj = serde_json::Map::new();
@@ -117,9 +124,18 @@ pub(super) fn execute_create_finding(
     investigation_id: &str,
     args: &serde_json::Value,
 ) -> anyhow::Result<serde_json::Value> {
-    let title = args.get("title").and_then(|v| v.as_str()).unwrap_or("Untitled");
-    let severity = args.get("severity").and_then(|v| v.as_str()).unwrap_or("medium");
-    let description = args.get("description").and_then(|v| v.as_str()).unwrap_or("");
+    let title = args
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Untitled");
+    let severity = args
+        .get("severity")
+        .and_then(|v| v.as_str())
+        .unwrap_or("medium");
+    let description = args
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let function = args.get("function").and_then(|v| v.as_str()).unwrap_or("");
     let cwe_id = args.get("cwe_id").and_then(|v| v.as_str()).unwrap_or("");
 
@@ -135,9 +151,15 @@ pub(super) fn execute_create_finding(
         "INSERT INTO findings (id, title, evidence, agent, timestamp, investigation_id, \
          status, severity, category) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         &[
-            &finding_id as &dyn rusqlite::types::ToSql, &title,
-            &evidence.to_string(), &"vuln_hunter", &timestamp,
-            &investigation_id, &"new", &severity, &cwe_id,
+            &finding_id as &dyn rusqlite::types::ToSql,
+            &title,
+            &evidence.to_string(),
+            &"vuln_hunter",
+            &timestamp,
+            &investigation_id,
+            &"new",
+            &severity,
+            &cwe_id,
         ],
     )?;
 
@@ -167,7 +189,13 @@ pub(super) fn execute_search_similar(
 
     let rows = stmt.query_map(
         rusqlite::params![investigation_id, search_pattern, limit as i64],
-        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?)),
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        },
     )?;
 
     let results: Vec<serde_json::Value> = rows
@@ -197,7 +225,12 @@ mod tests {
         let db = GraphDb::in_memory().unwrap();
 
         // Directly test execute_read_query with a write statement
-        let result = execute_read_query(&db, "INSERT INTO functions (id, name) VALUES ('evil', 'injected')", &[]).unwrap();
+        let result = execute_read_query(
+            &db,
+            "INSERT INTO functions (id, name) VALUES ('evil', 'injected')",
+            &[],
+        )
+        .unwrap();
 
         // Should return an error entry instead of executing
         assert_eq!(result.len(), 1);

--- a/crates/core/src/analysis/findings.rs
+++ b/crates/core/src/analysis/findings.rs
@@ -32,7 +32,7 @@ impl std::fmt::Display for FindingStatus {
 
 impl FindingStatus {
     /// Parse a status string back into the enum.
-    pub fn from_str(s: &str) -> Self {
+    pub fn parse(s: &str) -> Self {
         match s {
             "confirmed" => Self::Confirmed,
             "challenged" => Self::Challenged,
@@ -105,11 +105,17 @@ mod tests {
 
     #[test]
     fn test_finding_status_from_str() {
-        assert_eq!(FindingStatus::from_str("confirmed"), FindingStatus::Confirmed);
-        assert_eq!(FindingStatus::from_str("challenged"), FindingStatus::Challenged);
-        assert_eq!(FindingStatus::from_str("invalidated"), FindingStatus::Invalidated);
-        assert_eq!(FindingStatus::from_str("new"), FindingStatus::New);
-        assert_eq!(FindingStatus::from_str("unknown"), FindingStatus::New);
+        assert_eq!(FindingStatus::parse("confirmed"), FindingStatus::Confirmed);
+        assert_eq!(
+            FindingStatus::parse("challenged"),
+            FindingStatus::Challenged
+        );
+        assert_eq!(
+            FindingStatus::parse("invalidated"),
+            FindingStatus::Invalidated
+        );
+        assert_eq!(FindingStatus::parse("new"), FindingStatus::New);
+        assert_eq!(FindingStatus::parse("unknown"), FindingStatus::New);
     }
 
     #[test]

--- a/crates/core/src/analysis/orchestrator.rs
+++ b/crates/core/src/analysis/orchestrator.rs
@@ -6,7 +6,7 @@
 //! (no new findings and no invalidations in the latest cycle).
 
 use crate::analysis::findings::{Finding, FindingStatus, FindingUpdate};
-use crate::analysis::{perspective_pattern, perspective_dataflow, perspective_context};
+use crate::analysis::{perspective_context, perspective_dataflow, perspective_pattern};
 use crate::graph::GraphDb;
 
 /// Result of a single analysis cycle.
@@ -42,10 +42,7 @@ impl<'a> AnalysisOrchestrator<'a> {
     /// Returns the history of all cycles run. The final cycle's findings
     /// list contains the definitive results with statuses reflecting
     /// the full analysis.
-    pub fn run_quick_analysis(
-        &self,
-        investigation_id: &str,
-    ) -> anyhow::Result<Vec<AnalysisCycle>> {
+    pub fn run_quick_analysis(&self, investigation_id: &str) -> anyhow::Result<Vec<AnalysisCycle>> {
         let mut cycles = Vec::new();
         let mut all_findings: Vec<Finding> = Vec::new();
 
@@ -85,8 +82,11 @@ impl<'a> AnalysisOrchestrator<'a> {
                 // Cycle 1: Pattern detection + taint analysis + source/sink ID
                 let pattern_findings =
                     perspective_pattern::pattern_perspective(self.db, investigation_id, cycle_num);
-                let dataflow_findings =
-                    perspective_dataflow::dataflow_perspective(self.db, investigation_id, cycle_num);
+                let dataflow_findings = perspective_dataflow::dataflow_perspective(
+                    self.db,
+                    investigation_id,
+                    cycle_num,
+                );
 
                 let new_count = pattern_findings.len() + dataflow_findings.len();
                 all_findings.extend(pattern_findings);
@@ -149,11 +149,7 @@ impl<'a> AnalysisOrchestrator<'a> {
     }
 
     /// Persist final findings to the database.
-    fn store_findings(
-        &self,
-        investigation_id: &str,
-        findings: &[Finding],
-    ) -> anyhow::Result<()> {
+    fn store_findings(&self, investigation_id: &str, findings: &[Finding]) -> anyhow::Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
 
         for finding in findings {
@@ -229,7 +225,7 @@ mod tests {
         let orch = AnalysisOrchestrator::new(&db, 5);
         let cycles = orch.run_quick_analysis("inv1").unwrap();
         // Should run 2 cycles (cycle 1 finds nothing, cycle 2 finds nothing => convergence)
-        assert!(cycles.len() >= 1);
+        assert!(!cycles.is_empty());
         assert_eq!(cycles[0].new_findings, 0);
     }
 
@@ -339,7 +335,12 @@ mod tests {
 
         // At least some findings should be confirmed or invalidated
         assert!(
-            confirmed > 0 || invalidated > 0 || last.findings.iter().any(|f| f.status == FindingStatus::Challenged),
+            confirmed > 0
+                || invalidated > 0
+                || last
+                    .findings
+                    .iter()
+                    .any(|f| f.status == FindingStatus::Challenged),
             "Cycle 2+ should have processed findings"
         );
     }
@@ -433,10 +434,7 @@ mod tests {
         assert!(!cycles.is_empty());
 
         // Check that invalidated findings are not in the DB
-        let mut stmt = db
-            .conn()
-            .prepare("SELECT status FROM findings")
-            .unwrap();
+        let mut stmt = db.conn().prepare("SELECT status FROM findings").unwrap();
         let statuses: Vec<String> = stmt
             .query_map([], |row| row.get::<_, String>(0))
             .unwrap()
@@ -444,7 +442,10 @@ mod tests {
             .collect();
 
         for status in &statuses {
-            assert_ne!(status, "invalidated", "Invalidated findings should not be stored");
+            assert_ne!(
+                status, "invalidated",
+                "Invalidated findings should not be stored"
+            );
         }
     }
 }

--- a/crates/core/src/analysis/patterns.rs
+++ b/crates/core/src/analysis/patterns.rs
@@ -72,34 +72,154 @@ pub(crate) struct DangerousEntry {
 /// All known dangerous C/C++ APIs with their categories.
 pub(crate) const DANGEROUS_APIS: &[DangerousEntry] = &[
     // Memory safety
-    DangerousEntry { name: "strcpy",   category: DangerCategory::Memory,       severity: Severity::Critical, reason: "unbounded copy; use strncpy or strlcpy" },
-    DangerousEntry { name: "strcat",   category: DangerCategory::Memory,       severity: Severity::Critical, reason: "unbounded concatenation; use strncat or strlcat" },
-    DangerousEntry { name: "gets",     category: DangerCategory::Memory,       severity: Severity::Critical, reason: "no bounds checking; use fgets" },
-    DangerousEntry { name: "memcpy",   category: DangerCategory::Memory,       severity: Severity::Medium,   reason: "no bounds checking; verify size parameter" },
-    DangerousEntry { name: "memmove",  category: DangerCategory::Memory,       severity: Severity::Medium,   reason: "no bounds checking; verify size parameter" },
-    DangerousEntry { name: "strncpy",  category: DangerCategory::Memory,       severity: Severity::Low,      reason: "may not null-terminate; prefer strlcpy" },
-    DangerousEntry { name: "strncat",  category: DangerCategory::Memory,       severity: Severity::Low,      reason: "size semantics are error-prone; prefer strlcat" },
+    DangerousEntry {
+        name: "strcpy",
+        category: DangerCategory::Memory,
+        severity: Severity::Critical,
+        reason: "unbounded copy; use strncpy or strlcpy",
+    },
+    DangerousEntry {
+        name: "strcat",
+        category: DangerCategory::Memory,
+        severity: Severity::Critical,
+        reason: "unbounded concatenation; use strncat or strlcat",
+    },
+    DangerousEntry {
+        name: "gets",
+        category: DangerCategory::Memory,
+        severity: Severity::Critical,
+        reason: "no bounds checking; use fgets",
+    },
+    DangerousEntry {
+        name: "memcpy",
+        category: DangerCategory::Memory,
+        severity: Severity::Medium,
+        reason: "no bounds checking; verify size parameter",
+    },
+    DangerousEntry {
+        name: "memmove",
+        category: DangerCategory::Memory,
+        severity: Severity::Medium,
+        reason: "no bounds checking; verify size parameter",
+    },
+    DangerousEntry {
+        name: "strncpy",
+        category: DangerCategory::Memory,
+        severity: Severity::Low,
+        reason: "may not null-terminate; prefer strlcpy",
+    },
+    DangerousEntry {
+        name: "strncat",
+        category: DangerCategory::Memory,
+        severity: Severity::Low,
+        reason: "size semantics are error-prone; prefer strlcat",
+    },
     // Format string
-    DangerousEntry { name: "sprintf",  category: DangerCategory::FormatString, severity: Severity::High,     reason: "unbounded format output; use snprintf" },
-    DangerousEntry { name: "vsprintf", category: DangerCategory::FormatString, severity: Severity::High,     reason: "unbounded format output; use vsnprintf" },
-    DangerousEntry { name: "scanf",    category: DangerCategory::FormatString, severity: Severity::High,     reason: "unbounded input; use width specifiers or fgets" },
-    DangerousEntry { name: "fscanf",   category: DangerCategory::FormatString, severity: Severity::High,     reason: "unbounded input; use width specifiers" },
-    DangerousEntry { name: "sscanf",   category: DangerCategory::FormatString, severity: Severity::Medium,   reason: "potential buffer overflow with %s" },
+    DangerousEntry {
+        name: "sprintf",
+        category: DangerCategory::FormatString,
+        severity: Severity::High,
+        reason: "unbounded format output; use snprintf",
+    },
+    DangerousEntry {
+        name: "vsprintf",
+        category: DangerCategory::FormatString,
+        severity: Severity::High,
+        reason: "unbounded format output; use vsnprintf",
+    },
+    DangerousEntry {
+        name: "scanf",
+        category: DangerCategory::FormatString,
+        severity: Severity::High,
+        reason: "unbounded input; use width specifiers or fgets",
+    },
+    DangerousEntry {
+        name: "fscanf",
+        category: DangerCategory::FormatString,
+        severity: Severity::High,
+        reason: "unbounded input; use width specifiers",
+    },
+    DangerousEntry {
+        name: "sscanf",
+        category: DangerCategory::FormatString,
+        severity: Severity::Medium,
+        reason: "potential buffer overflow with %s",
+    },
     // Injection / command execution
-    DangerousEntry { name: "system",   category: DangerCategory::Injection,    severity: Severity::Critical, reason: "shell injection risk; use exec* family directly" },
-    DangerousEntry { name: "popen",    category: DangerCategory::Injection,    severity: Severity::Critical, reason: "shell injection risk; use pipe+fork+exec" },
-    DangerousEntry { name: "exec",     category: DangerCategory::Injection,    severity: Severity::High,     reason: "command execution; validate all arguments" },
-    DangerousEntry { name: "execl",    category: DangerCategory::Injection,    severity: Severity::High,     reason: "command execution; validate all arguments" },
-    DangerousEntry { name: "execle",   category: DangerCategory::Injection,    severity: Severity::High,     reason: "command execution; validate all arguments" },
-    DangerousEntry { name: "execlp",   category: DangerCategory::Injection,    severity: Severity::High,     reason: "command execution with PATH search; validate arguments" },
-    DangerousEntry { name: "execv",    category: DangerCategory::Injection,    severity: Severity::High,     reason: "command execution; validate all arguments" },
-    DangerousEntry { name: "execvp",   category: DangerCategory::Injection,    severity: Severity::High,     reason: "command execution with PATH search; validate arguments" },
-    DangerousEntry { name: "execvpe",  category: DangerCategory::Injection,    severity: Severity::High,     reason: "command execution with PATH/env; validate arguments" },
+    DangerousEntry {
+        name: "system",
+        category: DangerCategory::Injection,
+        severity: Severity::Critical,
+        reason: "shell injection risk; use exec* family directly",
+    },
+    DangerousEntry {
+        name: "popen",
+        category: DangerCategory::Injection,
+        severity: Severity::Critical,
+        reason: "shell injection risk; use pipe+fork+exec",
+    },
+    DangerousEntry {
+        name: "exec",
+        category: DangerCategory::Injection,
+        severity: Severity::High,
+        reason: "command execution; validate all arguments",
+    },
+    DangerousEntry {
+        name: "execl",
+        category: DangerCategory::Injection,
+        severity: Severity::High,
+        reason: "command execution; validate all arguments",
+    },
+    DangerousEntry {
+        name: "execle",
+        category: DangerCategory::Injection,
+        severity: Severity::High,
+        reason: "command execution; validate all arguments",
+    },
+    DangerousEntry {
+        name: "execlp",
+        category: DangerCategory::Injection,
+        severity: Severity::High,
+        reason: "command execution with PATH search; validate arguments",
+    },
+    DangerousEntry {
+        name: "execv",
+        category: DangerCategory::Injection,
+        severity: Severity::High,
+        reason: "command execution; validate all arguments",
+    },
+    DangerousEntry {
+        name: "execvp",
+        category: DangerCategory::Injection,
+        severity: Severity::High,
+        reason: "command execution with PATH search; validate arguments",
+    },
+    DangerousEntry {
+        name: "execvpe",
+        category: DangerCategory::Injection,
+        severity: Severity::High,
+        reason: "command execution with PATH/env; validate arguments",
+    },
     // Temp file / race condition
-    DangerousEntry { name: "mktemp",   category: DangerCategory::Race,        severity: Severity::Medium,   reason: "TOCTOU race; use mkstemp" },
-    DangerousEntry { name: "tmpnam",   category: DangerCategory::TempFile,    severity: Severity::Medium,   reason: "TOCTOU race; use tmpfile or mkstemp" },
+    DangerousEntry {
+        name: "mktemp",
+        category: DangerCategory::Race,
+        severity: Severity::Medium,
+        reason: "TOCTOU race; use mkstemp",
+    },
+    DangerousEntry {
+        name: "tmpnam",
+        category: DangerCategory::TempFile,
+        severity: Severity::Medium,
+        reason: "TOCTOU race; use tmpfile or mkstemp",
+    },
     // Path traversal
-    DangerousEntry { name: "realpath", category: DangerCategory::PathTraversal, severity: Severity::Low,    reason: "buffer overflow in some implementations; check buffer size" },
+    DangerousEntry {
+        name: "realpath",
+        category: DangerCategory::PathTraversal,
+        severity: Severity::Low,
+        reason: "buffer overflow in some implementations; check buffer size",
+    },
 ];
 
 /// A detected use of a dangerous API.

--- a/crates/core/src/analysis/patterns_binary.rs
+++ b/crates/core/src/analysis/patterns_binary.rs
@@ -30,8 +30,10 @@ impl DangerousApiDetector {
         imports
             .iter()
             .filter_map(|imp| {
-                self.entries.iter().find(|e| e.name == imp.name.as_str()).map(|entry| {
-                    DangerousApiHit {
+                self.entries
+                    .iter()
+                    .find(|e| e.name == imp.name.as_str())
+                    .map(|entry| DangerousApiHit {
                         function_name: imp.name.clone(),
                         library: imp.library.clone(),
                         reason: entry.reason.to_string(),
@@ -39,8 +41,7 @@ impl DangerousApiDetector {
                         severity: entry.severity.clone(),
                         file: String::new(),
                         line: 0,
-                    }
-                })
+                    })
             })
             .collect()
     }
@@ -53,9 +54,7 @@ impl DangerousApiDetector {
         let mut seen = std::collections::HashSet::new();
 
         // Check function names (strip @version suffix for matching)
-        let mut stmt = db.conn().prepare(
-            "SELECT f.name FROM functions f",
-        )?;
+        let mut stmt = db.conn().prepare("SELECT f.name FROM functions f")?;
         let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
         for row in rows {
             let name = row?;
@@ -76,9 +75,9 @@ impl DangerousApiDetector {
         }
 
         // Check imports stored in the symbols table
-        let mut stmt = db.conn().prepare(
-            "SELECT s.name FROM symbols s WHERE s.symbol_type = 'import'",
-        )?;
+        let mut stmt = db
+            .conn()
+            .prepare("SELECT s.name FROM symbols s WHERE s.symbol_type = 'import'")?;
         let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
         for row in rows {
             let name = row?;
@@ -99,9 +98,9 @@ impl DangerousApiDetector {
         }
 
         // Check data_sinks (already classified during ingestion)
-        let mut stmt = db.conn().prepare(
-            "SELECT s.name, s.danger_level FROM data_sinks s",
-        )?;
+        let mut stmt = db
+            .conn()
+            .prepare("SELECT s.name, s.danger_level FROM data_sinks s")?;
         let rows = stmt.query_map([], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })?;
@@ -163,9 +162,18 @@ mod tests {
     fn test_check_imports_finds_dangerous() {
         let detector = DangerousApiDetector::new();
         let imports = vec![
-            ImportInfo { name: "strcpy".into(), library: "libc.so.6".into() },
-            ImportInfo { name: "safe_func".into(), library: "libfoo.so".into() },
-            ImportInfo { name: "system".into(), library: "libc.so.6".into() },
+            ImportInfo {
+                name: "strcpy".into(),
+                library: "libc.so.6".into(),
+            },
+            ImportInfo {
+                name: "safe_func".into(),
+                library: "libfoo.so".into(),
+            },
+            ImportInfo {
+                name: "system".into(),
+                library: "libc.so.6".into(),
+            },
         ];
         let hits = detector.check_imports(&imports);
         assert_eq!(hits.len(), 2);
@@ -181,15 +189,18 @@ mod tests {
         db.execute(
             "INSERT INTO functions (id, name) VALUES ('f1', 'strcpy')",
             &[],
-        ).unwrap();
+        )
+        .unwrap();
         db.execute(
             "INSERT INTO functions (id, name) VALUES ('f2', 'main')",
             &[],
-        ).unwrap();
+        )
+        .unwrap();
         db.execute(
             "INSERT INTO calls (caller_id, callee_id) VALUES ('f2', 'f1')",
             &[],
-        ).unwrap();
+        )
+        .unwrap();
 
         let detector = DangerousApiDetector::new();
         let hits = detector.detect(&db).unwrap();
@@ -201,8 +212,14 @@ mod tests {
     fn test_no_false_positives() {
         let detector = DangerousApiDetector::new();
         let imports = vec![
-            ImportInfo { name: "printf".into(), library: "libc.so.6".into() },
-            ImportInfo { name: "malloc".into(), library: "libc.so.6".into() },
+            ImportInfo {
+                name: "printf".into(),
+                library: "libc.so.6".into(),
+            },
+            ImportInfo {
+                name: "malloc".into(),
+                library: "libc.so.6".into(),
+            },
         ];
         let hits = detector.check_imports(&imports);
         assert!(hits.is_empty());

--- a/crates/core/src/analysis/patterns_source.rs
+++ b/crates/core/src/analysis/patterns_source.rs
@@ -12,75 +12,296 @@ pub(crate) struct SourcePattern {
 
 fn python_patterns() -> &'static [SourcePattern] {
     &[
-        SourcePattern { regex: r"\beval\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "eval() executes arbitrary code; use ast.literal_eval() for data" },
-        SourcePattern { regex: r"\bexec\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "exec() executes arbitrary code; avoid or sandbox" },
-        SourcePattern { regex: r"\bos\.system\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "os.system() passes commands to shell; use subprocess with shell=False" },
-        SourcePattern { regex: r"\bsubprocess\.call\s*\(", category: DangerCategory::Injection, severity: Severity::High, reason: "subprocess.call may use shell; ensure shell=False and validate inputs" },
-        SourcePattern { regex: r"\bsubprocess\.Popen\s*\(", category: DangerCategory::Injection, severity: Severity::High, reason: "Popen may use shell; ensure shell=False and validate inputs" },
-        SourcePattern { regex: r"\bpickle\.loads?\s*\(", category: DangerCategory::Deserialization, severity: Severity::Critical, reason: "pickle deserialization executes arbitrary code; use json or safe alternatives" },
-        SourcePattern { regex: r"\byaml\.load\s*\(", category: DangerCategory::Deserialization, severity: Severity::High, reason: "yaml.load is unsafe; use yaml.safe_load" },
-        SourcePattern { regex: r"\b__import__\s*\(", category: DangerCategory::Injection, severity: Severity::High, reason: "__import__() can load arbitrary modules; validate input" },
-        SourcePattern { regex: r"\bshelve\.open\s*\(", category: DangerCategory::Deserialization, severity: Severity::High, reason: "shelve uses pickle internally; avoid with untrusted data" },
-        SourcePattern { regex: r"\bmarshall\.loads?\s*\(", category: DangerCategory::Deserialization, severity: Severity::High, reason: "marshal deserialization can execute code; use json" },
-        SourcePattern { regex: r"\bcursor\.execute\s*\([^)]*%", category: DangerCategory::Injection, severity: Severity::Critical, reason: "SQL injection via string formatting; use parameterized queries" },
-        SourcePattern { regex: r#"\bcursor\.execute\s*\([^)]*\+\s*"#, category: DangerCategory::Injection, severity: Severity::Critical, reason: "SQL injection via string concatenation; use parameterized queries" },
+        SourcePattern {
+            regex: r"\beval\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "eval() executes arbitrary code; use ast.literal_eval() for data",
+        },
+        SourcePattern {
+            regex: r"\bexec\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "exec() executes arbitrary code; avoid or sandbox",
+        },
+        SourcePattern {
+            regex: r"\bos\.system\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "os.system() passes commands to shell; use subprocess with shell=False",
+        },
+        SourcePattern {
+            regex: r"\bsubprocess\.call\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "subprocess.call may use shell; ensure shell=False and validate inputs",
+        },
+        SourcePattern {
+            regex: r"\bsubprocess\.Popen\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "Popen may use shell; ensure shell=False and validate inputs",
+        },
+        SourcePattern {
+            regex: r"\bpickle\.loads?\s*\(",
+            category: DangerCategory::Deserialization,
+            severity: Severity::Critical,
+            reason: "pickle deserialization executes arbitrary code; use json or safe alternatives",
+        },
+        SourcePattern {
+            regex: r"\byaml\.load\s*\(",
+            category: DangerCategory::Deserialization,
+            severity: Severity::High,
+            reason: "yaml.load is unsafe; use yaml.safe_load",
+        },
+        SourcePattern {
+            regex: r"\b__import__\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "__import__() can load arbitrary modules; validate input",
+        },
+        SourcePattern {
+            regex: r"\bshelve\.open\s*\(",
+            category: DangerCategory::Deserialization,
+            severity: Severity::High,
+            reason: "shelve uses pickle internally; avoid with untrusted data",
+        },
+        SourcePattern {
+            regex: r"\bmarshall\.loads?\s*\(",
+            category: DangerCategory::Deserialization,
+            severity: Severity::High,
+            reason: "marshal deserialization can execute code; use json",
+        },
+        SourcePattern {
+            regex: r"\bcursor\.execute\s*\([^)]*%",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "SQL injection via string formatting; use parameterized queries",
+        },
+        SourcePattern {
+            regex: r#"\bcursor\.execute\s*\([^)]*\+\s*"#,
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "SQL injection via string concatenation; use parameterized queries",
+        },
     ]
 }
 
 fn javascript_patterns() -> &'static [SourcePattern] {
     &[
-        SourcePattern { regex: r"\beval\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "eval() executes arbitrary code; avoid entirely" },
-        SourcePattern { regex: r"\.innerHTML\s*=", category: DangerCategory::Xss, severity: Severity::High, reason: "innerHTML can execute scripts; use textContent or sanitize" },
-        SourcePattern { regex: r"\bdocument\.write\s*\(", category: DangerCategory::Xss, severity: Severity::High, reason: "document.write can inject scripts; use DOM API" },
-        SourcePattern { regex: r"\bchild_process\.exec\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "child_process.exec uses shell; use execFile or spawn" },
-        SourcePattern { regex: r"\bnew\s+Function\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "new Function() is eval-equivalent; avoid" },
-        SourcePattern { regex: r#"\bsetTimeout\s*\(\s*['""]"#, category: DangerCategory::Injection, severity: Severity::High, reason: "setTimeout with string arg is eval-equivalent; pass a function reference" },
-        SourcePattern { regex: r#"\bsetInterval\s*\(\s*['""]"#, category: DangerCategory::Injection, severity: Severity::High, reason: "setInterval with string arg is eval-equivalent; pass a function reference" },
-        SourcePattern { regex: r"__proto__", category: DangerCategory::PrototypePollution, severity: Severity::High, reason: "prototype pollution via __proto__; validate or freeze prototypes" },
-        SourcePattern { regex: r"\bconstructor\s*\[", category: DangerCategory::PrototypePollution, severity: Severity::High, reason: "prototype pollution via constructor; sanitize keys" },
+        SourcePattern {
+            regex: r"\beval\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "eval() executes arbitrary code; avoid entirely",
+        },
+        SourcePattern {
+            regex: r"\.innerHTML\s*=",
+            category: DangerCategory::Xss,
+            severity: Severity::High,
+            reason: "innerHTML can execute scripts; use textContent or sanitize",
+        },
+        SourcePattern {
+            regex: r"\bdocument\.write\s*\(",
+            category: DangerCategory::Xss,
+            severity: Severity::High,
+            reason: "document.write can inject scripts; use DOM API",
+        },
+        SourcePattern {
+            regex: r"\bchild_process\.exec\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "child_process.exec uses shell; use execFile or spawn",
+        },
+        SourcePattern {
+            regex: r"\bnew\s+Function\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "new Function() is eval-equivalent; avoid",
+        },
+        SourcePattern {
+            regex: r#"\bsetTimeout\s*\(\s*['""]"#,
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "setTimeout with string arg is eval-equivalent; pass a function reference",
+        },
+        SourcePattern {
+            regex: r#"\bsetInterval\s*\(\s*['""]"#,
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "setInterval with string arg is eval-equivalent; pass a function reference",
+        },
+        SourcePattern {
+            regex: r"__proto__",
+            category: DangerCategory::PrototypePollution,
+            severity: Severity::High,
+            reason: "prototype pollution via __proto__; validate or freeze prototypes",
+        },
+        SourcePattern {
+            regex: r"\bconstructor\s*\[",
+            category: DangerCategory::PrototypePollution,
+            severity: Severity::High,
+            reason: "prototype pollution via constructor; sanitize keys",
+        },
     ]
 }
 
 fn go_patterns() -> &'static [SourcePattern] {
     &[
-        SourcePattern { regex: r"\bexec\.Command\s*\(", category: DangerCategory::Injection, severity: Severity::High, reason: "exec.Command runs external processes; validate arguments" },
-        SourcePattern { regex: r"\btemplate\.HTML\s*\(", category: DangerCategory::Xss, severity: Severity::High, reason: "template.HTML bypasses escaping; sanitize input" },
-        SourcePattern { regex: r#"\bsql\.Query\s*\([^)]*\+"#, category: DangerCategory::Injection, severity: Severity::Critical, reason: "SQL injection via concatenation; use parameterized queries" },
-        SourcePattern { regex: r#"\bdb\.Exec\s*\([^)]*\+"#, category: DangerCategory::Injection, severity: Severity::Critical, reason: "SQL injection via concatenation; use parameterized queries" },
-        SourcePattern { regex: r"\bhttp\.ListenAndServe\s*\(", category: DangerCategory::Crypto, severity: Severity::Medium, reason: "HTTP without TLS; use ListenAndServeTLS for production" },
+        SourcePattern {
+            regex: r"\bexec\.Command\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "exec.Command runs external processes; validate arguments",
+        },
+        SourcePattern {
+            regex: r"\btemplate\.HTML\s*\(",
+            category: DangerCategory::Xss,
+            severity: Severity::High,
+            reason: "template.HTML bypasses escaping; sanitize input",
+        },
+        SourcePattern {
+            regex: r#"\bsql\.Query\s*\([^)]*\+"#,
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "SQL injection via concatenation; use parameterized queries",
+        },
+        SourcePattern {
+            regex: r#"\bdb\.Exec\s*\([^)]*\+"#,
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "SQL injection via concatenation; use parameterized queries",
+        },
+        SourcePattern {
+            regex: r"\bhttp\.ListenAndServe\s*\(",
+            category: DangerCategory::Crypto,
+            severity: Severity::Medium,
+            reason: "HTTP without TLS; use ListenAndServeTLS for production",
+        },
     ]
 }
 
 fn rust_patterns() -> &'static [SourcePattern] {
     &[
-        SourcePattern { regex: r"\bunsafe\s*\{", category: DangerCategory::UnsafeCode, severity: Severity::High, reason: "unsafe block bypasses Rust safety guarantees; minimize and audit" },
-        SourcePattern { regex: r"\bCommand::new\s*\(", category: DangerCategory::Injection, severity: Severity::High, reason: "Command::new runs external processes; validate arguments" },
-        SourcePattern { regex: r"\.unwrap\s*\(\s*\)", category: DangerCategory::Memory, severity: Severity::Low, reason: ".unwrap() panics on error; consider .expect() or proper error handling" },
-        SourcePattern { regex: r"\*\s*\w+\s+as\s+\*", category: DangerCategory::Memory, severity: Severity::High, reason: "raw pointer cast; ensure safety invariants" },
-        SourcePattern { regex: r"std::mem::transmute", category: DangerCategory::Memory, severity: Severity::Critical, reason: "transmute bypasses type safety; use safe alternatives" },
+        SourcePattern {
+            regex: r"\bunsafe\s*\{",
+            category: DangerCategory::UnsafeCode,
+            severity: Severity::High,
+            reason: "unsafe block bypasses Rust safety guarantees; minimize and audit",
+        },
+        SourcePattern {
+            regex: r"\bCommand::new\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "Command::new runs external processes; validate arguments",
+        },
+        SourcePattern {
+            regex: r"\.unwrap\s*\(\s*\)",
+            category: DangerCategory::Memory,
+            severity: Severity::Low,
+            reason: ".unwrap() panics on error; consider .expect() or proper error handling",
+        },
+        SourcePattern {
+            regex: r"\*\s*\w+\s+as\s+\*",
+            category: DangerCategory::Memory,
+            severity: Severity::High,
+            reason: "raw pointer cast; ensure safety invariants",
+        },
+        SourcePattern {
+            regex: r"std::mem::transmute",
+            category: DangerCategory::Memory,
+            severity: Severity::Critical,
+            reason: "transmute bypasses type safety; use safe alternatives",
+        },
     ]
 }
 
 fn java_patterns() -> &'static [SourcePattern] {
     &[
-        SourcePattern { regex: r"\bRuntime\.getRuntime\(\)\.exec\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "Runtime.exec runs OS commands; validate all arguments" },
-        SourcePattern { regex: r"\bProcessBuilder\s*\(", category: DangerCategory::Injection, severity: Severity::High, reason: "ProcessBuilder runs OS commands; validate arguments" },
-        SourcePattern { regex: r"\bStatement\.execute\s*\(", category: DangerCategory::Injection, severity: Severity::High, reason: "Statement.execute may be vulnerable to SQL injection; use PreparedStatement" },
-        SourcePattern { regex: r"\bObjectInputStream\b", category: DangerCategory::Deserialization, severity: Severity::Critical, reason: "Java deserialization can execute code; use allowlists or safe formats" },
-        SourcePattern { regex: r"\bJNDI\b|\bInitialContext\b", category: DangerCategory::Injection, severity: Severity::Critical, reason: "JNDI lookup can lead to remote code execution (Log4Shell class); validate inputs" },
-        SourcePattern { regex: r"\bScriptEngine\b.*\beval\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "ScriptEngine.eval executes arbitrary code; avoid with untrusted input" },
+        SourcePattern {
+            regex: r"\bRuntime\.getRuntime\(\)\.exec\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "Runtime.exec runs OS commands; validate all arguments",
+        },
+        SourcePattern {
+            regex: r"\bProcessBuilder\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "ProcessBuilder runs OS commands; validate arguments",
+        },
+        SourcePattern {
+            regex: r"\bStatement\.execute\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "Statement.execute may be vulnerable to SQL injection; use PreparedStatement",
+        },
+        SourcePattern {
+            regex: r"\bObjectInputStream\b",
+            category: DangerCategory::Deserialization,
+            severity: Severity::Critical,
+            reason: "Java deserialization can execute code; use allowlists or safe formats",
+        },
+        SourcePattern {
+            regex: r"\bJNDI\b|\bInitialContext\b",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason:
+                "JNDI lookup can lead to remote code execution (Log4Shell class); validate inputs",
+        },
+        SourcePattern {
+            regex: r"\bScriptEngine\b.*\beval\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "ScriptEngine.eval executes arbitrary code; avoid with untrusted input",
+        },
     ]
 }
 
 fn c_cpp_patterns() -> &'static [SourcePattern] {
     &[
-        SourcePattern { regex: r"\bstrcpy\s*\(", category: DangerCategory::Memory, severity: Severity::Critical, reason: "strcpy has no bounds checking; use strncpy or strlcpy" },
-        SourcePattern { regex: r"\bsprintf\s*\(", category: DangerCategory::FormatString, severity: Severity::High, reason: "sprintf has no bounds checking; use snprintf" },
-        SourcePattern { regex: r"\bgets\s*\(", category: DangerCategory::Memory, severity: Severity::Critical, reason: "gets has no bounds checking; use fgets" },
-        SourcePattern { regex: r"\bsystem\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "system() passes to shell; use exec* family" },
-        SourcePattern { regex: r"\bstrcat\s*\(", category: DangerCategory::Memory, severity: Severity::Critical, reason: "strcat has no bounds checking; use strncat or strlcat" },
-        SourcePattern { regex: r"\bscanf\s*\(", category: DangerCategory::FormatString, severity: Severity::High, reason: "scanf with %s has no bounds; use width specifiers" },
-        SourcePattern { regex: r"\bpopen\s*\(", category: DangerCategory::Injection, severity: Severity::Critical, reason: "popen passes to shell; use pipe+fork+exec" },
+        SourcePattern {
+            regex: r"\bstrcpy\s*\(",
+            category: DangerCategory::Memory,
+            severity: Severity::Critical,
+            reason: "strcpy has no bounds checking; use strncpy or strlcpy",
+        },
+        SourcePattern {
+            regex: r"\bsprintf\s*\(",
+            category: DangerCategory::FormatString,
+            severity: Severity::High,
+            reason: "sprintf has no bounds checking; use snprintf",
+        },
+        SourcePattern {
+            regex: r"\bgets\s*\(",
+            category: DangerCategory::Memory,
+            severity: Severity::Critical,
+            reason: "gets has no bounds checking; use fgets",
+        },
+        SourcePattern {
+            regex: r"\bsystem\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "system() passes to shell; use exec* family",
+        },
+        SourcePattern {
+            regex: r"\bstrcat\s*\(",
+            category: DangerCategory::Memory,
+            severity: Severity::Critical,
+            reason: "strcat has no bounds checking; use strncat or strlcat",
+        },
+        SourcePattern {
+            regex: r"\bscanf\s*\(",
+            category: DangerCategory::FormatString,
+            severity: Severity::High,
+            reason: "scanf with %s has no bounds; use width specifiers",
+        },
+        SourcePattern {
+            regex: r"\bpopen\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Critical,
+            reason: "popen passes to shell; use pipe+fork+exec",
+        },
     ]
 }
 
@@ -146,9 +367,15 @@ os.system("echo " + user_input)
 eval(user_input)
 pickle.loads(data)
 "#;
-        let hits = detector.detect_in_source_content(src, "python", "app.py").unwrap();
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Injection));
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Deserialization));
+        let hits = detector
+            .detect_in_source_content(src, "python", "app.py")
+            .unwrap();
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Injection));
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Deserialization));
         assert!(hits.len() >= 3);
     }
 
@@ -162,9 +389,13 @@ document.innerHTML = input;
 child_process.exec("ls " + input);
 new Function(input);
 "#;
-        let hits = detector.detect_in_source_content(src, "javascript", "app.js").unwrap();
+        let hits = detector
+            .detect_in_source_content(src, "javascript", "app.js")
+            .unwrap();
         assert!(hits.iter().any(|h| h.function_name.contains("eval")));
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Xss));
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Xss));
         assert!(hits.len() >= 3);
     }
 
@@ -179,9 +410,15 @@ fn run(input: &str) {
     Command::new(input).output().unwrap();
 }
 "#;
-        let hits = detector.detect_in_source_content(src, "rust", "main.rs").unwrap();
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::UnsafeCode));
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Injection));
+        let hits = detector
+            .detect_in_source_content(src, "rust", "main.rs")
+            .unwrap();
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::UnsafeCode));
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Injection));
     }
 
     #[test]
@@ -193,9 +430,15 @@ func run(input string) {
     template.HTML(input)
 }
 "#;
-        let hits = detector.detect_in_source_content(src, "go", "main.go").unwrap();
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Injection));
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Xss));
+        let hits = detector
+            .detect_in_source_content(src, "go", "main.go")
+            .unwrap();
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Injection));
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Xss));
     }
 
     #[test]
@@ -206,9 +449,15 @@ import java.io.ObjectInputStream;
 Runtime.getRuntime().exec(cmd);
 ObjectInputStream ois = new ObjectInputStream(in);
 "#;
-        let hits = detector.detect_in_source_content(src, "java", "Vuln.java").unwrap();
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Injection));
-        assert!(hits.iter().any(|h| h.danger_category == DangerCategory::Deserialization));
+        let hits = detector
+            .detect_in_source_content(src, "java", "Vuln.java")
+            .unwrap();
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Injection));
+        assert!(hits
+            .iter()
+            .any(|h| h.danger_category == DangerCategory::Deserialization));
     }
 
     #[test]
@@ -222,7 +471,9 @@ void vuln(char *input) {
     system(input);
 }
 "#;
-        let hits = detector.detect_in_source_content(src, "c", "vuln.c").unwrap();
+        let hits = detector
+            .detect_in_source_content(src, "c", "vuln.c")
+            .unwrap();
         assert!(hits.iter().any(|h| h.function_name.contains("strcpy")));
         assert!(hits.iter().any(|h| h.function_name.contains("system")));
         assert!(hits.len() >= 3);
@@ -237,7 +488,9 @@ def safe_function():
     x = 1 + 2
     return x
 "#;
-        let hits = detector.detect_in_source_content(src, "python", "safe.py").unwrap();
+        let hits = detector
+            .detect_in_source_content(src, "python", "safe.py")
+            .unwrap();
         assert!(hits.is_empty());
     }
 }

--- a/crates/core/src/analysis/perspective_context.rs
+++ b/crates/core/src/analysis/perspective_context.rs
@@ -84,7 +84,12 @@ pub fn context_perspective(
     }
 
     // Deeper analysis: look for wrapper functions that hide dangerous operations
-    new_findings.extend(detect_indirect_dangerous_calls(db, inv_id, existing_findings, cycle));
+    new_findings.extend(detect_indirect_dangerous_calls(
+        db,
+        inv_id,
+        existing_findings,
+        cycle,
+    ));
 
     (updates, new_findings)
 }
@@ -93,9 +98,14 @@ pub fn context_perspective(
 fn is_sanitizer_name(name: &str) -> bool {
     const SANITIZER_WORDS: &[&str] = &["validate", "sanitize", "check", "verify"];
     const SANITIZER_EXACT: &[&str] = &[
-        "bounds_check", "strlcpy", "strlcat", "snprintf", "strncpy_s", "strcpy_s",
+        "bounds_check",
+        "strlcpy",
+        "strlcat",
+        "snprintf",
+        "strncpy_s",
+        "strcpy_s",
     ];
-    if SANITIZER_EXACT.iter().any(|s| name == *s) {
+    if SANITIZER_EXACT.contains(&name) {
         return true;
     }
     let words: Vec<&str> = name.split('_').collect();
@@ -208,9 +218,10 @@ fn check_has_bounds_checking(db: &GraphDb, func_name: &str) -> bool {
         // might be mitigated
         for safe_fn in *safe_list {
             let sql = "SELECT count(*) FROM functions WHERE name LIKE ?1";
-            if let Ok(count) = db.conn().query_row(sql, [format!("%{}%", safe_fn)], |row| {
-                row.get::<_, i64>(0)
-            }) {
+            if let Ok(count) = db
+                .conn()
+                .query_row(sql, [format!("%{}%", safe_fn)], |row| row.get::<_, i64>(0))
+            {
                 if count > 0 {
                     return true;
                 }

--- a/crates/core/src/analysis/perspective_dataflow.rs
+++ b/crates/core/src/analysis/perspective_dataflow.rs
@@ -101,7 +101,9 @@ pub fn dataflow_perspective(db: &GraphDb, inv_id: &str, cycle: u32) -> Vec<Findi
             .prepare("SELECT id FROM functions WHERE name = ?1 AND investigation_id = ?2")
         {
             let source_ids: Vec<String> = id_stmt
-                .query_map(rusqlite::params![source.as_str(), inv_id], |row| row.get::<_, String>(0))
+                .query_map(rusqlite::params![source.as_str(), inv_id], |row| {
+                    row.get::<_, String>(0)
+                })
                 .ok()
                 .map(|rows| rows.flatten().collect())
                 .unwrap_or_default();
@@ -128,8 +130,7 @@ pub fn dataflow_perspective(db: &GraphDb, inv_id: &str, cycle: u32) -> Vec<Findi
                         for row in rows.flatten() {
                             let (func_name, path) = row;
                             if sinks.contains(&func_name)
-                                && !existing_pairs
-                                    .contains(&(source.clone(), func_name.clone()))
+                                && !existing_pairs.contains(&(source.clone(), func_name.clone()))
                             {
                                 findings.push(Finding {
                                     id: Uuid::new_v4().to_string(),

--- a/crates/core/src/analysis/perspective_pattern.rs
+++ b/crates/core/src/analysis/perspective_pattern.rs
@@ -13,7 +13,10 @@ pub fn pattern_perspective(db: &GraphDb, inv_id: &str, cycle: u32) -> Vec<Findin
     let mut seen = std::collections::HashSet::new();
 
     // Check functions for dangerous API names
-    if let Ok(mut stmt) = db.conn().prepare("SELECT f.name, f.address FROM functions f WHERE f.investigation_id = ?1") {
+    if let Ok(mut stmt) = db
+        .conn()
+        .prepare("SELECT f.name, f.address FROM functions f WHERE f.investigation_id = ?1")
+    {
         if let Ok(rows) = stmt.query_map([inv_id], |row| {
             Ok((
                 row.get::<_, String>(0)?,
@@ -56,10 +59,9 @@ pub fn pattern_perspective(db: &GraphDb, inv_id: &str, cycle: u32) -> Vec<Findin
     }
 
     // Check imports in symbols table
-    if let Ok(mut stmt) = db
-        .conn()
-        .prepare("SELECT s.name FROM symbols s WHERE s.symbol_type = 'import' AND s.investigation_id = ?1")
-    {
+    if let Ok(mut stmt) = db.conn().prepare(
+        "SELECT s.name FROM symbols s WHERE s.symbol_type = 'import' AND s.investigation_id = ?1",
+    ) {
         if let Ok(rows) = stmt.query_map([inv_id], |row| row.get::<_, String>(0)) {
             for row in rows.flatten() {
                 let base = row.split('@').next().unwrap_or(&row);
@@ -136,7 +138,11 @@ pub fn pattern_perspective(db: &GraphDb, inv_id: &str, cycle: u32) -> Vec<Findin
 /// Look up danger info for a function name. Returns (category, severity, reason).
 pub(crate) fn dangerous_api_info(name: &str) -> Option<(&'static str, &'static str, &'static str)> {
     match name {
-        "strcpy" => Some(("memory", "critical", "unbounded copy; use strncpy or strlcpy")),
+        "strcpy" => Some((
+            "memory",
+            "critical",
+            "unbounded copy; use strncpy or strlcpy",
+        )),
         "strcat" => Some((
             "memory",
             "critical",
@@ -153,11 +159,7 @@ pub(crate) fn dangerous_api_info(name: &str) -> Option<(&'static str, &'static s
             "medium",
             "no bounds checking; verify size parameter",
         )),
-        "strncpy" => Some((
-            "memory",
-            "low",
-            "may not null-terminate; prefer strlcpy",
-        )),
+        "strncpy" => Some(("memory", "low", "may not null-terminate; prefer strlcpy")),
         "strncat" => Some((
             "memory",
             "low",

--- a/crates/core/src/analysis/semgrep.rs
+++ b/crates/core/src/analysis/semgrep.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 use std::time::Duration;
 
-use crate::binary::subprocess::{SubprocessTool, ToolHealth, command_exists, get_version};
+use crate::binary::subprocess::{command_exists, get_version, SubprocessTool, ToolHealth};
 
 /// Runs Semgrep static analysis as a subprocess.
 pub struct SemgrepRunner {

--- a/crates/core/src/analysis/surface.rs
+++ b/crates/core/src/analysis/surface.rs
@@ -5,8 +5,8 @@
 //! - `surface_source`: source-level source/sink identification
 
 pub use super::surface_binary::{
-    identify_attack_surface, AttackSurface, AttackSurfaceAnalyzer, SurfaceEntry,
-    SINK_PATTERNS, SOURCE_PATTERNS,
+    identify_attack_surface, AttackSurface, AttackSurfaceAnalyzer, SurfaceEntry, SINK_PATTERNS,
+    SOURCE_PATTERNS,
 };
 pub use super::surface_source::{
     identify_source_sinks, identify_source_sinks_in_content, SourceSinkHit, SourceSinkKind,

--- a/crates/core/src/analysis/surface_binary.rs
+++ b/crates/core/src/analysis/surface_binary.rs
@@ -20,37 +20,51 @@ pub struct AttackSurface {
 }
 
 const NETWORK_PATTERNS: &[&str] = &[
-    "socket", "bind", "listen", "accept", "recv", "recvfrom", "recvmsg",
-    "send", "sendto", "sendmsg", "connect", "getaddrinfo", "gethostbyname",
+    "socket",
+    "bind",
+    "listen",
+    "accept",
+    "recv",
+    "recvfrom",
+    "recvmsg",
+    "send",
+    "sendto",
+    "sendmsg",
+    "connect",
+    "getaddrinfo",
+    "gethostbyname",
 ];
 
 const FILE_PATTERNS: &[&str] = &[
-    "fopen", "fread", "fgets", "read", "open", "openat", "pread", "readdir",
-    "fclose", "fwrite", "fdopen",
+    "fopen", "fread", "fgets", "read", "open", "openat", "pread", "readdir", "fclose", "fwrite",
+    "fdopen",
 ];
 
 const IPC_PATTERNS: &[&str] = &[
-    "pipe", "shmget", "msgget", "mq_open", "shmat", "semget", "mkfifo",
+    "pipe",
+    "shmget",
+    "msgget",
+    "mq_open",
+    "shmat",
+    "semget",
+    "mkfifo",
     "socketpair",
 ];
 
 const INPUT_PATTERNS: &[&str] = &[
-    "scanf", "sscanf", "fscanf", "gets", "getenv", "getchar", "getline",
-    "readline",
+    "scanf", "sscanf", "fscanf", "gets", "getenv", "getchar", "getline", "readline",
 ];
 
 /// Source patterns: functions that read external data into the program.
 pub const SOURCE_PATTERNS: &[&str] = &[
-    "recv", "recvfrom", "recvmsg", "accept", "read", "fread", "fgets",
-    "gets", "getenv", "scanf", "sscanf", "fscanf", "getchar", "getline",
-    "readline", "fopen", "open",
+    "recv", "recvfrom", "recvmsg", "accept", "read", "fread", "fgets", "gets", "getenv", "scanf",
+    "sscanf", "fscanf", "getchar", "getline", "readline", "fopen", "open",
 ];
 
 /// Sink patterns: dangerous functions that consume tainted data.
 pub const SINK_PATTERNS: &[&str] = &[
-    "strcpy", "strncpy", "sprintf", "snprintf", "strcat", "strncat",
-    "system", "exec", "execve", "execvp", "popen", "memcpy", "memmove",
-    "gets", "free", "realloc", "malloc",
+    "strcpy", "strncpy", "sprintf", "snprintf", "strcat", "strncat", "system", "exec", "execve",
+    "execvp", "popen", "memcpy", "memmove", "gets", "free", "realloc", "malloc",
 ];
 
 /// Analyze the attack surface of a binary by categorizing its imports.
@@ -62,16 +76,16 @@ pub fn identify_attack_surface(info: &BinaryInfo) -> AttackSurface {
         // Strip optional "@" version suffix (e.g. "recv@@GLIBC_2.2.5")
         let base = name.split('@').next().unwrap_or(name);
 
-        if NETWORK_PATTERNS.iter().any(|p| base == *p) {
+        if NETWORK_PATTERNS.contains(&base) {
             surface.network.push(name.to_string());
         }
-        if FILE_PATTERNS.iter().any(|p| base == *p) {
+        if FILE_PATTERNS.contains(&base) {
             surface.file.push(name.to_string());
         }
-        if IPC_PATTERNS.iter().any(|p| base == *p) {
+        if IPC_PATTERNS.contains(&base) {
             surface.ipc.push(name.to_string());
         }
-        if INPUT_PATTERNS.iter().any(|p| base == *p) {
+        if INPUT_PATTERNS.contains(&base) {
             surface.input.push(name.to_string());
         }
     }

--- a/crates/core/src/analysis/surface_source.rs
+++ b/crates/core/src/analysis/surface_source.rs
@@ -37,100 +37,376 @@ struct SourceSinkPattern {
 
 fn python_source_sinks() -> &'static [SourceSinkPattern] {
     &[
-        SourceSinkPattern { regex: r#"request\.args"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"request\.form"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"request\.json"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"request\.data"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"\binput\s*\("#, kind: SourceSinkKind::Source, category: "user_input" },
-        SourceSinkPattern { regex: r#"\bos\.environ"#, kind: SourceSinkKind::Source, category: "environment" },
-        SourceSinkPattern { regex: r#"\bopen\s*\([^)]+\)\.read"#, kind: SourceSinkKind::Source, category: "file_read" },
-        SourceSinkPattern { regex: r#"\bsys\.argv"#, kind: SourceSinkKind::Source, category: "command_line" },
-        SourceSinkPattern { regex: r#"\bsys\.stdin"#, kind: SourceSinkKind::Source, category: "stdin" },
-        SourceSinkPattern { regex: r#"\bcursor\.execute\s*\("#, kind: SourceSinkKind::Sink, category: "sql_query" },
-        SourceSinkPattern { regex: r#"\bos\.system\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\bsubprocess\.\w+\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\beval\s*\("#, kind: SourceSinkKind::Sink, category: "code_exec" },
-        SourceSinkPattern { regex: r#"\bexec\s*\("#, kind: SourceSinkKind::Sink, category: "code_exec" },
-        SourceSinkPattern { regex: r#"\bpickle\.loads?\s*\("#, kind: SourceSinkKind::Sink, category: "deserialization" },
-        SourceSinkPattern { regex: r#"\bopen\s*\([^)]+,\s*['"]w"#, kind: SourceSinkKind::Sink, category: "file_write" },
+        SourceSinkPattern {
+            regex: r#"request\.args"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"request\.form"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"request\.json"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"request\.data"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"\binput\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "user_input",
+        },
+        SourceSinkPattern {
+            regex: r#"\bos\.environ"#,
+            kind: SourceSinkKind::Source,
+            category: "environment",
+        },
+        SourceSinkPattern {
+            regex: r#"\bopen\s*\([^)]+\)\.read"#,
+            kind: SourceSinkKind::Source,
+            category: "file_read",
+        },
+        SourceSinkPattern {
+            regex: r#"\bsys\.argv"#,
+            kind: SourceSinkKind::Source,
+            category: "command_line",
+        },
+        SourceSinkPattern {
+            regex: r#"\bsys\.stdin"#,
+            kind: SourceSinkKind::Source,
+            category: "stdin",
+        },
+        SourceSinkPattern {
+            regex: r#"\bcursor\.execute\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "sql_query",
+        },
+        SourceSinkPattern {
+            regex: r#"\bos\.system\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\bsubprocess\.\w+\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\beval\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "code_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\bexec\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "code_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\bpickle\.loads?\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "deserialization",
+        },
+        SourceSinkPattern {
+            regex: r#"\bopen\s*\([^)]+,\s*['"]w"#,
+            kind: SourceSinkKind::Sink,
+            category: "file_write",
+        },
     ]
 }
 
 fn javascript_source_sinks() -> &'static [SourceSinkPattern] {
     &[
-        SourceSinkPattern { regex: r#"req\.params"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"req\.body"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"req\.query"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"process\.env"#, kind: SourceSinkKind::Source, category: "environment" },
-        SourceSinkPattern { regex: r#"process\.argv"#, kind: SourceSinkKind::Source, category: "command_line" },
-        SourceSinkPattern { regex: r#"process\.stdin"#, kind: SourceSinkKind::Source, category: "stdin" },
-        SourceSinkPattern { regex: r#"window\.location"#, kind: SourceSinkKind::Source, category: "url_input" },
-        SourceSinkPattern { regex: r#"document\.cookie"#, kind: SourceSinkKind::Source, category: "cookie" },
-        SourceSinkPattern { regex: r#"\bdb\.query\s*\("#, kind: SourceSinkKind::Sink, category: "sql_query" },
-        SourceSinkPattern { regex: r#"\bchild_process\.exec\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\beval\s*\("#, kind: SourceSinkKind::Sink, category: "code_exec" },
-        SourceSinkPattern { regex: r#"\.innerHTML\s*="#, kind: SourceSinkKind::Sink, category: "xss" },
-        SourceSinkPattern { regex: r#"\bdocument\.write\s*\("#, kind: SourceSinkKind::Sink, category: "xss" },
-        SourceSinkPattern { regex: r#"\bfs\.writeFile"#, kind: SourceSinkKind::Sink, category: "file_write" },
-        SourceSinkPattern { regex: r#"\bres\.send\s*\("#, kind: SourceSinkKind::Sink, category: "http_response" },
+        SourceSinkPattern {
+            regex: r#"req\.params"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"req\.body"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"req\.query"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"process\.env"#,
+            kind: SourceSinkKind::Source,
+            category: "environment",
+        },
+        SourceSinkPattern {
+            regex: r#"process\.argv"#,
+            kind: SourceSinkKind::Source,
+            category: "command_line",
+        },
+        SourceSinkPattern {
+            regex: r#"process\.stdin"#,
+            kind: SourceSinkKind::Source,
+            category: "stdin",
+        },
+        SourceSinkPattern {
+            regex: r#"window\.location"#,
+            kind: SourceSinkKind::Source,
+            category: "url_input",
+        },
+        SourceSinkPattern {
+            regex: r#"document\.cookie"#,
+            kind: SourceSinkKind::Source,
+            category: "cookie",
+        },
+        SourceSinkPattern {
+            regex: r#"\bdb\.query\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "sql_query",
+        },
+        SourceSinkPattern {
+            regex: r#"\bchild_process\.exec\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\beval\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "code_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\.innerHTML\s*="#,
+            kind: SourceSinkKind::Sink,
+            category: "xss",
+        },
+        SourceSinkPattern {
+            regex: r#"\bdocument\.write\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "xss",
+        },
+        SourceSinkPattern {
+            regex: r#"\bfs\.writeFile"#,
+            kind: SourceSinkKind::Sink,
+            category: "file_write",
+        },
+        SourceSinkPattern {
+            regex: r#"\bres\.send\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "http_response",
+        },
     ]
 }
 
 fn go_source_sinks() -> &'static [SourceSinkPattern] {
     &[
-        SourceSinkPattern { regex: r#"r\.URL\.Query\s*\("#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"r\.FormValue\s*\("#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"\bos\.Getenv\s*\("#, kind: SourceSinkKind::Source, category: "environment" },
-        SourceSinkPattern { regex: r#"\bbufio\.NewReader\s*\("#, kind: SourceSinkKind::Source, category: "reader" },
-        SourceSinkPattern { regex: r#"\bos\.Args\b"#, kind: SourceSinkKind::Source, category: "command_line" },
-        SourceSinkPattern { regex: r#"\bos\.Stdin\b"#, kind: SourceSinkKind::Source, category: "stdin" },
-        SourceSinkPattern { regex: r#"\bdb\.Exec\s*\("#, kind: SourceSinkKind::Sink, category: "sql_query" },
-        SourceSinkPattern { regex: r#"\bdb\.Query\s*\("#, kind: SourceSinkKind::Sink, category: "sql_query" },
-        SourceSinkPattern { regex: r#"\bexec\.Command\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\btemplate\.HTML\s*\("#, kind: SourceSinkKind::Sink, category: "xss" },
-        SourceSinkPattern { regex: r#"\bfmt\.Fprintf\s*\(w,"#, kind: SourceSinkKind::Sink, category: "http_response" },
+        SourceSinkPattern {
+            regex: r#"r\.URL\.Query\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"r\.FormValue\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"\bos\.Getenv\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "environment",
+        },
+        SourceSinkPattern {
+            regex: r#"\bbufio\.NewReader\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "reader",
+        },
+        SourceSinkPattern {
+            regex: r#"\bos\.Args\b"#,
+            kind: SourceSinkKind::Source,
+            category: "command_line",
+        },
+        SourceSinkPattern {
+            regex: r#"\bos\.Stdin\b"#,
+            kind: SourceSinkKind::Source,
+            category: "stdin",
+        },
+        SourceSinkPattern {
+            regex: r#"\bdb\.Exec\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "sql_query",
+        },
+        SourceSinkPattern {
+            regex: r#"\bdb\.Query\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "sql_query",
+        },
+        SourceSinkPattern {
+            regex: r#"\bexec\.Command\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\btemplate\.HTML\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "xss",
+        },
+        SourceSinkPattern {
+            regex: r#"\bfmt\.Fprintf\s*\(w,"#,
+            kind: SourceSinkKind::Sink,
+            category: "http_response",
+        },
     ]
 }
 
 fn java_source_sinks() -> &'static [SourceSinkPattern] {
     &[
-        SourceSinkPattern { regex: r#"request\.getParameter\s*\("#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"request\.getInputStream"#, kind: SourceSinkKind::Source, category: "http_input" },
-        SourceSinkPattern { regex: r#"\bSystem\.getenv\s*\("#, kind: SourceSinkKind::Source, category: "environment" },
-        SourceSinkPattern { regex: r#"\bSystem\.getProperty\s*\("#, kind: SourceSinkKind::Source, category: "environment" },
-        SourceSinkPattern { regex: r#"\bScanner\s*\(\s*System\.in"#, kind: SourceSinkKind::Source, category: "stdin" },
-        SourceSinkPattern { regex: r#"\bstatement\.execute\s*\("#, kind: SourceSinkKind::Sink, category: "sql_query" },
-        SourceSinkPattern { regex: r#"\bRuntime\.getRuntime\(\)\.exec\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\bProcessBuilder\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\bObjectInputStream\b"#, kind: SourceSinkKind::Sink, category: "deserialization" },
-        SourceSinkPattern { regex: r#"\bresponse\.getWriter\(\)\.write\s*\("#, kind: SourceSinkKind::Sink, category: "http_response" },
+        SourceSinkPattern {
+            regex: r#"request\.getParameter\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"request\.getInputStream"#,
+            kind: SourceSinkKind::Source,
+            category: "http_input",
+        },
+        SourceSinkPattern {
+            regex: r#"\bSystem\.getenv\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "environment",
+        },
+        SourceSinkPattern {
+            regex: r#"\bSystem\.getProperty\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "environment",
+        },
+        SourceSinkPattern {
+            regex: r#"\bScanner\s*\(\s*System\.in"#,
+            kind: SourceSinkKind::Source,
+            category: "stdin",
+        },
+        SourceSinkPattern {
+            regex: r#"\bstatement\.execute\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "sql_query",
+        },
+        SourceSinkPattern {
+            regex: r#"\bRuntime\.getRuntime\(\)\.exec\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\bProcessBuilder\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\bObjectInputStream\b"#,
+            kind: SourceSinkKind::Sink,
+            category: "deserialization",
+        },
+        SourceSinkPattern {
+            regex: r#"\bresponse\.getWriter\(\)\.write\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "http_response",
+        },
     ]
 }
 
 fn rust_source_sinks() -> &'static [SourceSinkPattern] {
     &[
-        SourceSinkPattern { regex: r#"\bstd::env::args\s*\("#, kind: SourceSinkKind::Source, category: "command_line" },
-        SourceSinkPattern { regex: r#"\bstd::env::var\s*\("#, kind: SourceSinkKind::Source, category: "environment" },
-        SourceSinkPattern { regex: r#"\bstd::io::stdin\s*\("#, kind: SourceSinkKind::Source, category: "stdin" },
-        SourceSinkPattern { regex: r#"\bstd::fs::read"#, kind: SourceSinkKind::Source, category: "file_read" },
-        SourceSinkPattern { regex: r#"\bCommand::new\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\bconn\.execute\s*\("#, kind: SourceSinkKind::Sink, category: "sql_query" },
-        SourceSinkPattern { regex: r#"\bstd::fs::write\s*\("#, kind: SourceSinkKind::Sink, category: "file_write" },
+        SourceSinkPattern {
+            regex: r#"\bstd::env::args\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "command_line",
+        },
+        SourceSinkPattern {
+            regex: r#"\bstd::env::var\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "environment",
+        },
+        SourceSinkPattern {
+            regex: r#"\bstd::io::stdin\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "stdin",
+        },
+        SourceSinkPattern {
+            regex: r#"\bstd::fs::read"#,
+            kind: SourceSinkKind::Source,
+            category: "file_read",
+        },
+        SourceSinkPattern {
+            regex: r#"\bCommand::new\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\bconn\.execute\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "sql_query",
+        },
+        SourceSinkPattern {
+            regex: r#"\bstd::fs::write\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "file_write",
+        },
     ]
 }
 
 fn c_cpp_source_sinks() -> &'static [SourceSinkPattern] {
     &[
-        SourceSinkPattern { regex: r#"\brecv\s*\("#, kind: SourceSinkKind::Source, category: "network" },
-        SourceSinkPattern { regex: r#"\bfread\s*\("#, kind: SourceSinkKind::Source, category: "file_read" },
-        SourceSinkPattern { regex: r#"\bfgets\s*\("#, kind: SourceSinkKind::Source, category: "file_read" },
-        SourceSinkPattern { regex: r#"\bgets\s*\("#, kind: SourceSinkKind::Source, category: "stdin" },
-        SourceSinkPattern { regex: r#"\bgetenv\s*\("#, kind: SourceSinkKind::Source, category: "environment" },
-        SourceSinkPattern { regex: r#"\bscanf\s*\("#, kind: SourceSinkKind::Source, category: "stdin" },
-        SourceSinkPattern { regex: r#"\bstrcpy\s*\("#, kind: SourceSinkKind::Sink, category: "memory" },
-        SourceSinkPattern { regex: r#"\bsprintf\s*\("#, kind: SourceSinkKind::Sink, category: "memory" },
-        SourceSinkPattern { regex: r#"\bsystem\s*\("#, kind: SourceSinkKind::Sink, category: "command_exec" },
-        SourceSinkPattern { regex: r#"\bmemcpy\s*\("#, kind: SourceSinkKind::Sink, category: "memory" },
+        SourceSinkPattern {
+            regex: r#"\brecv\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "network",
+        },
+        SourceSinkPattern {
+            regex: r#"\bfread\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "file_read",
+        },
+        SourceSinkPattern {
+            regex: r#"\bfgets\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "file_read",
+        },
+        SourceSinkPattern {
+            regex: r#"\bgets\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "stdin",
+        },
+        SourceSinkPattern {
+            regex: r#"\bgetenv\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "environment",
+        },
+        SourceSinkPattern {
+            regex: r#"\bscanf\s*\("#,
+            kind: SourceSinkKind::Source,
+            category: "stdin",
+        },
+        SourceSinkPattern {
+            regex: r#"\bstrcpy\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "memory",
+        },
+        SourceSinkPattern {
+            regex: r#"\bsprintf\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "memory",
+        },
+        SourceSinkPattern {
+            regex: r#"\bsystem\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "command_exec",
+        },
+        SourceSinkPattern {
+            regex: r#"\bmemcpy\s*\("#,
+            kind: SourceSinkKind::Sink,
+            category: "memory",
+        },
     ]
 }
 
@@ -204,8 +480,14 @@ os.system("echo " + name)
 eval(name)
 "#;
         let hits = identify_source_sinks_in_content(src, "python", "app.py").unwrap();
-        let sources: Vec<_> = hits.iter().filter(|h| h.kind == SourceSinkKind::Source).collect();
-        let sinks: Vec<_> = hits.iter().filter(|h| h.kind == SourceSinkKind::Sink).collect();
+        let sources: Vec<_> = hits
+            .iter()
+            .filter(|h| h.kind == SourceSinkKind::Source)
+            .collect();
+        let sinks: Vec<_> = hits
+            .iter()
+            .filter(|h| h.kind == SourceSinkKind::Sink)
+            .collect();
         assert!(!sources.is_empty(), "Should find data sources");
         assert!(!sinks.is_empty(), "Should find data sinks");
         assert!(sources.iter().any(|s| s.category == "http_input"));
@@ -222,8 +504,14 @@ res.send(output);
 db.query("SELECT * FROM x WHERE id = " + id);
 "#;
         let hits = identify_source_sinks_in_content(src, "javascript", "app.js").unwrap();
-        let sources: Vec<_> = hits.iter().filter(|h| h.kind == SourceSinkKind::Source).collect();
-        let sinks: Vec<_> = hits.iter().filter(|h| h.kind == SourceSinkKind::Sink).collect();
+        let sources: Vec<_> = hits
+            .iter()
+            .filter(|h| h.kind == SourceSinkKind::Source)
+            .collect();
+        let sinks: Vec<_> = hits
+            .iter()
+            .filter(|h| h.kind == SourceSinkKind::Sink)
+            .collect();
         assert!(!sources.is_empty());
         assert!(!sinks.is_empty());
     }

--- a/crates/core/src/analysis/taint.rs
+++ b/crates/core/src/analysis/taint.rs
@@ -124,9 +124,10 @@ impl<'a> TaintAnalyzer<'a> {
                      SELECT func_name, path FROM call_chain WHERE depth > 0";
 
                 let mut cte_stmt = self.db.conn().prepare(sql)?;
-                let rows = cte_stmt.query_map(rusqlite::params![source_id.as_str(), max_depth], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-                })?;
+                let rows = cte_stmt
+                    .query_map(rusqlite::params![source_id.as_str(), max_depth], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                    })?;
 
                 for row in rows {
                     let (func_name, path) = row?;
@@ -134,10 +135,7 @@ impl<'a> TaintAnalyzer<'a> {
                         results.push(TaintPath {
                             source: source.clone(),
                             sink: func_name,
-                            hops: path
-                                .split(" -> ")
-                                .map(|s| s.trim().to_string())
-                                .collect(),
+                            hops: path.split(" -> ").map(|s| s.trim().to_string()).collect(),
                             sanitized: false,
                         });
                     }
@@ -195,11 +193,31 @@ mod tests {
         let db = GraphDb::in_memory().unwrap();
 
         // Set up a call chain: recv -> process -> strcpy
-        db.execute("INSERT INTO functions (id, name) VALUES ('f1', 'recv')", &[]).unwrap();
-        db.execute("INSERT INTO functions (id, name) VALUES ('f2', 'process')", &[]).unwrap();
-        db.execute("INSERT INTO functions (id, name) VALUES ('f3', 'strcpy')", &[]).unwrap();
-        db.execute("INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')", &[]).unwrap();
-        db.execute("INSERT INTO calls (caller_id, callee_id) VALUES ('f2', 'f3')", &[]).unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f1', 'recv')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f2', 'process')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f3', 'strcpy')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f2', 'f3')",
+            &[],
+        )
+        .unwrap();
 
         // Register source and sink
         db.execute(

--- a/crates/core/src/analysis/variant.rs
+++ b/crates/core/src/analysis/variant.rs
@@ -37,13 +37,17 @@ impl<'a> VariantAnalyzer<'a> {
     /// of callee sets.
     pub fn find_variants(&self, pattern_id: &str) -> anyhow::Result<Vec<VariantHit>> {
         // Look up the function associated with the vulnerability pattern.
-        let func_name: Option<String> = self.db.conn().query_row(
-            "SELECT f.name FROM vulnerabilities v \
+        let func_name: Option<String> = self
+            .db
+            .conn()
+            .query_row(
+                "SELECT f.name FROM vulnerabilities v \
              JOIN functions f ON v.function_id = f.id \
              WHERE v.id = ?1",
-            [pattern_id],
-            |row| row.get(0),
-        ).ok();
+                [pattern_id],
+                |row| row.get(0),
+            )
+            .ok();
 
         let func_name = match func_name {
             Some(n) => n,
@@ -62,7 +66,7 @@ impl<'a> VariantAnalyzer<'a> {
              JOIN calls c2 ON c1.callee_id = c2.callee_id \
              JOIN functions f1 ON c1.caller_id = f1.id \
              JOIN functions f2 ON c2.caller_id = f2.id \
-             WHERE f1.name = ?1 AND f2.name != ?1"
+             WHERE f1.name = ?1 AND f2.name != ?1",
         )?;
         let candidate_names: Vec<String> = stmt
             .query_map([&func_name], |row| row.get::<_, String>(0))?
@@ -83,12 +87,19 @@ impl<'a> VariantAnalyzer<'a> {
             hits.push(VariantHit {
                 function_name: candidate_name,
                 similarity,
-                description: format!("Shares callee pattern with {} (Jaccard: {:.2})", func_name, similarity),
+                description: format!(
+                    "Shares callee pattern with {} (Jaccard: {:.2})",
+                    func_name, similarity
+                ),
             });
         }
 
         // Sort by similarity descending.
-        hits.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap_or(std::cmp::Ordering::Equal));
+        hits.sort_by(|a, b| {
+            b.similarity
+                .partial_cmp(&a.similarity)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         Ok(hits)
     }

--- a/crates/core/src/binary/cache.rs
+++ b/crates/core/src/binary/cache.rs
@@ -27,7 +27,8 @@ impl AnalysisCache {
     }
 
     pub fn put(&self, binary_path: &Path, analysis: &GhidraAnalysis) -> anyhow::Result<()> {
-        let hash = self.hash_file(binary_path)
+        let hash = self
+            .hash_file(binary_path)
             .ok_or_else(|| anyhow::anyhow!("Cannot hash binary"))?;
         let dir = self.cache_dir.join(&hash);
         std::fs::create_dir_all(&dir)?;

--- a/crates/core/src/binary/ghidra.rs
+++ b/crates/core/src/binary/ghidra.rs
@@ -27,11 +27,7 @@ impl GhidraRunner {
         }
 
         // Check common locations
-        let candidates = [
-            "/opt/ghidra",
-            "/usr/local/ghidra",
-            "/usr/share/ghidra",
-        ];
+        let candidates = ["/opt/ghidra", "/usr/local/ghidra", "/usr/share/ghidra"];
         for candidate in candidates {
             let p = PathBuf::from(candidate);
             if p.join("support/analyzeHeadless").exists() {
@@ -97,41 +93,65 @@ impl GhidraRunner {
     fn headless_path(&self) -> Option<PathBuf> {
         let base = self.ghidra_path.as_ref()?;
         let path = base.join("support/analyzeHeadless");
-        if path.exists() { Some(path) } else { None }
+        if path.exists() {
+            Some(path)
+        } else {
+            None
+        }
     }
 
     /// Run Ghidra headless analysis on a binary.
     /// Returns parsed analysis output with decompiled functions.
-    pub async fn analyze(&self, binary_path: &Path, timeout_secs: u64) -> anyhow::Result<GhidraAnalysis> {
-        let headless = self.headless_path()
+    pub async fn analyze(
+        &self,
+        binary_path: &Path,
+        timeout_secs: u64,
+    ) -> anyhow::Result<GhidraAnalysis> {
+        let headless = self
+            .headless_path()
             .ok_or_else(|| anyhow::anyhow!("Ghidra not found. Set GHIDRA_INSTALL_DIR"))?;
 
-        let scripts_dir = Self::find_scripts_dir()
-            .ok_or_else(|| anyhow::anyhow!(
+        let scripts_dir = Self::find_scripts_dir().ok_or_else(|| {
+            anyhow::anyhow!(
                 "ghidra-scripts/extract_analysis.py not found. \
                  Set SKWAQ_SCRIPTS_DIR or run from the skwaq project root."
-            ))?;
+            )
+        })?;
 
         let project_dir = tempfile::tempdir()?;
         let output_file = project_dir.path().join("ghidra_output.json");
 
-        let binary_abs = std::fs::canonicalize(binary_path)
-            .map_err(|e| anyhow::anyhow!("Cannot resolve binary path {}: {}", binary_path.display(), e))?;
+        let binary_abs = std::fs::canonicalize(binary_path).map_err(|e| {
+            anyhow::anyhow!(
+                "Cannot resolve binary path {}: {}",
+                binary_path.display(),
+                e
+            )
+        })?;
 
         let mut cmd = tokio::process::Command::new(&headless);
         cmd.args([
-            project_dir.path().to_str().ok_or_else(|| anyhow::anyhow!("non-UTF-8 path"))?,
+            project_dir
+                .path()
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("non-UTF-8 path"))?,
             "SkwaqProject",
             "-import",
-            binary_abs.to_str().ok_or_else(|| anyhow::anyhow!("non-UTF-8 binary path"))?,
+            binary_abs
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("non-UTF-8 binary path"))?,
             "-postScript",
             "extract_analysis.py",
-            output_file.to_str().ok_or_else(|| anyhow::anyhow!("non-UTF-8 output path"))?,
+            output_file
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("non-UTF-8 output path"))?,
             "-scriptPath",
-            scripts_dir.to_str().ok_or_else(|| anyhow::anyhow!("non-UTF-8 scripts path"))?,
+            scripts_dir
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("non-UTF-8 scripts path"))?,
             "-analysisTimeoutPerFile",
             &timeout_secs.to_string(),
-            "-deleteProject",  // Clean up Ghidra project files automatically
+            "-deleteProject", // Clean up Ghidra project files automatically
         ]);
 
         let _output = run_tool(
@@ -139,7 +159,8 @@ impl GhidraRunner {
             "Ghidra",
             Duration::from_secs(timeout_secs + 60), // Extra buffer beyond analysis timeout
             Some(project_dir.path()),
-        ).await?;
+        )
+        .await?;
 
         // Parse the JSON output from the post-script
         if output_file.exists() {
@@ -161,87 +182,125 @@ impl GhidraRunner {
 /// The Python script may produce string offsets (e.g. "00401234") instead of
 /// numeric offsets. This function handles both formats.
 fn parse_ghidra_json(raw: &serde_json::Value) -> anyhow::Result<GhidraAnalysis> {
-    let functions: Vec<GhidraFunction> = raw.get("functions")
+    let functions: Vec<GhidraFunction> = raw
+        .get("functions")
         .and_then(|v| v.as_array())
         .map(|arr| {
-            arr.iter().filter_map(|f| {
-                Some(GhidraFunction {
-                    name: f.get("name")?.as_str()?.to_string(),
-                    address: f.get("address")?.as_str()?.to_string(),
-                    size: f.get("size").and_then(|v| v.as_u64()).unwrap_or(0),
-                    decompiled: f.get("decompiled").and_then(|v| v.as_str()).map(String::from),
-                    calls: f.get("calls")
-                        .and_then(|v| v.as_array())
-                        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-                        .unwrap_or_default(),
-                    called_by: f.get("called_by")
-                        .and_then(|v| v.as_array())
-                        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-                        .unwrap_or_default(),
-                    parameter_count: f.get("parameter_count").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
-                })
-            }).collect()
-        })
-        .unwrap_or_default();
-
-    let strings: Vec<ExtractedString> = raw.get("strings")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter().filter_map(|s| {
-                let value = s.get("value")?.as_str()?.to_string();
-                // offset may be a hex string (from Ghidra addresses) or a number
-                let offset = s.get("offset")
-                    .map(|v| {
-                        if let Some(n) = v.as_u64() {
-                            n
-                        } else if let Some(s) = v.as_str() {
-                            // Parse hex address like "00401234"
-                            u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0)
-                        } else {
-                            0
-                        }
+            arr.iter()
+                .filter_map(|f| {
+                    Some(GhidraFunction {
+                        name: f.get("name")?.as_str()?.to_string(),
+                        address: f.get("address")?.as_str()?.to_string(),
+                        size: f.get("size").and_then(|v| v.as_u64()).unwrap_or(0),
+                        decompiled: f
+                            .get("decompiled")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                        calls: f
+                            .get("calls")
+                            .and_then(|v| v.as_array())
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|v| v.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                        called_by: f
+                            .get("called_by")
+                            .and_then(|v| v.as_array())
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|v| v.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                        parameter_count: f
+                            .get("parameter_count")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0) as u32,
                     })
-                    .unwrap_or(0);
-                let encoding = s.get("encoding")
-                    .and_then(|v| v.as_str())
-                    .map(|e| match e {
-                        "utf16le" | "utf16" => StringEncoding::Utf16Le,
-                        "ascii" => StringEncoding::Ascii,
-                        _ => StringEncoding::Utf8,
-                    })
-                    .unwrap_or(StringEncoding::Utf8);
-                Some(ExtractedString { value, offset, encoding })
-            }).collect()
+                })
+                .collect()
         })
         .unwrap_or_default();
 
-    let imports: Vec<ImportInfo> = raw.get("imports")
+    let strings: Vec<ExtractedString> = raw
+        .get("strings")
         .and_then(|v| v.as_array())
         .map(|arr| {
-            arr.iter().filter_map(|i| {
-                Some(ImportInfo {
-                    name: i.get("name")?.as_str()?.to_string(),
-                    library: i.get("library").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            arr.iter()
+                .filter_map(|s| {
+                    let value = s.get("value")?.as_str()?.to_string();
+                    // offset may be a hex string (from Ghidra addresses) or a number
+                    let offset = s
+                        .get("offset")
+                        .map(|v| {
+                            if let Some(n) = v.as_u64() {
+                                n
+                            } else if let Some(s) = v.as_str() {
+                                // Parse hex address like "00401234"
+                                u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0)
+                            } else {
+                                0
+                            }
+                        })
+                        .unwrap_or(0);
+                    let encoding = s
+                        .get("encoding")
+                        .and_then(|v| v.as_str())
+                        .map(|e| match e {
+                            "utf16le" | "utf16" => StringEncoding::Utf16Le,
+                            "ascii" => StringEncoding::Ascii,
+                            _ => StringEncoding::Utf8,
+                        })
+                        .unwrap_or(StringEncoding::Utf8);
+                    Some(ExtractedString {
+                        value,
+                        offset,
+                        encoding,
+                    })
                 })
-            }).collect()
+                .collect()
         })
         .unwrap_or_default();
 
-    Ok(GhidraAnalysis { functions, strings, imports })
+    let imports: Vec<ImportInfo> = raw
+        .get("imports")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| {
+                    Some(ImportInfo {
+                        name: i.get("name")?.as_str()?.to_string(),
+                        library: i
+                            .get("library")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(GhidraAnalysis {
+        functions,
+        strings,
+        imports,
+    })
 }
 
 #[async_trait]
 impl SubprocessTool for GhidraRunner {
-    fn name(&self) -> &str { "Ghidra" }
+    fn name(&self) -> &str {
+        "Ghidra"
+    }
 
     async fn health_check(&self) -> ToolHealth {
         match Self::find_ghidra() {
             Some(path) => {
                 let headless_str = path.join("support/analyzeHeadless");
-                let version = get_version(
-                    headless_str.to_str().unwrap_or(""),
-                    &[],
-                ).await;
+                let version = get_version(headless_str.to_str().unwrap_or(""), &[]).await;
                 ToolHealth {
                     available: true,
                     version,
@@ -319,7 +378,10 @@ mod tests {
         let analysis = parse_ghidra_json(&json).unwrap();
         assert_eq!(analysis.functions.len(), 1);
         assert_eq!(analysis.functions[0].name, "main");
-        assert_eq!(analysis.functions[0].decompiled.as_deref(), Some("int main(int argc, char **argv) { return 0; }"));
+        assert_eq!(
+            analysis.functions[0].decompiled.as_deref(),
+            Some("int main(int argc, char **argv) { return 0; }")
+        );
         assert_eq!(analysis.functions[0].calls.len(), 1);
         assert_eq!(analysis.strings.len(), 1);
         assert_eq!(analysis.strings[0].value, "/bin/sh");

--- a/crates/core/src/binary/native.rs
+++ b/crates/core/src/binary/native.rs
@@ -37,43 +37,77 @@ fn parse_elf(elf: &goblin::elf::Elf, data: &[u8]) -> anyhow::Result<BinaryInfo> 
 
     let is_stripped = elf.syms.is_empty();
 
-    let sections = elf.section_headers.iter().filter_map(|sh| {
-        let name = elf.shdr_strtab.get_at(sh.sh_name).unwrap_or("").to_string();
-        if name.is_empty() { return None; }
-        let perms = format!("{}{}{}",
-            if sh.sh_flags as u32 & goblin::elf::section_header::SHF_ALLOC as u32 != 0 { "A" } else { "-" },
-            if sh.sh_flags as u32 & goblin::elf::section_header::SHF_WRITE as u32 != 0 { "W" } else { "-" },
-            if sh.sh_flags as u32 & goblin::elf::section_header::SHF_EXECINSTR as u32 != 0 { "X" } else { "-" },
-        );
-        Some(SectionInfo {
-            name,
-            address: sh.sh_addr,
-            size: sh.sh_size,
-            permissions: perms,
+    let sections = elf
+        .section_headers
+        .iter()
+        .filter_map(|sh| {
+            let name = elf.shdr_strtab.get_at(sh.sh_name).unwrap_or("").to_string();
+            if name.is_empty() {
+                return None;
+            }
+            let perms = format!(
+                "{}{}{}",
+                if sh.sh_flags as u32 & goblin::elf::section_header::SHF_ALLOC != 0 {
+                    "A"
+                } else {
+                    "-"
+                },
+                if sh.sh_flags as u32 & goblin::elf::section_header::SHF_WRITE != 0 {
+                    "W"
+                } else {
+                    "-"
+                },
+                if sh.sh_flags as u32 & goblin::elf::section_header::SHF_EXECINSTR != 0 {
+                    "X"
+                } else {
+                    "-"
+                },
+            );
+            Some(SectionInfo {
+                name,
+                address: sh.sh_addr,
+                size: sh.sh_size,
+                permissions: perms,
+            })
         })
-    }).collect();
+        .collect();
 
-    let symbols: Vec<SymbolInfo> = elf.syms.iter().filter_map(|sym| {
-        let name = elf.strtab.get_at(sym.st_name).unwrap_or("").to_string();
-        if name.is_empty() { return None; }
-        Some(SymbolInfo {
-            name,
-            address: sym.st_value,
-            size: sym.st_size,
-            symbol_type: format!("{:?}", goblin::elf::sym::st_type(sym.st_info)),
-            binding: format!("{:?}", goblin::elf::sym::st_bind(sym.st_info)),
+    let symbols: Vec<SymbolInfo> = elf
+        .syms
+        .iter()
+        .filter_map(|sym| {
+            let name = elf.strtab.get_at(sym.st_name).unwrap_or("").to_string();
+            if name.is_empty() {
+                return None;
+            }
+            Some(SymbolInfo {
+                name,
+                address: sym.st_value,
+                size: sym.st_size,
+                symbol_type: format!("{:?}", goblin::elf::sym::st_type(sym.st_info)),
+                binding: format!("{:?}", goblin::elf::sym::st_bind(sym.st_info)),
+            })
         })
-    }).collect();
+        .collect();
 
-    let imports: Vec<ImportInfo> = elf.dynsyms.iter().filter_map(|sym| {
-        if sym.is_import() {
-            let name = elf.dynstrtab.get_at(sym.st_name).unwrap_or("").to_string();
-            if name.is_empty() { return None; }
-            Some(ImportInfo { name, library: String::new() })
-        } else {
-            None
-        }
-    }).collect();
+    let imports: Vec<ImportInfo> = elf
+        .dynsyms
+        .iter()
+        .filter_map(|sym| {
+            if sym.is_import() {
+                let name = elf.dynstrtab.get_at(sym.st_name).unwrap_or("").to_string();
+                if name.is_empty() {
+                    return None;
+                }
+                Some(ImportInfo {
+                    name,
+                    library: String::new(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
 
     let strings = extract_strings(data, 4);
 
@@ -84,7 +118,11 @@ fn parse_elf(elf: &goblin::elf::Elf, data: &[u8]) -> anyhow::Result<BinaryInfo> 
         format: BinaryFormat::Elf,
         architecture: architecture.to_string(),
         bits: if elf.is_64 { 64 } else { 32 },
-        endianness: if elf.little_endian { "little".into() } else { "big".into() },
+        endianness: if elf.little_endian {
+            "little".into()
+        } else {
+            "big".into()
+        },
         is_stripped,
         entry_point: elf.header.e_entry,
         sections,
@@ -98,22 +136,30 @@ fn parse_elf(elf: &goblin::elf::Elf, data: &[u8]) -> anyhow::Result<BinaryInfo> 
 fn parse_pe(pe: &goblin::pe::PE, data: &[u8]) -> anyhow::Result<BinaryInfo> {
     let architecture = if pe.is_64 { "x86_64" } else { "x86" };
 
-    let sections = pe.sections.iter().map(|s| {
-        let name = String::from_utf8_lossy(&s.name).trim_end_matches('\0').to_string();
-        SectionInfo {
-            name,
-            address: s.virtual_address as u64,
-            size: s.virtual_size as u64,
-            permissions: format!("{:#x}", s.characteristics),
-        }
-    }).collect();
+    let sections = pe
+        .sections
+        .iter()
+        .map(|s| {
+            let name = String::from_utf8_lossy(&s.name)
+                .trim_end_matches('\0')
+                .to_string();
+            SectionInfo {
+                name,
+                address: s.virtual_address as u64,
+                size: s.virtual_size as u64,
+                permissions: format!("{:#x}", s.characteristics),
+            }
+        })
+        .collect();
 
-    let imports: Vec<ImportInfo> = pe.imports.iter().map(|imp| {
-        ImportInfo {
+    let imports: Vec<ImportInfo> = pe
+        .imports
+        .iter()
+        .map(|imp| ImportInfo {
             name: imp.name.to_string(),
             library: imp.dll.to_string(),
-        }
-    }).collect();
+        })
+        .collect();
 
     let strings = extract_strings(data, 4);
 
@@ -143,7 +189,7 @@ fn extract_strings(data: &[u8], min_length: usize) -> Vec<ExtractedString> {
     let mut start_offset = 0;
 
     for (i, &byte) in data.iter().enumerate() {
-        if byte >= 0x20 && byte < 0x7f {
+        if (0x20..0x7f).contains(&byte) {
             if current.is_empty() {
                 start_offset = i;
             }
@@ -191,23 +237,27 @@ fn detect_elf_hardening(elf: &goblin::elf::Elf) -> HardeningInfo {
     };
 
     // Check for stack canary via __stack_chk_fail import
-    let canary = if elf.dynsyms.iter().any(|sym| {
-        elf.dynstrtab.get_at(sym.st_name).unwrap_or("") == "__stack_chk_fail"
-    }) {
+    let canary = if elf
+        .dynsyms
+        .iter()
+        .any(|sym| elf.dynstrtab.get_at(sym.st_name).unwrap_or("") == "__stack_chk_fail")
+    {
         HardeningStatus::Enabled
     } else {
         HardeningStatus::Disabled
     };
 
     // Check RELRO
-    let has_relro = elf.program_headers.iter().any(|ph| {
-        ph.p_type == goblin::elf::program_header::PT_GNU_RELRO
-    });
-    let has_bind_now = elf.dynamic.as_ref().map_or(false, |dyn_info| {
+    let has_relro = elf
+        .program_headers
+        .iter()
+        .any(|ph| ph.p_type == goblin::elf::program_header::PT_GNU_RELRO);
+    let has_bind_now = elf.dynamic.as_ref().is_some_and(|dyn_info| {
         dyn_info.dyns.iter().any(|d| {
             d.d_tag == goblin::elf::dynamic::DT_BIND_NOW
             || (d.d_tag == goblin::elf::dynamic::DT_FLAGS && d.d_val & 0x8 != 0)  // DF_BIND_NOW
-            || (d.d_tag == goblin::elf::dynamic::DT_FLAGS_1 && d.d_val & 0x1 != 0)  // DF_1_NOW
+            || (d.d_tag == goblin::elf::dynamic::DT_FLAGS_1 && d.d_val & 0x1 != 0)
+            // DF_1_NOW
         })
     });
     let relro = match (has_relro, has_bind_now) {
@@ -226,7 +276,13 @@ fn detect_elf_hardening(elf: &goblin::elf::Elf) -> HardeningInfo {
         HardeningStatus::Disabled
     };
 
-    HardeningInfo { pie, nx, canary, relro, fortify }
+    HardeningInfo {
+        pie,
+        nx,
+        canary,
+        relro,
+        fortify,
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/binary/subprocess.rs
+++ b/crates/core/src/binary/subprocess.rs
@@ -12,7 +12,9 @@ use tokio::time::timeout;
 pub trait SubprocessTool: Send + Sync {
     fn name(&self) -> &str;
     async fn health_check(&self) -> ToolHealth;
-    fn min_version(&self) -> Option<&str> { None }
+    fn min_version(&self) -> Option<&str> {
+        None
+    }
     fn default_timeout(&self) -> Duration;
     fn install_hint(&self) -> &str;
 }
@@ -68,11 +70,7 @@ pub async fn run_tool(
 
 /// Check if a command exists on PATH.
 pub async fn command_exists(cmd: &str) -> Option<String> {
-    let result = Command::new("which")
-        .arg(cmd)
-        .output()
-        .await
-        .ok()?;
+    let result = Command::new("which").arg(cmd).output().await.ok()?;
 
     if result.status.success() {
         Some(String::from_utf8_lossy(&result.stdout).trim().to_string())
@@ -83,11 +81,7 @@ pub async fn command_exists(cmd: &str) -> Option<String> {
 
 /// Get version string from a command.
 pub async fn get_version(cmd: &str, args: &[&str]) -> Option<String> {
-    let result = Command::new(cmd)
-        .args(args)
-        .output()
-        .await
-        .ok()?;
+    let result = Command::new(cmd).args(args).output().await.ok()?;
 
     if result.status.success() {
         let output = String::from_utf8_lossy(&result.stdout);

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub general: GeneralConfig,
@@ -89,21 +89,51 @@ pub struct OutputConfig {
     pub default_format: String,
 }
 
-fn default_database_path() -> String { ".skwaq/graph".into() }
-fn default_cache_path() -> String { ".skwaq/cache".into() }
-fn default_log_level() -> String { "info".into() }
-fn default_llm_backend() -> String { "copilot".into() }
-fn default_ollama() -> String { "ollama".into() }
-fn default_model() -> String { "openai/gpt-4o-mini".into() }
-fn default_ollama_host() -> String { "http://localhost:11434".into() }
-fn default_ollama_model() -> String { "llama3.1".into() }
-fn default_embedding_model() -> String { "nomic-embed-text".into() }
-fn default_timeout() -> u64 { 600 }
-fn default_true() -> bool { true }
-fn default_taint_depth() -> u32 { 15 }
-fn default_fp_target() -> f64 { 0.15 }
-fn default_token_budget() -> u64 { 100_000 }
-fn default_format() -> String { "text".into() }
+fn default_database_path() -> String {
+    ".skwaq/graph".into()
+}
+fn default_cache_path() -> String {
+    ".skwaq/cache".into()
+}
+fn default_log_level() -> String {
+    "info".into()
+}
+fn default_llm_backend() -> String {
+    "copilot".into()
+}
+fn default_ollama() -> String {
+    "ollama".into()
+}
+fn default_model() -> String {
+    "openai/gpt-4o-mini".into()
+}
+fn default_ollama_host() -> String {
+    "http://localhost:11434".into()
+}
+fn default_ollama_model() -> String {
+    "llama3.1".into()
+}
+fn default_embedding_model() -> String {
+    "nomic-embed-text".into()
+}
+fn default_timeout() -> u64 {
+    600
+}
+fn default_true() -> bool {
+    true
+}
+fn default_taint_depth() -> u32 {
+    15
+}
+fn default_fp_target() -> f64 {
+    0.15
+}
+fn default_token_budget() -> u64 {
+    100_000
+}
+fn default_format() -> String {
+    "text".into()
+}
 
 impl Default for GeneralConfig {
     fn default() -> Self {
@@ -165,17 +195,7 @@ impl Default for OutputConfig {
     }
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            general: GeneralConfig::default(),
-            llm: LlmConfig::default(),
-            binary: BinaryConfig::default(),
-            analysis: AnalysisConfig::default(),
-            output: OutputConfig::default(),
-        }
-    }
-}
+// Config derives Default since all fields implement Default.
 
 impl Config {
     pub fn load() -> anyhow::Result<Self> {

--- a/crates/core/src/graph/builder.rs
+++ b/crates/core/src/graph/builder.rs
@@ -81,12 +81,7 @@ impl<'a> GraphBuilder<'a> {
     }
 
     /// Insert a DataSource node representing an extracted string or input.
-    pub fn insert_string_source(
-        &self,
-        id: &str,
-        name: &str,
-        kind: &str,
-    ) -> anyhow::Result<()> {
+    pub fn insert_string_source(&self, id: &str, name: &str, kind: &str) -> anyhow::Result<()> {
         self.db.execute(
             "INSERT OR IGNORE INTO data_sources (id, name, source_type) VALUES (?1, ?2, ?3)",
             &[&id, &name, &kind],
@@ -95,12 +90,7 @@ impl<'a> GraphBuilder<'a> {
     }
 
     /// Insert a DataSink node.
-    pub fn insert_data_sink(
-        &self,
-        id: &str,
-        name: &str,
-        kind: &str,
-    ) -> anyhow::Result<()> {
+    pub fn insert_data_sink(&self, id: &str, name: &str, kind: &str) -> anyhow::Result<()> {
         self.db.execute(
             "INSERT OR IGNORE INTO data_sinks (id, name, sink_type) VALUES (?1, ?2, ?3)",
             &[&id, &name, &kind],

--- a/crates/core/src/graph/builder_binary.rs
+++ b/crates/core/src/graph/builder_binary.rs
@@ -23,10 +23,8 @@ impl<'a> GraphBuilder<'a> {
 
         if result.is_ok() {
             self.db().mutate("COMMIT;")?;
-        } else {
-            if let Err(e) = self.db().mutate("ROLLBACK;") {
-                tracing::error!("Failed to rollback transaction: {e}");
-            }
+        } else if let Err(e) = self.db().mutate("ROLLBACK;") {
+            tracing::error!("Failed to rollback transaction: {e}");
         }
 
         result?;
@@ -47,7 +45,12 @@ impl<'a> GraphBuilder<'a> {
                 self.db().execute(
                     "INSERT OR IGNORE INTO functions (id, name, address, investigation_id) \
                      VALUES (?1, ?2, ?3, ?4)",
-                    &[&id.as_str(), &sym.name.as_str(), &format!("0x{:x}", sym.address).as_str(), &investigation_id],
+                    &[
+                        &id.as_str(),
+                        &sym.name.as_str(),
+                        &format!("0x{:x}", sym.address).as_str(),
+                        &investigation_id,
+                    ],
                 )?;
                 counts.functions += 1;
             }
@@ -65,19 +68,24 @@ impl<'a> GraphBuilder<'a> {
 
             // Classify as data source.
             let base = imp.name.split('@').next().unwrap_or(&imp.name);
-            if SOURCE_PATTERNS.iter().any(|p| base == *p) {
+            if SOURCE_PATTERNS.contains(&base) {
                 let src_id = format!("src-{}", &imp.name);
                 let source_type = classify_source(base);
                 self.db().execute(
                     "INSERT OR IGNORE INTO data_sources (id, name, source_type, investigation_id) \
                      VALUES (?1, ?2, ?3, ?4)",
-                    &[&src_id.as_str(), &imp.name.as_str(), &source_type, &investigation_id],
+                    &[
+                        &src_id.as_str(),
+                        &imp.name.as_str(),
+                        &source_type,
+                        &investigation_id,
+                    ],
                 )?;
                 counts.sources += 1;
             }
 
             // Classify as data sink.
-            if SINK_PATTERNS.iter().any(|p| base == *p) {
+            if SINK_PATTERNS.contains(&base) {
                 let sink_id = format!("sink-{}", &imp.name);
                 let danger = classify_sink_danger(base);
                 self.db().execute(
@@ -96,7 +104,12 @@ impl<'a> GraphBuilder<'a> {
             self.db().execute(
                 "INSERT OR IGNORE INTO string_literals (id, value, offset, investigation_id) \
                  VALUES (?1, ?2, ?3, ?4)",
-                &[&id.as_str(), &s.value.as_str(), &format!("{}", s.offset).as_str(), &investigation_id],
+                &[
+                    &id.as_str(),
+                    &s.value.as_str(),
+                    &format!("{}", s.offset).as_str(),
+                    &investigation_id,
+                ],
             )?;
             counts.strings += 1;
         }
@@ -186,17 +199,24 @@ mod tests {
                 },
             ],
             imports: vec![
-                ImportInfo { name: "recv".into(), library: String::new() },
-                ImportInfo { name: "strcpy".into(), library: String::new() },
-                ImportInfo { name: "printf".into(), library: String::new() },
-            ],
-            strings: vec![
-                ExtractedString {
-                    value: "hello".into(),
-                    offset: 100,
-                    encoding: StringEncoding::Ascii,
+                ImportInfo {
+                    name: "recv".into(),
+                    library: String::new(),
+                },
+                ImportInfo {
+                    name: "strcpy".into(),
+                    library: String::new(),
+                },
+                ImportInfo {
+                    name: "printf".into(),
+                    library: String::new(),
                 },
             ],
+            strings: vec![ExtractedString {
+                value: "hello".into(),
+                offset: 100,
+                encoding: StringEncoding::Ascii,
+            }],
             hardening: HardeningInfo::default(),
         };
 

--- a/crates/core/src/graph/builder_ghidra.rs
+++ b/crates/core/src/graph/builder_ghidra.rs
@@ -1,6 +1,6 @@
 //! Graph enrichment from Ghidra decompilation results.
 
-use super::builder::{GraphBuilder, GhidraInsertCounts};
+use super::builder::{GhidraInsertCounts, GraphBuilder};
 use crate::binary::types::GhidraAnalysis;
 
 impl<'a> GraphBuilder<'a> {
@@ -18,15 +18,12 @@ impl<'a> GraphBuilder<'a> {
 
         self.db().mutate("BEGIN TRANSACTION;")?;
 
-        let result =
-            self.build_from_ghidra_inner(analysis, investigation_id, &mut counts);
+        let result = self.build_from_ghidra_inner(analysis, investigation_id, &mut counts);
 
         if result.is_ok() {
             self.db().mutate("COMMIT;")?;
-        } else {
-            if let Err(e) = self.db().mutate("ROLLBACK;") {
-                tracing::error!("Failed to rollback transaction: {e}");
-            }
+        } else if let Err(e) = self.db().mutate("ROLLBACK;") {
+            tracing::error!("Failed to rollback transaction: {e}");
         }
 
         result?;
@@ -48,9 +45,10 @@ impl<'a> GraphBuilder<'a> {
         let mut name_to_id: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         {
-            let mut stmt = self.db().conn().prepare(
-                "SELECT id, name, address FROM functions WHERE investigation_id = ?1",
-            )?;
+            let mut stmt = self
+                .db()
+                .conn()
+                .prepare("SELECT id, name, address FROM functions WHERE investigation_id = ?1")?;
             let rows = stmt.query_map([investigation_id], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -79,7 +77,8 @@ impl<'a> GraphBuilder<'a> {
             // Try to find an existing function by address first, then by name.
             // Address matching: goblin stores "0x10d0", Ghidra stores "00101000".
             // These often differ due to PIE base address differences.
-            let existing_id = addr_to_id.get(&gfunc.address)
+            let existing_id = addr_to_id
+                .get(&gfunc.address)
                 .or_else(|| {
                     let with_prefix = format!("0x{}", &gfunc.address);
                     addr_to_id.get(&with_prefix)
@@ -88,7 +87,8 @@ impl<'a> GraphBuilder<'a> {
                     // Try stripping leading zeros from Ghidra address
                     let stripped = gfunc.address.trim_start_matches('0');
                     if !stripped.is_empty() {
-                        addr_to_id.get(stripped)
+                        addr_to_id
+                            .get(stripped)
                             .or_else(|| addr_to_id.get(&format!("0x{}", stripped)))
                     } else {
                         None
@@ -221,7 +221,10 @@ mod tests {
                     name: "main".into(),
                     address: "401000".into(), // without 0x prefix (Ghidra style)
                     size: 100,
-                    decompiled: Some("int main(int argc, char **argv) {\n  system(argv[1]);\n  return 0;\n}".into()),
+                    decompiled: Some(
+                        "int main(int argc, char **argv) {\n  system(argv[1]);\n  return 0;\n}"
+                            .into(),
+                    ),
                     calls: vec!["401100".into()],
                     called_by: vec![],
                     parameter_count: 2,
@@ -240,7 +243,9 @@ mod tests {
             imports: vec![],
         };
 
-        let gcounts = builder.build_from_ghidra_analysis(&ghidra, "inv-ghidra").unwrap();
+        let gcounts = builder
+            .build_from_ghidra_analysis(&ghidra, "inv-ghidra")
+            .unwrap();
 
         // main should be updated (address match via 0x prefix stripping)
         assert_eq!(gcounts.functions_updated, 1);
@@ -274,11 +279,7 @@ mod tests {
         // Verify call edge exists
         let call_count: i64 = db
             .conn()
-            .query_row(
-                "SELECT count(*) FROM calls",
-                [],
-                |row| row.get(0),
-            )
+            .query_row("SELECT count(*) FROM calls", [], |row| row.get(0))
             .unwrap();
         assert_eq!(call_count, 1);
     }
@@ -294,7 +295,9 @@ mod tests {
             imports: vec![],
         };
 
-        let gcounts = builder.build_from_ghidra_analysis(&ghidra, "inv-empty").unwrap();
+        let gcounts = builder
+            .build_from_ghidra_analysis(&ghidra, "inv-empty")
+            .unwrap();
         assert_eq!(gcounts.functions_updated, 0);
         assert_eq!(gcounts.functions_added, 0);
         assert_eq!(gcounts.calls_added, 0);

--- a/crates/core/src/graph/builder_source.rs
+++ b/crates/core/src/graph/builder_source.rs
@@ -18,15 +18,12 @@ impl<'a> GraphBuilder<'a> {
 
         self.db().mutate("BEGIN TRANSACTION;")?;
 
-        let result =
-            self.build_from_source_inner(parsed_files, investigation_id, &mut counts);
+        let result = self.build_from_source_inner(parsed_files, investigation_id, &mut counts);
 
         if result.is_ok() {
             self.db().mutate("COMMIT;")?;
-        } else {
-            if let Err(e) = self.db().mutate("ROLLBACK;") {
-                tracing::error!("Failed to rollback transaction: {e}");
-            }
+        } else if let Err(e) = self.db().mutate("ROLLBACK;") {
+            tracing::error!("Failed to rollback transaction: {e}");
         }
 
         result?;
@@ -82,11 +79,7 @@ impl<'a> GraphBuilder<'a> {
                 )?;
 
                 // Find enclosing function (closest function with line <= call.line).
-                let enclosing = parsed
-                    .functions
-                    .iter()
-                    .filter(|f| f.line <= call.line)
-                    .last();
+                let enclosing = parsed.functions.iter().rfind(|f| f.line <= call.line);
 
                 if let Some(enc) = enclosing {
                     let caller_id = format!("{}-fn-{}-L{}", file_prefix, enc.name, enc.line);
@@ -139,21 +132,14 @@ impl<'a> GraphBuilder<'a> {
             let raw_content = std::fs::read_to_string(&parsed.path).ok();
             if let Some(ref content) = raw_content {
                 let _ = source_content; // suppress warning
-                let ss_hits = identify_source_sinks_in_content(
-                    content,
-                    &parsed.language,
-                    &parsed.path,
-                )?;
+                let ss_hits =
+                    identify_source_sinks_in_content(content, &parsed.language, &parsed.path)?;
 
                 for hit in &ss_hits {
                     match hit.kind {
                         SourceSinkKind::Source => {
-                            let src_id = format!(
-                                "{}-source-{}-L{}",
-                                file_prefix,
-                                hit.category,
-                                hit.line
-                            );
+                            let src_id =
+                                format!("{}-source-{}-L{}", file_prefix, hit.category, hit.line);
                             self.db().execute(
                                 "INSERT OR IGNORE INTO data_sources \
                                  (id, name, source_type, location, investigation_id) \
@@ -169,12 +155,8 @@ impl<'a> GraphBuilder<'a> {
                             counts.sources += 1;
                         }
                         SourceSinkKind::Sink => {
-                            let sink_id = format!(
-                                "{}-sink-{}-L{}",
-                                file_prefix,
-                                hit.category,
-                                hit.line
-                            );
+                            let sink_id =
+                                format!("{}-sink-{}-L{}", file_prefix, hit.category, hit.line);
                             self.db().execute(
                                 "INSERT OR IGNORE INTO data_sinks \
                                  (id, name, sink_type, danger_level, location, investigation_id) \

--- a/crates/core/src/graph/db.rs
+++ b/crates/core/src/graph/db.rs
@@ -41,7 +41,11 @@ impl GraphDb {
     }
 
     /// Execute a write statement.
-    pub fn execute(&self, sql: &str, params: &[&dyn rusqlite::types::ToSql]) -> anyhow::Result<usize> {
+    pub fn execute(
+        &self,
+        sql: &str,
+        params: &[&dyn rusqlite::types::ToSql],
+    ) -> anyhow::Result<usize> {
         Ok(self.conn.execute(sql, params)?)
     }
 
@@ -227,7 +231,7 @@ impl GraphDb {
             CREATE INDEX IF NOT EXISTS idx_taint_source ON taint_flows(source_id);
             CREATE INDEX IF NOT EXISTS idx_taint_sink ON taint_flows(sink_id);
             CREATE INDEX IF NOT EXISTS idx_vulns_investigation ON vulnerabilities(investigation_id);
-            "
+            ",
         )?;
         Ok(())
     }
@@ -241,7 +245,8 @@ mod tests {
     fn test_open_in_memory() {
         let db = GraphDb::in_memory().unwrap();
         // Schema should exist
-        let count: i64 = db.conn()
+        let count: i64 = db
+            .conn()
             .query_row("SELECT count(*) FROM functions", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
@@ -263,11 +268,22 @@ mod tests {
         db.execute(
             "INSERT INTO functions (id, name, address, decompiled, confidence, investigation_id) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            &[&"func1", &"main", &"0x401000", &"int main() { return 0; }", &0.95_f64 as &dyn rusqlite::types::ToSql, &"inv1"],
-        ).unwrap();
+            &[
+                &"func1",
+                &"main",
+                &"0x401000",
+                &"int main() { return 0; }",
+                &0.95_f64 as &dyn rusqlite::types::ToSql,
+                &"inv1",
+            ],
+        )
+        .unwrap();
 
-        let name: String = db.conn()
-            .query_row("SELECT name FROM functions WHERE id = 'func1'", [], |row| row.get(0))
+        let name: String = db
+            .conn()
+            .query_row("SELECT name FROM functions WHERE id = 'func1'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(name, "main");
     }
@@ -276,11 +292,24 @@ mod tests {
     fn test_call_relationship() {
         let db = GraphDb::in_memory().unwrap();
 
-        db.execute("INSERT INTO functions (id, name) VALUES ('f1', 'caller')", &[]).unwrap();
-        db.execute("INSERT INTO functions (id, name) VALUES ('f2', 'callee')", &[]).unwrap();
-        db.execute("INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')", &[]).unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f1', 'caller')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f2', 'callee')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')",
+            &[],
+        )
+        .unwrap();
 
-        let callee: String = db.conn()
+        let callee: String = db
+            .conn()
             .query_row(
                 "SELECT f2.name FROM calls c \
                  JOIN functions f1 ON c.caller_id = f1.id \
@@ -301,10 +330,16 @@ mod tests {
             "INSERT INTO investigations (id, name, target, status, created_at) \
              VALUES ('inv1', 'Test', '/usr/bin/test', 'active', '2026-03-10')",
             &[],
-        ).unwrap();
+        )
+        .unwrap();
 
-        let status: String = db.conn()
-            .query_row("SELECT status FROM investigations WHERE id = 'inv1'", [], |row| row.get(0))
+        let status: String = db
+            .conn()
+            .query_row(
+                "SELECT status FROM investigations WHERE id = 'inv1'",
+                [],
+                |row| row.get(0),
+            )
             .unwrap();
         assert_eq!(status, "active");
     }
@@ -313,14 +348,19 @@ mod tests {
     fn test_taint_flow() {
         let db = GraphDb::in_memory().unwrap();
 
-        db.execute("INSERT INTO data_sources (id, name, source_type) VALUES ('src1', 'recv', 'network')", &[]).unwrap();
+        db.execute(
+            "INSERT INTO data_sources (id, name, source_type) VALUES ('src1', 'recv', 'network')",
+            &[],
+        )
+        .unwrap();
         db.execute("INSERT INTO data_sinks (id, name, sink_type, danger_level) VALUES ('sink1', 'strcpy', 'memory', 'critical')", &[]).unwrap();
         db.execute(
             "INSERT INTO taint_flows (source_id, sink_id, path, sanitized) VALUES ('src1', 'sink1', 'recv->process->strcpy', 0)",
             &[],
         ).unwrap();
 
-        let path: String = db.conn()
+        let path: String = db
+            .conn()
             .query_row(
                 "SELECT tf.path FROM taint_flows tf \
                  JOIN data_sources s ON tf.source_id = s.id \

--- a/crates/core/src/graph/mod.rs
+++ b/crates/core/src/graph/mod.rs
@@ -11,6 +11,6 @@ pub mod db;
 pub mod queries;
 pub mod types;
 
-pub use builder::{GraphBuilder, GhidraInsertCounts, InsertCounts, SourceInsertCounts};
+pub use builder::{GhidraInsertCounts, GraphBuilder, InsertCounts, SourceInsertCounts};
 pub use db::GraphDb;
 pub use types::{NodeLabel, RelationshipType};

--- a/crates/core/src/graph/queries.rs
+++ b/crates/core/src/graph/queries.rs
@@ -3,24 +3,34 @@
 use super::db::GraphDb;
 
 /// Return all function names and addresses for an investigation.
-pub fn get_functions(db: &GraphDb, investigation_id: &str) -> anyhow::Result<Vec<(String, String, String)>> {
+pub fn get_functions(
+    db: &GraphDb,
+    investigation_id: &str,
+) -> anyhow::Result<Vec<(String, String, String)>> {
     let mut stmt = db.conn().prepare(
-        "SELECT id, name, address FROM functions WHERE investigation_id = ?1 ORDER BY name"
+        "SELECT id, name, address FROM functions WHERE investigation_id = ?1 ORDER BY name",
     )?;
     let rows = stmt.query_map([investigation_id], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
     })?;
     let results = rows.collect::<Result<Vec<_>, rusqlite::Error>>()?;
     Ok(results)
 }
 
 /// Return the call graph as (caller_name, callee_name) pairs.
-pub fn get_call_graph(db: &GraphDb, investigation_id: &str) -> anyhow::Result<Vec<(String, String)>> {
+pub fn get_call_graph(
+    db: &GraphDb,
+    investigation_id: &str,
+) -> anyhow::Result<Vec<(String, String)>> {
     let mut stmt = db.conn().prepare(
         "SELECT f1.name, f2.name FROM calls c \
          JOIN functions f1 ON c.caller_id = f1.id \
          JOIN functions f2 ON c.callee_id = f2.id \
-         WHERE f1.investigation_id = ?1 AND f2.investigation_id = ?1"
+         WHERE f1.investigation_id = ?1 AND f2.investigation_id = ?1",
     )?;
     let rows = stmt.query_map([investigation_id], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -30,25 +40,35 @@ pub fn get_call_graph(db: &GraphDb, investigation_id: &str) -> anyhow::Result<Ve
 }
 
 /// Return unsanitized taint flow paths for a given investigation.
-pub fn get_taint_paths(db: &GraphDb, investigation_id: &str) -> anyhow::Result<Vec<(String, String, String)>> {
+pub fn get_taint_paths(
+    db: &GraphDb,
+    investigation_id: &str,
+) -> anyhow::Result<Vec<(String, String, String)>> {
     let mut stmt = db.conn().prepare(
         "SELECT s.name, k.name, tf.path FROM taint_flows tf \
          JOIN data_sources s ON tf.source_id = s.id \
          JOIN data_sinks k ON tf.sink_id = k.id \
-         WHERE tf.sanitized = 0 AND s.investigation_id = ?1"
+         WHERE tf.sanitized = 0 AND s.investigation_id = ?1",
     )?;
     let rows = stmt.query_map([investigation_id], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
     })?;
     let results = rows.collect::<Result<Vec<_>, rusqlite::Error>>()?;
     Ok(results)
 }
 
 /// Return all vulnerabilities with severity.
-pub fn get_vulnerabilities(db: &GraphDb, investigation_id: &str) -> anyhow::Result<Vec<(String, String, String, f64)>> {
+pub fn get_vulnerabilities(
+    db: &GraphDb,
+    investigation_id: &str,
+) -> anyhow::Result<Vec<(String, String, String, f64)>> {
     let mut stmt = db.conn().prepare(
         "SELECT id, title, severity, confidence FROM vulnerabilities \
-         WHERE investigation_id = ?1 ORDER BY confidence DESC"
+         WHERE investigation_id = ?1 ORDER BY confidence DESC",
     )?;
     let rows = stmt.query_map([investigation_id], |row| {
         Ok((
@@ -65,7 +85,7 @@ pub fn get_vulnerabilities(db: &GraphDb, investigation_id: &str) -> anyhow::Resu
 /// Get all investigations.
 pub fn get_investigations(db: &GraphDb) -> anyhow::Result<Vec<(String, String, String, String)>> {
     let mut stmt = db.conn().prepare(
-        "SELECT id, name, status, created_at FROM investigations ORDER BY created_at DESC"
+        "SELECT id, name, status, created_at FROM investigations ORDER BY created_at DESC",
     )?;
     let rows = stmt.query_map([], |row| {
         Ok((

--- a/crates/core/src/investigation/annotations.rs
+++ b/crates/core/src/investigation/annotations.rs
@@ -48,7 +48,7 @@ impl<'a> AnnotationManager<'a> {
     pub fn list(&self, investigation_id: &str) -> anyhow::Result<Vec<Annotation>> {
         let mut stmt = self.db.conn().prepare(
             "SELECT id, text, author, timestamp FROM annotations \
-             WHERE investigation_id = ?1 ORDER BY timestamp DESC"
+             WHERE investigation_id = ?1 ORDER BY timestamp DESC",
         )?;
         let rows = stmt.query_map([investigation_id], |row| {
             Ok(Annotation {
@@ -73,7 +73,11 @@ mod tests {
         db.execute(
             "INSERT INTO investigations (id, name, target, status, created_at, updated_at) \
              VALUES (?1, ?2, '', 'active', ?3, ?3)",
-            &[&id.as_str() as &dyn rusqlite::types::ToSql, &"test", &now.as_str()],
+            &[
+                &id.as_str() as &dyn rusqlite::types::ToSql,
+                &"test",
+                &now.as_str(),
+            ],
         )
         .unwrap();
         id
@@ -85,7 +89,9 @@ mod tests {
         let inv_id = setup_investigation(&db);
         let mgr = AnnotationManager::new(&db);
 
-        let a_id = mgr.add(&inv_id, "suspicious pattern in parse_input", "analyst").unwrap();
+        let a_id = mgr
+            .add(&inv_id, "suspicious pattern in parse_input", "analyst")
+            .unwrap();
         assert!(!a_id.is_empty());
 
         let list = mgr.list(&inv_id).unwrap();

--- a/crates/core/src/investigation/hypotheses.rs
+++ b/crates/core/src/investigation/hypotheses.rs
@@ -52,12 +52,7 @@ impl<'a> HypothesisManager<'a> {
     }
 
     /// Update the status and confidence of a hypothesis.
-    pub fn update(
-        &self,
-        hypothesis_id: &str,
-        status: &str,
-        confidence: f64,
-    ) -> anyhow::Result<()> {
+    pub fn update(&self, hypothesis_id: &str, status: &str, confidence: f64) -> anyhow::Result<()> {
         let rows = self.db.execute(
             "UPDATE hypotheses SET status = ?1, confidence = ?2 WHERE id = ?3",
             &[
@@ -76,7 +71,7 @@ impl<'a> HypothesisManager<'a> {
     pub fn list(&self, investigation_id: &str) -> anyhow::Result<Vec<Hypothesis>> {
         let mut stmt = self.db.conn().prepare(
             "SELECT id, description, status, confidence, timestamp FROM hypotheses \
-             WHERE investigation_id = ?1 ORDER BY timestamp DESC"
+             WHERE investigation_id = ?1 ORDER BY timestamp DESC",
         )?;
         let rows = stmt.query_map([investigation_id], |row| {
             Ok(Hypothesis {
@@ -102,7 +97,11 @@ mod tests {
         db.execute(
             "INSERT INTO investigations (id, name, target, status, created_at, updated_at) \
              VALUES (?1, ?2, '', 'active', ?3, ?3)",
-            &[&id.as_str() as &dyn rusqlite::types::ToSql, &"test", &now.as_str()],
+            &[
+                &id.as_str() as &dyn rusqlite::types::ToSql,
+                &"test",
+                &now.as_str(),
+            ],
         )
         .unwrap();
         id
@@ -114,7 +113,9 @@ mod tests {
         let inv_id = setup_investigation(&db);
         let mgr = HypothesisManager::new(&db);
 
-        let h_id = mgr.create(&inv_id, "buffer overflow possible", 0.8).unwrap();
+        let h_id = mgr
+            .create(&inv_id, "buffer overflow possible", 0.8)
+            .unwrap();
         assert!(!h_id.is_empty());
 
         let list = mgr.list(&inv_id).unwrap();

--- a/crates/core/src/investigation/manager.rs
+++ b/crates/core/src/investigation/manager.rs
@@ -43,7 +43,7 @@ impl<'a> InvestigationManager<'a> {
     pub fn list(&self) -> anyhow::Result<Vec<InvestigationSummary>> {
         let mut stmt = self.db.conn().prepare(
             "SELECT id, name, status, created_at FROM investigations \
-             ORDER BY created_at DESC"
+             ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map([], |row| {
             Ok(InvestigationSummary {

--- a/crates/core/src/llm/copilot.rs
+++ b/crates/core/src/llm/copilot.rs
@@ -6,5 +6,6 @@
 
 pub(crate) const COPILOT_MODELS_URL: &str = "https://api.githubcopilot.com/models";
 pub(crate) const COPILOT_CHAT_URL: &str = "https://api.githubcopilot.com/chat/completions";
-pub(crate) const GITHUB_MODELS_CHAT_URL: &str = "https://models.github.ai/inference/chat/completions";
+pub(crate) const GITHUB_MODELS_CHAT_URL: &str =
+    "https://models.github.ai/inference/chat/completions";
 pub(crate) const GITHUB_MODELS_PREFIX: &str = "openai/";

--- a/crates/core/src/llm/copilot_auth.rs
+++ b/crates/core/src/llm/copilot_auth.rs
@@ -1,6 +1,8 @@
 //! Authentication and endpoint negotiation for GitHub Copilot / Models API.
 
-use super::copilot::{COPILOT_CHAT_URL, COPILOT_MODELS_URL, GITHUB_MODELS_CHAT_URL, GITHUB_MODELS_PREFIX};
+use super::copilot::{
+    COPILOT_CHAT_URL, COPILOT_MODELS_URL, GITHUB_MODELS_CHAT_URL, GITHUB_MODELS_PREFIX,
+};
 
 /// Which API endpoint is active.
 #[derive(Debug, Clone, Copy)]
@@ -84,9 +86,7 @@ pub(crate) async fn ensure_auth(http: &reqwest::Client) -> anyhow::Result<AuthSt
     // Log the failure details
     if let Ok(resp) = models_resp {
         let status = resp.status();
-        tracing::debug!(
-            "GitHub Models API probe returned {status}, trying Copilot API"
-        );
+        tracing::debug!("GitHub Models API probe returned {status}, trying Copilot API");
     }
 
     // Fall back: check Copilot API models list

--- a/crates/core/src/llm/copilot_client.rs
+++ b/crates/core/src/llm/copilot_client.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
 
 use super::copilot_auth::{ensure_auth, AuthState};
-use super::traits::{LlmClient, LlmResponse, Message, ToolCall, ToolDefinition, TokenUsage};
+use super::traits::{LlmClient, LlmResponse, Message, TokenUsage, ToolCall, ToolDefinition};
 
 // ── request types (OpenAI-compatible) ────────────────────────────
 
@@ -128,9 +128,7 @@ impl CopilotClient {
     /// Lazily discover and validate auth.
     async fn ensure_auth(&self) -> anyhow::Result<&AuthState> {
         self.auth
-            .get_or_try_init(|| async {
-                ensure_auth(&self.http).await
-            })
+            .get_or_try_init(|| async { ensure_auth(&self.http).await })
             .await
     }
 }
@@ -167,11 +165,12 @@ impl LlmClient for CopilotClient {
 
                 // For assistant messages with tool_calls, content should be
                 // null (not empty string) per OpenAI API spec
-                let content = if m.role == "assistant" && api_tool_calls.is_some() && m.content.is_empty() {
-                    None
-                } else {
-                    Some(m.content.clone())
-                };
+                let content =
+                    if m.role == "assistant" && api_tool_calls.is_some() && m.content.is_empty() {
+                        None
+                    } else {
+                        Some(m.content.clone())
+                    };
 
                 CompletionsMessage {
                     role: m.role.clone(),
@@ -237,8 +236,7 @@ impl LlmClient for CopilotClient {
             .into_iter()
             .map(|tc| {
                 let arguments: serde_json::Value =
-                    serde_json::from_str(&tc.function.arguments)
-                        .unwrap_or(serde_json::Value::Null);
+                    serde_json::from_str(&tc.function.arguments).unwrap_or(serde_json::Value::Null);
                 ToolCall {
                     id: tc.id,
                     name: tc.function.name,

--- a/crates/core/src/llm/mod.rs
+++ b/crates/core/src/llm/mod.rs
@@ -6,8 +6,8 @@ pub mod copilot_client;
 pub mod ollama;
 pub mod traits;
 
-pub use traits::*;
 pub use copilot_client::CopilotClient;
+pub use traits::*;
 
 use crate::config::LlmConfig;
 
@@ -30,8 +30,10 @@ mod tests {
 
     #[test]
     fn test_create_ollama_client() {
-        let mut config = LlmConfig::default();
-        config.reasoning = "ollama".into();
+        let config = LlmConfig {
+            reasoning: "ollama".into(),
+            ..Default::default()
+        };
         let client = create_llm_client(&config);
         assert_eq!(client.provider_name(), "ollama");
     }
@@ -45,8 +47,10 @@ mod tests {
 
     #[test]
     fn test_create_copilot_client_explicit() {
-        let mut config = LlmConfig::default();
-        config.reasoning = "copilot".into();
+        let config = LlmConfig {
+            reasoning: "copilot".into(),
+            ..Default::default()
+        };
         let client = create_llm_client(&config);
         assert_eq!(client.provider_name(), "copilot");
     }

--- a/crates/core/src/llm/ollama.rs
+++ b/crates/core/src/llm/ollama.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use super::traits::{LlmClient, LlmResponse, Message, ToolCall, ToolDefinition, TokenUsage};
+use super::traits::{LlmClient, LlmResponse, Message, TokenUsage, ToolCall, ToolDefinition};
 
 /// Ollama chat API client.
 pub struct OllamaClient {

--- a/crates/core/src/llm/traits.rs
+++ b/crates/core/src/llm/traits.rs
@@ -100,7 +100,10 @@ impl TokenBudget {
     }
 
     pub fn unlimited() -> Self {
-        Self { limit: u64::MAX, used: 0 }
+        Self {
+            limit: u64::MAX,
+            used: 0,
+        }
     }
 
     pub fn exhausted(&self) -> bool {
@@ -133,10 +136,7 @@ where
     F: Fn(String, serde_json::Value) -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<serde_json::Value>>,
 {
-    let mut messages = vec![
-        Message::system(system_prompt),
-        Message::user(user_prompt),
-    ];
+    let mut messages = vec![Message::system(system_prompt), Message::user(user_prompt)];
 
     let max_turns = 50; // Safety limit
     for _ in 0..max_turns {
@@ -163,10 +163,7 @@ where
         for call in &response.tool_calls {
             tracing::debug!("Tool call: {} args={}", call.name, call.arguments);
             let result = tool_executor(call.name.clone(), call.arguments.clone()).await?;
-            messages.push(Message::tool(
-                &serde_json::to_string(&result)?,
-                &call.id,
-            ));
+            messages.push(Message::tool(&serde_json::to_string(&result)?, &call.id));
         }
     }
 

--- a/crates/core/src/reporting/markdown.rs
+++ b/crates/core/src/reporting/markdown.rs
@@ -28,7 +28,7 @@ pub fn generate_markdown(findings: &[Value]) -> anyhow::Result<String> {
     let medium = count_severity(findings, "medium");
     let low = count_severity(findings, "low");
 
-    md.push_str(&format!("| Metric | Value |\n"));
+    md.push_str("| Metric | Value |\n");
     md.push_str("| --- | --- |\n");
     md.push_str(&format!("| Total findings | {total} |\n"));
     md.push_str(&format!("| Critical | {critical} |\n"));
@@ -47,9 +47,7 @@ pub fn generate_markdown(findings: &[Value]) -> anyhow::Result<String> {
     md.push_str("| --- | --- | --- | --- | --- | --- |\n");
 
     let mut sorted: Vec<&Value> = findings.iter().collect();
-    sorted.sort_by(|a, b| {
-        severity_rank(a).cmp(&severity_rank(b))
-    });
+    sorted.sort_by_key(|a| severity_rank(a));
 
     for (i, finding) in sorted.iter().enumerate() {
         let title = finding.get("title").and_then(|v| v.as_str()).unwrap_or("—");
@@ -106,12 +104,14 @@ pub fn generate_markdown(findings: &[Value]) -> anyhow::Result<String> {
             .get("evidence")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        let cvss = finding
-            .get("cvss")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
+        let cvss = finding.get("cvss").and_then(|v| v.as_f64()).unwrap_or(0.0);
 
-        md.push_str(&format!("### {}. {} {}\n\n", i + 1, severity_badge(severity), title));
+        md.push_str(&format!(
+            "### {}. {} {}\n\n",
+            i + 1,
+            severity_badge(severity),
+            title
+        ));
         md.push_str(&format!("- **Severity**: {severity}\n"));
         if cvss > 0.0 {
             md.push_str(&format!("- **CVSS**: {cvss:.1}\n"));
@@ -183,7 +183,7 @@ pub fn generate_markdown_for_investigation(
     let mut md = String::new();
     md.push_str("# Vulnerability Assessment Report\n\n");
     md.push_str("## Investigation\n\n");
-    md.push_str(&format!("| Field | Value |\n"));
+    md.push_str("| Field | Value |\n");
     md.push_str("| --- | --- |\n");
     md.push_str(&format!("| Name | {inv_name} |\n"));
     md.push_str(&format!("| Target | `{inv_target}` |\n"));
@@ -309,9 +309,7 @@ fn cwe_link(cwe_id: &str) -> String {
         return "—".into();
     }
     let numeric = cwe_id.strip_prefix("CWE-").unwrap_or(cwe_id);
-    format!(
-        "[{cwe_id}](https://cwe.mitre.org/data/definitions/{numeric}.html)"
-    )
+    format!("[{cwe_id}](https://cwe.mitre.org/data/definitions/{numeric}.html)")
 }
 
 #[cfg(test)]
@@ -425,7 +423,13 @@ mod tests {
         db.execute(
             "INSERT INTO investigations (id, name, target, status, created_at) \
              VALUES (?1, ?2, ?3, ?4, ?5)",
-            &[&"inv2", &"Quick Test", &"/usr/bin/quick", &"active", &"2026-03-10"],
+            &[
+                &"inv2",
+                &"Quick Test",
+                &"/usr/bin/quick",
+                &"active",
+                &"2026-03-10",
+            ],
         )
         .unwrap();
 
@@ -456,7 +460,13 @@ mod tests {
         db.execute(
             "INSERT INTO investigations (id, name, target, status, created_at) \
              VALUES (?1, ?2, ?3, ?4, ?5)",
-            &[&"inv3", &"Combined", &"/usr/bin/combo", &"active", &"2026-03-10"],
+            &[
+                &"inv3",
+                &"Combined",
+                &"/usr/bin/combo",
+                &"active",
+                &"2026-03-10",
+            ],
         )
         .unwrap();
 

--- a/crates/core/src/reporting/sarif.rs
+++ b/crates/core/src/reporting/sarif.rs
@@ -113,9 +113,7 @@ fn severity_to_level(severity: &str) -> &'static str {
 
 /// Build a CWE help URI.
 fn cwe_help_uri(cwe_id: &str) -> String {
-    let numeric = cwe_id
-        .strip_prefix("CWE-")
-        .unwrap_or(cwe_id);
+    let numeric = cwe_id.strip_prefix("CWE-").unwrap_or(cwe_id);
     format!("https://cwe.mitre.org/data/definitions/{numeric}.html")
 }
 
@@ -354,7 +352,9 @@ mod tests {
         assert_eq!(results[0]["level"], "error");
         assert_eq!(results[0]["properties"]["severity"], "critical");
 
-        let rules = doc["runs"][0]["tool"]["driver"]["rules"].as_array().unwrap();
+        let rules = doc["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0]["id"], "CWE-122");
     }
@@ -531,14 +531,20 @@ mod tests {
 
     #[test]
     fn test_title_to_rule_id() {
-        assert_eq!(title_to_rule_id("Dangerous API - system"), "dangerous-api-system");
+        assert_eq!(
+            title_to_rule_id("Dangerous API - system"),
+            "dangerous-api-system"
+        );
         assert_eq!(title_to_rule_id("Buffer Overflow"), "buffer-overflow");
         assert_eq!(title_to_rule_id("simple"), "simple");
     }
 
     #[test]
     fn test_parse_severity_from_evidence() {
-        assert_eq!(parse_severity_from_evidence("severity=critical something"), "critical");
+        assert_eq!(
+            parse_severity_from_evidence("severity=critical something"),
+            "critical"
+        );
         assert_eq!(parse_severity_from_evidence("severity=high"), "high");
         assert_eq!(parse_severity_from_evidence("severity=low minor"), "low");
         assert_eq!(parse_severity_from_evidence("no severity marker"), "medium");

--- a/crates/core/src/skills/discovery.rs
+++ b/crates/core/src/skills/discovery.rs
@@ -130,9 +130,8 @@ pub fn discover_skills() -> Vec<SkillDefinition> {
 /// 2. `~/.skwaq/skills/{name}/SKILL.md` (user-global)
 /// 3. `skills/{name}/SKILL.md` (bundled defaults)
 pub fn load_skill(name: &str) -> anyhow::Result<SkillDefinition> {
-    let mut candidates: Vec<PathBuf> = vec![
-        PathBuf::from(".skwaq/skills").join(name).join("SKILL.md"),
-    ];
+    let mut candidates: Vec<PathBuf> =
+        vec![PathBuf::from(".skwaq/skills").join(name).join("SKILL.md")];
     if let Some(home) = dirs::home_dir() {
         candidates.push(home.join(".skwaq/skills").join(name).join("SKILL.md"));
     }
@@ -182,8 +181,7 @@ fn parse_skill_markdown(content: &str, path: &Path) -> anyhow::Result<SkillDefin
         .unwrap_or("unknown")
         .to_string();
 
-    if content.starts_with("---") {
-        let rest = &content[3..];
+    if let Some(rest) = content.strip_prefix("---") {
         if let Some(end) = rest.find("\n---") {
             let yaml_str = &rest[..end];
             let body = rest[end + 4..].trim();
@@ -192,11 +190,7 @@ fn parse_skill_markdown(content: &str, path: &Path) -> anyhow::Result<SkillDefin
                 .map_err(|e| anyhow::anyhow!("Failed to parse skill frontmatter: {e}"))?;
 
             // Use frontmatter name if provided, otherwise use directory name.
-            let skill_name = if fm.name.is_empty() {
-                name
-            } else {
-                fm.name
-            };
+            let skill_name = if fm.name.is_empty() { name } else { fm.name };
 
             return Ok(SkillDefinition {
                 name: skill_name,
@@ -315,10 +309,7 @@ description: A skill without a name field
             parse_allowed_tools(Some("Bash(skwaq *), Read, Grep")),
             vec!["Bash(skwaq *)", "Read", "Grep"]
         );
-        assert_eq!(
-            parse_allowed_tools(Some("Bash")),
-            vec!["Bash"]
-        );
+        assert_eq!(parse_allowed_tools(Some("Bash")), vec!["Bash"]);
         assert!(parse_allowed_tools(None).is_empty());
         assert!(parse_allowed_tools(Some("")).is_empty());
     }

--- a/crates/core/src/skills/mod.rs
+++ b/crates/core/src/skills/mod.rs
@@ -129,11 +129,7 @@ pub async fn run_skill(
         let tool_names: Vec<String> = all_tools.iter().map(|t| t.name.clone()).collect();
         filter_tools(&all_tools, &tool_names)
     } else {
-        let tool_names: Vec<String> = skill
-            .allowed_tools
-            .iter()
-            .map(|t| t.to_string())
-            .collect();
+        let tool_names: Vec<String> = skill.allowed_tools.iter().map(|t| t.to_string()).collect();
         filter_tools(&all_tools, &tool_names)
     };
 
@@ -192,7 +188,10 @@ mod tests {
         let content = "Scan $ARGUMENTS\nFirst: $0\nSecond: $1";
         let args = vec!["foo.bin".to_string(), "bar.bin".to_string()];
         let result = substitute_skill_args(content, &args, Path::new("skills/test"));
-        assert_eq!(result, "Scan foo.bin bar.bin\nFirst: foo.bin\nSecond: bar.bin");
+        assert_eq!(
+            result,
+            "Scan foo.bin bar.bin\nFirst: foo.bin\nSecond: bar.bin"
+        );
     }
 
     #[test]

--- a/crates/core/src/source/parser.rs
+++ b/crates/core/src/source/parser.rs
@@ -79,8 +79,8 @@ pub fn detect_language(path: &Path) -> Option<&'static str> {
 
 /// List of recognized source file extensions.
 pub const SOURCE_EXTENSIONS: &[&str] = &[
-    "py", "pyw", "js", "mjs", "cjs", "ts", "tsx", "go", "rs", "java", "c", "h", "cpp", "cc",
-    "cxx", "hpp", "hh",
+    "py", "pyw", "js", "mjs", "cjs", "ts", "tsx", "go", "rs", "java", "c", "h", "cpp", "cc", "cxx",
+    "hpp", "hh",
 ];
 
 /// Return `true` when the path has a recognized source extension.
@@ -135,22 +135,24 @@ fn extract_functions(content: &str, language: &str) -> Vec<ExtractedFunction> {
         ],
         "javascript" | "typescript" => vec![
             Regex::new(r"(?m)\bfunction\s+(\w+)\s*\(").expect("compile-time regex"),
-            Regex::new(r"(?m)(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?\(").expect("compile-time regex"),
-            Regex::new(r"(?m)(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?function").expect("compile-time regex"),
+            Regex::new(r"(?m)(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?\(")
+                .expect("compile-time regex"),
+            Regex::new(r"(?m)(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?function")
+                .expect("compile-time regex"),
             Regex::new(r"(?m)^\s*(?:async\s+)?(\w+)\s*\([^)]*\)\s*\{").expect("compile-time regex"),
         ],
-        "go" => vec![
-            Regex::new(r"(?m)^func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(").expect("compile-time regex"),
-        ],
-        "rust" => vec![
-            Regex::new(r"(?m)(?:pub\s+)?(?:async\s+)?fn\s+(\w+)").expect("compile-time regex"),
-        ],
-        "java" => vec![
-            Regex::new(
-                r"(?m)(?:public|private|protected|static|\s)+[\w<>\[\]]+\s+(\w+)\s*\(",
-            )
-            .expect("compile-time regex"),
-        ],
+        "go" => {
+            vec![Regex::new(r"(?m)^func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(").expect("compile-time regex")]
+        }
+        "rust" => {
+            vec![Regex::new(r"(?m)(?:pub\s+)?(?:async\s+)?fn\s+(\w+)").expect("compile-time regex")]
+        }
+        "java" => {
+            vec![
+                Regex::new(r"(?m)(?:public|private|protected|static|\s)+[\w<>\[\]]+\s+(\w+)\s*\(")
+                    .expect("compile-time regex"),
+            ]
+        }
         "c" | "cpp" => vec![
             // Return type + name + paren – rough but effective for common patterns.
             Regex::new(r"(?m)^[\w*\s]+\s+(\w+)\s*\([^;]*\)\s*\{").expect("compile-time regex"),
@@ -166,7 +168,12 @@ fn extract_functions(content: &str, language: &str) -> Vec<ExtractedFunction> {
             let name = m.get(1).expect("compile-time regex").as_str().to_string();
             let byte_offset = m.get(0).expect("compile-time regex").start();
             let line = content[..byte_offset].matches('\n').count() + 1;
-            let sig = m.get(0).expect("compile-time regex").as_str().trim().to_string();
+            let sig = m
+                .get(0)
+                .expect("compile-time regex")
+                .as_str()
+                .trim()
+                .to_string();
 
             if seen.insert((name.clone(), line)) {
                 result.push(ExtractedFunction {
@@ -192,18 +199,104 @@ fn extract_calls(content: &str, language: &str) -> Vec<ExtractedCall> {
     let call_re = Regex::new(r"(?m)([\w.]+)\s*\(").expect("compile-time regex");
 
     let keywords: HashSet<&str> = match language {
-        "python" => ["def", "class", "if", "elif", "while", "for", "with", "async", "await", "return", "import", "from", "except", "assert"]
-            .iter().copied().collect(),
-        "javascript" | "typescript" => ["function", "if", "else", "while", "for", "switch", "case", "catch", "return", "typeof", "instanceof", "new", "class", "import", "from", "const", "let", "var"]
-            .iter().copied().collect(),
-        "go" => ["func", "if", "else", "for", "switch", "case", "select", "return", "go", "defer", "range", "type", "struct", "interface"]
-            .iter().copied().collect(),
-        "rust" => ["fn", "if", "else", "while", "for", "loop", "match", "return", "let", "mut", "pub", "mod", "use", "struct", "enum", "impl", "trait", "type", "where", "async", "await", "unsafe"]
-            .iter().copied().collect(),
-        "java" => ["if", "else", "while", "for", "switch", "case", "catch", "return", "class", "interface", "new", "import", "package", "throw", "throws", "instanceof"]
-            .iter().copied().collect(),
-        "c" | "cpp" => ["if", "else", "while", "for", "switch", "case", "return", "sizeof", "typeof", "struct", "union", "enum", "class", "template", "namespace"]
-            .iter().copied().collect(),
+        "python" => [
+            "def", "class", "if", "elif", "while", "for", "with", "async", "await", "return",
+            "import", "from", "except", "assert",
+        ]
+        .iter()
+        .copied()
+        .collect(),
+        "javascript" | "typescript" => [
+            "function",
+            "if",
+            "else",
+            "while",
+            "for",
+            "switch",
+            "case",
+            "catch",
+            "return",
+            "typeof",
+            "instanceof",
+            "new",
+            "class",
+            "import",
+            "from",
+            "const",
+            "let",
+            "var",
+        ]
+        .iter()
+        .copied()
+        .collect(),
+        "go" => [
+            "func",
+            "if",
+            "else",
+            "for",
+            "switch",
+            "case",
+            "select",
+            "return",
+            "go",
+            "defer",
+            "range",
+            "type",
+            "struct",
+            "interface",
+        ]
+        .iter()
+        .copied()
+        .collect(),
+        "rust" => [
+            "fn", "if", "else", "while", "for", "loop", "match", "return", "let", "mut", "pub",
+            "mod", "use", "struct", "enum", "impl", "trait", "type", "where", "async", "await",
+            "unsafe",
+        ]
+        .iter()
+        .copied()
+        .collect(),
+        "java" => [
+            "if",
+            "else",
+            "while",
+            "for",
+            "switch",
+            "case",
+            "catch",
+            "return",
+            "class",
+            "interface",
+            "new",
+            "import",
+            "package",
+            "throw",
+            "throws",
+            "instanceof",
+        ]
+        .iter()
+        .copied()
+        .collect(),
+        "c" | "cpp" => [
+            "if",
+            "else",
+            "while",
+            "for",
+            "switch",
+            "case",
+            "return",
+            "sizeof",
+            "typeof",
+            "struct",
+            "union",
+            "enum",
+            "class",
+            "template",
+            "namespace",
+        ]
+        .iter()
+        .copied()
+        .collect(),
         _ => HashSet::new(),
     };
 
@@ -218,7 +311,12 @@ fn extract_calls(content: &str, language: &str) -> Vec<ExtractedCall> {
         }
         let byte_offset = m.get(0).expect("compile-time regex").start();
         let line = content[..byte_offset].matches('\n').count() + 1;
-        let expression = m.get(0).expect("compile-time regex").as_str().trim().to_string();
+        let expression = m
+            .get(0)
+            .expect("compile-time regex")
+            .as_str()
+            .trim()
+            .to_string();
 
         result.push(ExtractedCall {
             name: full.to_string(),
@@ -241,7 +339,8 @@ fn extract_imports(content: &str, language: &str) -> Vec<String> {
             Regex::new(r"(?m)^\s*from\s+([\w.]+)\s+import").expect("compile-time regex"),
         ],
         "javascript" | "typescript" => vec![
-            Regex::new(r#"(?m)(?:import|require)\s*\(?['"]([^'"]+)['"]\)?"#).expect("compile-time regex"),
+            Regex::new(r#"(?m)(?:import|require)\s*\(?['"]([^'"]+)['"]\)?"#)
+                .expect("compile-time regex"),
             Regex::new(r#"(?m)import\s+.*\s+from\s+['"]([^'"]+)['"]"#).expect("compile-time regex"),
         ],
         "go" => vec![
@@ -252,12 +351,11 @@ fn extract_imports(content: &str, language: &str) -> Vec<String> {
             Regex::new(r"(?m)^\s*use\s+([\w:]+)").expect("compile-time regex"),
             Regex::new(r"(?m)^\s*extern\s+crate\s+(\w+)").expect("compile-time regex"),
         ],
-        "java" => vec![
-            Regex::new(r"(?m)^\s*import\s+([\w.]+);").expect("compile-time regex"),
-        ],
-        "c" | "cpp" => vec![
-            Regex::new(r#"(?m)^\s*#\s*include\s+[<"]([^>"]+)[>"]"#).expect("compile-time regex"),
-        ],
+        "java" => vec![Regex::new(r"(?m)^\s*import\s+([\w.]+);").expect("compile-time regex")],
+        "c" | "cpp" => {
+            vec![Regex::new(r#"(?m)^\s*#\s*include\s+[<"]([^>"]+)[>"]"#)
+                .expect("compile-time regex")]
+        }
         _ => vec![],
     };
 
@@ -284,7 +382,8 @@ fn extract_strings(content: &str) -> Vec<ExtractedString> {
     // Matches double-quoted and single-quoted strings (non-greedy).
     // Does not handle multi-line strings or escaped quotes perfectly,
     // but catches the common cases.
-    let re = Regex::new(r#"(?m)("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')"#).expect("compile-time regex");
+    let re =
+        Regex::new(r#"(?m)("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')"#).expect("compile-time regex");
 
     let mut result = Vec::new();
     for m in re.captures_iter(content) {


### PR DESCRIPTION
## Summary
Fixes #9

- .pre-commit-config.yaml with cargo fmt + clippy on pre-commit, tests on pre-push
- Fixed all clippy warnings across 15 files
- Formatted all 57 source files with cargo fmt
- Pre-commit hooks installed and verified

## Step 13: Local Testing Results
1. Simple: `pre-commit run --all-files` -> all hooks pass
2. Complex: `cargo test` -> 143 tests pass after clippy fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)