### PR TITLE
fix: use create_llm_client() instead of hardcoded CopilotClient (#18)

### DIFF
--- a/crates/cli/src/commands/analyze.rs
+++ b/crates/cli/src/commands/analyze.rs
@@ -85,7 +85,7 @@ async fn run_ai_analysis(
 
     // Create the LLM client
     let llm_client: std::sync::Arc<dyn skwaq_core::llm::LlmClient> =
-        std::sync::Arc::new(skwaq_core::llm::CopilotClient::new());
+        skwaq_core::llm::create_llm_client(&config.llm);
 
     let mut token_budget = skwaq_core::llm::TokenBudget::new(budget_amount);
 

--- a/crates/cli/src/commands/skills_cmd.rs
+++ b/crates/cli/src/commands/skills_cmd.rs
@@ -78,7 +78,7 @@ pub async fn run_run(name: &str, args: Vec<String>) -> anyhow::Result<()> {
     println!();
 
     let llm_client: Arc<dyn skwaq_core::llm::LlmClient> =
-        Arc::new(skwaq_core::llm::CopilotClient::new());
+        skwaq_core::llm::create_llm_client(&config.llm);
 
     let result = run_skill(
         &skill,

--- a/crates/core/src/llm/mod.rs
+++ b/crates/core/src/llm/mod.rs
@@ -11,6 +11,7 @@ pub use copilot_client::CopilotClient;
 pub use traits::*;
 
 use crate::config::LlmConfig;
+use std::sync::Arc;
 
 /// Create an LLM client from configuration.
 ///
@@ -21,17 +22,17 @@ use crate::config::LlmConfig;
 ///
 /// Auto-detection: if no explicit backend is configured and `ANTHROPIC_API_KEY`
 /// is set, the Anthropic backend is preferred.
-pub fn create_llm_client(config: &LlmConfig) -> Box<dyn LlmClient> {
+pub fn create_llm_client(config: &LlmConfig) -> Arc<dyn LlmClient> {
     match config.reasoning.as_str() {
         "anthropic" => match anthropic::AnthropicClient::new() {
-            Ok(client) => Box::new(client),
+            Ok(client) => Arc::new(client),
             Err(e) => {
                 tracing::warn!("Anthropic client init failed ({e}), falling back to copilot");
-                Box::new(CopilotClient::new())
+                Arc::new(CopilotClient::new())
             }
         },
-        "ollama" => Box::new(ollama::OllamaClient::new(&config.ollama.host)),
-        "copilot" => Box::new(CopilotClient::new()),
+        "ollama" => Arc::new(ollama::OllamaClient::new(&config.ollama.host)),
+        "copilot" => Arc::new(CopilotClient::new()),
         other => {
             // Auto-detect: try Anthropic if ANTHROPIC_API_KEY is set
             if std::env::var("ANTHROPIC_API_KEY").is_ok() {
@@ -39,12 +40,12 @@ pub fn create_llm_client(config: &LlmConfig) -> Box<dyn LlmClient> {
                     "Unknown backend '{other}', but ANTHROPIC_API_KEY set; using Anthropic"
                 );
                 match anthropic::AnthropicClient::new() {
-                    Ok(client) => Box::new(client),
-                    Err(_) => Box::new(CopilotClient::new()),
+                    Ok(client) => Arc::new(client),
+                    Err(_) => Arc::new(CopilotClient::new()),
                 }
             } else {
                 tracing::info!("Unknown backend '{other}', falling back to copilot");
-                Box::new(CopilotClient::new())
+                Arc::new(CopilotClient::new())
             }
         }
     }


### PR DESCRIPTION
Fixes #18. Verified: Claude Opus now used for analysis. Attack surface agent produced comprehensive analysis with ASCII diagrams and OWASP classifications.

## Step 13: Local Testing
1. cargo test -> 155 passed
2. skwaq analyze on vuln_app.py -> Model: claude-opus-4-6, 4 critical findings, detailed attack surface map

🤖 Generated with [Claude Code](https://claude.com/claude-code)