### PR TITLE
fix: switch default model to gpt-4o (#12)

### DIFF
--- a/agents/attack-surface.md
+++ b/agents/attack-surface.md
@@ -1,7 +1,7 @@
 ---
 name: attack-surface
 description: Attack surface mapper
-model: openai/gpt-4o-mini
+model: openai/gpt-4o
 tools:
   - query_graph
   - read_function

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -1,7 +1,7 @@
 ---
 name: critic
 description: Finding validation and false positive reduction
-model: openai/gpt-4o-mini
+model: openai/gpt-4o
 tools:
   - query_graph
   - read_function

--- a/agents/decompile-analyst.md
+++ b/agents/decompile-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: decompile-analyst
 description: Decompiled code analysis specialist
-model: openai/gpt-4o-mini
+model: openai/gpt-4o
 tools:
   - query_graph
   - read_function

--- a/agents/taint-tracer.md
+++ b/agents/taint-tracer.md
@@ -1,7 +1,7 @@
 ---
 name: taint-tracer
 description: Data flow analysis specialist
-model: openai/gpt-4o-mini
+model: openai/gpt-4o
 tools:
   - query_graph
   - read_function

--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: vuln-hunter
 description: Primary vulnerability discovery agent
-model: openai/gpt-4o-mini
+model: openai/gpt-4o
 tools:
   - query_graph
   - read_function

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -105,7 +105,7 @@ fn default_ollama() -> String {
     "ollama".into()
 }
 fn default_model() -> String {
-    "openai/gpt-4o-mini".into()
+    "openai/gpt-4o".into()
 }
 fn default_ollama_host() -> String {
     "http://localhost:11434".into()


### PR DESCRIPTION
Fixes #12. gpt-4o-mini has an 8000 token request limit on GitHub Models API which is too small for tool-calling agents (system prompt + tool definitions + context exceeds it). gpt-4o has 128k context. All 143 tests pass.