### PR TITLE
feat: add Skwaq Gym benchmark harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,10 +265,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "camino"
@@ -439,6 +473,19 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
@@ -455,6 +502,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -492,6 +545,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +574,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -609,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,12 +713,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console",
+ "console 0.16.2",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -858,6 +953,17 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1497,6 +1603,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,7 +1779,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1760,6 +1882,27 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "mac"
@@ -1992,6 +2135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "octocrab"
 version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,9 +2298,19 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -2540,10 +2699,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -3107,6 +3295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,6 +3393,7 @@ dependencies = [
  "serde",
  "serde_json",
  "skwaq-core",
+ "skwaq-gym",
  "tempfile",
  "tokio",
  "tracing",
@@ -3224,6 +3424,34 @@ dependencies = [
  "toml",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "skwaq-gym"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "dirs",
+ "flate2",
+ "indicatif",
+ "rayon",
+ "reqwest 0.12.28",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "skwaq-core",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "uuid",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -3396,6 +3624,17 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -4204,6 +4443,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4436,6 +4684,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xml5ever"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,6 +4702,15 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]
@@ -4564,7 +4831,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/core", "crates/cli"]
+members = ["crates/core", "crates/cli", "crates/gym"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 skwaq-core = { path = "../core" }
+skwaq-gym = { path = "../gym" }
 rustyclawd-tools = { workspace = true }
 tokio = { workspace = true }
 clap = { workspace = true }

--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -1,0 +1,129 @@
+//! CLI dispatch for `skwaq gym *` subcommands.
+
+use clap::Subcommand;
+use std::path::PathBuf;
+
+#[derive(Subcommand)]
+pub enum GymSub {
+    /// Download and prepare all benchmark data
+    Setup,
+
+    /// Run benchmarks
+    Run {
+        /// Suite name (fixtures). Omit for all.
+        suite: Option<String>,
+
+        /// Filter to specific CWE (e.g., CWE-119)
+        #[arg(long)]
+        cwe: Option<String>,
+
+        /// Maximum test cases per suite (for quick validation)
+        #[arg(long)]
+        max_cases: Option<usize>,
+
+        /// Use full analysis (default is quick mode)
+        #[arg(long)]
+        full: bool,
+
+        /// Output JSON report to file
+        #[arg(long)]
+        json: Option<PathBuf>,
+
+        /// Output Markdown report to file
+        #[arg(long)]
+        markdown: Option<PathBuf>,
+    },
+
+    /// Show latest benchmark results
+    Report {
+        /// Output format (terminal, json, markdown)
+        #[arg(long, default_value = "terminal")]
+        format: String,
+    },
+
+    /// Compare last two runs
+    Compare,
+
+    /// Show benchmark history
+    History {
+        /// Number of runs to show
+        #[arg(long, default_value = "10")]
+        limit: u32,
+    },
+}
+
+pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
+    let skwaq_root = find_skwaq_root()?;
+    let mut gym = skwaq_gym::Gym::new(skwaq_root)?;
+
+    match sub {
+        GymSub::Setup => {
+            gym.setup().await?;
+            println!("All benchmarks set up.");
+        }
+        GymSub::Run {
+            suite,
+            cwe,
+            max_cases,
+            full,
+            json,
+            markdown,
+        } => {
+            let cwe_filter = cwe.as_ref().map(|c| {
+                let num: u32 = c
+                    .trim_start_matches("CWE-")
+                    .trim_start_matches("cwe-")
+                    .parse()
+                    .expect("Invalid CWE number");
+                vec![num]
+            });
+            gym.run(suite.as_deref(), cwe_filter, *max_cases, *full)
+                .await?;
+
+            if let Some(path) = json {
+                let report = gym.report(skwaq_gym::ReportFormat::Json)?;
+                std::fs::write(path, report)?;
+            }
+            if let Some(path) = markdown {
+                let report = gym.report(skwaq_gym::ReportFormat::Markdown)?;
+                std::fs::write(path, report)?;
+            }
+        }
+        GymSub::Report { format } => {
+            let fmt = match format.as_str() {
+                "json" => skwaq_gym::ReportFormat::Json,
+                "markdown" | "md" => skwaq_gym::ReportFormat::Markdown,
+                _ => skwaq_gym::ReportFormat::Terminal,
+            };
+            let output = gym.report(fmt)?;
+            if !output.is_empty() {
+                println!("{}", output);
+            }
+        }
+        GymSub::Compare => {
+            gym.compare()?;
+        }
+        GymSub::History { limit } => {
+            gym.history(*limit)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Find the workspace root by looking for Cargo.toml with [workspace].
+fn find_skwaq_root() -> anyhow::Result<PathBuf> {
+    let mut dir = std::env::current_dir()?;
+    loop {
+        let cargo_toml = dir.join("Cargo.toml");
+        if cargo_toml.exists() {
+            let content = std::fs::read_to_string(&cargo_toml)?;
+            if content.contains("[workspace]") {
+                return Ok(dir);
+            }
+        }
+        if !dir.pop() {
+            anyhow::bail!("Could not find skwaq workspace root (Cargo.toml with [workspace])");
+        }
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod checksec_cmd;
 pub mod common;
 pub mod config_cmd;
 pub mod doctor;
+pub mod gym_cmd;
 pub mod hypothesize_cmd;
 pub mod ingest;
 pub mod investigate;
@@ -204,6 +205,12 @@ pub enum Commands {
     Skills {
         #[command(subcommand)]
         sub: SkillsSub,
+    },
+
+    /// Benchmark and self-improvement harness
+    Gym {
+        #[command(subcommand)]
+        sub: gym_cmd::GymSub,
     },
 
     /// Check system dependencies and connectivity

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -23,6 +23,9 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     match &cli.command {
+        Commands::Gym { sub } => {
+            skwaq::commands::gym_cmd::run(sub).await?;
+        }
         Commands::Version => {
             skwaq::commands::version_cmd::run();
         }

--- a/crates/gym/Cargo.toml
+++ b/crates/gym/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "skwaq-gym"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+skwaq-core = { path = "../core" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+reqwest = { workspace = true }
+rusqlite = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
+dirs = { workspace = true }
+async-trait = { workspace = true }
+flate2 = "1"
+tar = "0.4"
+zip = "2"
+walkdir = "2"
+rayon = "1"
+indicatif = "0.17"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }

--- a/crates/gym/src/adapters/fixtures.rs
+++ b/crates/gym/src/adapters/fixtures.rs
@@ -1,0 +1,74 @@
+//! Adapter for skwaq's own test fixtures as a mini benchmark.
+
+use super::*;
+use crate::ground_truth::GroundTruth;
+use std::path::{Path, PathBuf};
+
+/// Uses skwaq's own test fixtures (tests/fixtures/) as a mini benchmark.
+pub struct FixturesAdapter {
+    manifest_path: PathBuf,
+    fixtures_dir: PathBuf,
+}
+
+impl FixturesAdapter {
+    pub fn new(manifest_path: PathBuf, fixtures_dir: PathBuf) -> Self {
+        Self {
+            manifest_path,
+            fixtures_dir,
+        }
+    }
+}
+
+#[async_trait]
+impl BenchmarkAdapter for FixturesAdapter {
+    fn name(&self) -> &str {
+        "fixtures"
+    }
+
+    fn ground_truth(&self) -> anyhow::Result<GroundTruth> {
+        GroundTruth::load(&self.manifest_path)
+    }
+
+    async fn setup(&self, _config: &BenchmarkConfig) -> anyhow::Result<PathBuf> {
+        // Fixtures are already in the repo.
+        Ok(self.fixtures_dir.clone())
+    }
+
+    fn is_ready(&self, _config: &BenchmarkConfig) -> bool {
+        self.fixtures_dir.exists()
+    }
+
+    async fn compile(&self, data_dir: &Path, _config: &BenchmarkConfig) -> anyhow::Result<()> {
+        // Compile C fixtures if a Makefile exists.
+        let makefile = data_dir.join("Makefile");
+        if makefile.exists() {
+            let status = std::process::Command::new("make")
+                .arg("-C")
+                .arg(data_dir)
+                .arg("-j4")
+                .stderr(std::process::Stdio::piped())
+                .status()?;
+            if !status.success() {
+                tracing::warn!("Fixture compilation had errors (some may be expected)");
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_case(
+        &self,
+        case: &TestCase,
+        data_dir: &Path,
+        _config: &BenchmarkConfig,
+    ) -> anyhow::Result<Vec<DetectedFinding>> {
+        let path = data_dir.join(&case.path);
+        run_source_pattern_detection(&path)
+    }
+
+    fn map_finding_to_cwes(&self, finding: &DetectedFinding) -> Vec<u32> {
+        if !finding.cwes.is_empty() {
+            return finding.cwes.clone();
+        }
+        crate::scoring::category_to_cwes(&finding.category)
+    }
+}

--- a/crates/gym/src/adapters/mod.rs
+++ b/crates/gym/src/adapters/mod.rs
@@ -1,0 +1,118 @@
+//! Benchmark adapter trait and implementations.
+
+pub mod fixtures;
+
+use crate::ground_truth::{GroundTruth, TestCase};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+
+/// Configuration for running a benchmark.
+#[derive(Debug, Clone)]
+pub struct BenchmarkConfig {
+    /// Root directory where benchmark data is cached.
+    pub cache_dir: PathBuf,
+    /// Optional CWE filter: only run test cases matching these CWEs.
+    pub cwe_filter: Option<Vec<u32>>,
+    /// Maximum test cases to run (for quick validation). None = all.
+    pub max_cases: Option<usize>,
+    /// Whether to use skwaq's quick mode or full analysis.
+    pub quick_mode: bool,
+    /// Number of parallel compilation/analysis jobs.
+    pub parallelism: usize,
+    /// Per-case timeout in seconds.
+    pub timeout_secs: u64,
+}
+
+/// Every benchmark suite implements this trait.
+#[async_trait]
+pub trait BenchmarkAdapter: Send + Sync {
+    /// Human-readable name of this suite.
+    fn name(&self) -> &str;
+
+    /// Load the ground truth manifest for this suite.
+    fn ground_truth(&self) -> anyhow::Result<GroundTruth>;
+
+    /// Download and prepare benchmark data. Idempotent.
+    async fn setup(&self, config: &BenchmarkConfig) -> anyhow::Result<PathBuf>;
+
+    /// Check if benchmark data is already set up.
+    fn is_ready(&self, config: &BenchmarkConfig) -> bool;
+
+    /// Compile test cases if needed. No-op for pre-built suites.
+    async fn compile(&self, data_dir: &Path, config: &BenchmarkConfig) -> anyhow::Result<()>;
+
+    /// Run skwaq against a single test case and return raw findings.
+    async fn run_case(
+        &self,
+        case: &TestCase,
+        data_dir: &Path,
+        config: &BenchmarkConfig,
+    ) -> anyhow::Result<Vec<DetectedFinding>>;
+
+    /// Map a raw skwaq finding to CWE numbers.
+    fn map_finding_to_cwes(&self, finding: &DetectedFinding) -> Vec<u32>;
+}
+
+/// A finding detected by skwaq during a benchmark run.
+#[derive(Debug, Clone)]
+pub struct DetectedFinding {
+    /// Skwaq finding ID.
+    pub id: String,
+    /// Finding category from skwaq.
+    pub category: String,
+    /// Severity from skwaq.
+    pub severity: String,
+    /// CWE IDs that skwaq associated with this finding.
+    pub cwes: Vec<u32>,
+    /// File where found.
+    pub file: String,
+    /// Function where found.
+    pub function: String,
+    /// Line number if available.
+    pub line: Option<u32>,
+    /// Short description.
+    pub title: String,
+}
+
+/// Run skwaq's source analysis on a file and collect findings.
+/// Uses DangerousApiDetector::detect_in_source_content() (the correct API).
+pub fn run_source_pattern_detection(path: &Path) -> anyhow::Result<Vec<DetectedFinding>> {
+    use skwaq_core::analysis::patterns_binary::DangerousApiDetector;
+
+    let content = std::fs::read_to_string(path)?;
+    let file_str = path.to_string_lossy().to_string();
+
+    // Detect language from extension.
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("c");
+    let language = match ext {
+        "c" | "h" => "c",
+        "cpp" | "cxx" | "cc" | "hpp" => "cpp",
+        "py" => "python",
+        "js" | "ts" => "javascript",
+        "java" => "java",
+        _ => ext,
+    };
+
+    let detector = DangerousApiDetector::new();
+    let hits = detector.detect_in_source_content(&content, language, &file_str)?;
+
+    let findings = hits
+        .into_iter()
+        .map(|hit| DetectedFinding {
+            id: uuid::Uuid::new_v4().to_string(),
+            category: hit.danger_category.to_string(),
+            severity: hit.severity.to_string(),
+            cwes: vec![],
+            file: file_str.clone(),
+            function: hit.function_name.clone(),
+            line: if hit.line > 0 {
+                Some(hit.line as u32)
+            } else {
+                None
+            },
+            title: format!("Dangerous API: {}", hit.function_name),
+        })
+        .collect();
+
+    Ok(findings)
+}

--- a/crates/gym/src/download.rs
+++ b/crates/gym/src/download.rs
@@ -1,0 +1,109 @@
+//! Benchmark data download, integrity verification, and extraction.
+
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+/// Download a file, verify its SHA-256, and extract it.
+/// SHA-256 verification is mandatory -- empty checksums are rejected.
+pub async fn download_and_extract(
+    url: &str,
+    expected_sha256: &str,
+    dest: &Path,
+) -> anyhow::Result<()> {
+    // Mandatory SHA-256 (review finding #1).
+    if expected_sha256.is_empty() {
+        anyhow::bail!(
+            "SHA-256 checksum is required for download: {}. \
+             Add the hash to the ground truth manifest.",
+            url
+        );
+    }
+
+    std::fs::create_dir_all(dest)?;
+
+    let tmp = tempfile::NamedTempFile::new()?;
+    let tmp_path = tmp.path().to_path_buf();
+
+    tracing::info!("Downloading {}...", url);
+    let response = reqwest::get(url).await?;
+    let bytes = response.bytes().await?;
+    std::fs::write(&tmp_path, &bytes)?;
+
+    // Verify SHA-256.
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let hash = format!("{:x}", hasher.finalize());
+    if hash != expected_sha256 {
+        anyhow::bail!(
+            "SHA-256 mismatch for {}:\n  expected: {}\n  got:      {}",
+            url,
+            expected_sha256,
+            hash
+        );
+    }
+
+    // Extract based on extension, with safe path validation.
+    if url.ends_with(".zip") {
+        extract_zip(&tmp_path, dest)?;
+    } else if url.ends_with(".tar.gz") || url.ends_with(".tgz") {
+        extract_tar_gz(&tmp_path, dest)?;
+    } else {
+        let filename = url.rsplit('/').next().unwrap_or("data");
+        std::fs::copy(&tmp_path, dest.join(filename))?;
+    }
+
+    Ok(())
+}
+
+fn extract_zip(archive: &Path, dest: &Path) -> anyhow::Result<()> {
+    let file = std::fs::File::open(archive)?;
+    let mut zip = zip::ZipArchive::new(file)?;
+
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i)?;
+        let name = entry.name().to_string();
+
+        // Safe extraction: reject paths with .. or absolute paths (review finding #7).
+        if name.contains("..") || Path::new(&name).is_absolute() {
+            anyhow::bail!(
+                "Unsafe path in zip archive: '{}'. Rejecting extraction.",
+                name
+            );
+        }
+
+        let out_path = dest.join(&name);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)?;
+        } else {
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let mut outfile = std::fs::File::create(&out_path)?;
+            std::io::copy(&mut entry, &mut outfile)?;
+        }
+    }
+    Ok(())
+}
+
+fn extract_tar_gz(archive: &Path, dest: &Path) -> anyhow::Result<()> {
+    let file = std::fs::File::open(archive)?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut tar = tar::Archive::new(gz);
+
+    for entry in tar.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        let path_str = path.to_string_lossy();
+
+        // Safe extraction: reject paths with .. or absolute paths (review finding #7).
+        if path_str.contains("..") || path.is_absolute() {
+            anyhow::bail!(
+                "Unsafe path in tar archive: '{}'. Rejecting extraction.",
+                path_str
+            );
+        }
+
+        entry.unpack_in(dest)?;
+    }
+    Ok(())
+}

--- a/crates/gym/src/ground_truth.rs
+++ b/crates/gym/src/ground_truth.rs
@@ -1,0 +1,127 @@
+//! Ground truth data model and TOML manifest loader.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// A single test case with its expected vulnerabilities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestCase {
+    /// Unique identifier within the suite.
+    pub id: String,
+    /// Relative path to the test file/binary within the benchmark data directory.
+    pub path: String,
+    /// CWE IDs that SHOULD be detected in this test case.
+    pub expected_cwes: Vec<u32>,
+    /// Whether this is a "good" (patched) variant that should have NO findings.
+    pub is_negative: bool,
+    /// Language of the test case (c, cpp, java, python, etc.).
+    pub language: String,
+}
+
+/// Ground truth for an entire benchmark suite.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroundTruth {
+    /// Suite name (juliet, cgc, cyberseceval, fixtures).
+    pub suite: String,
+    /// Version or commit hash of the benchmark data.
+    pub version: String,
+    /// URL to download the benchmark data (empty for fixtures).
+    #[serde(default)]
+    pub download_url: String,
+    /// SHA-256 of the download archive for integrity verification.
+    #[serde(default)]
+    pub download_sha256: String,
+    /// All test cases in this suite.
+    pub cases: Vec<TestCase>,
+}
+
+impl GroundTruth {
+    /// Load from a TOML manifest file.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let text = std::fs::read_to_string(path)?;
+        let gt: Self = toml::from_str(&text)?;
+
+        // Validate: reject paths with .. or absolute paths.
+        for case in &gt.cases {
+            if case.path.contains("..") || Path::new(&case.path).is_absolute() {
+                anyhow::bail!(
+                    "Invalid path in manifest case '{}': {}. Paths must be relative without '..'",
+                    case.id,
+                    case.path
+                );
+            }
+            // Restrict case IDs to safe characters.
+            if !case
+                .id
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
+            {
+                anyhow::bail!(
+                    "Invalid case ID '{}': must be alphanumeric, underscore, hyphen, or dot",
+                    case.id
+                );
+            }
+        }
+
+        Ok(gt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_manifest() {
+        let toml = r#"
+suite = "test"
+version = "1.0"
+download_url = ""
+download_sha256 = ""
+
+[[cases]]
+id = "test_case_1"
+path = "src/test.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "test_case_1_good"
+path = "src/test_good.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+"#;
+        let gt: GroundTruth = toml::from_str(toml).unwrap();
+        assert_eq!(gt.suite, "test");
+        assert_eq!(gt.cases.len(), 2);
+        assert_eq!(gt.cases[0].expected_cwes, vec![121]);
+        assert!(gt.cases[1].is_negative);
+    }
+
+    #[test]
+    fn test_reject_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("bad.toml");
+        std::fs::write(
+            &manifest,
+            r#"
+suite = "bad"
+version = "1.0"
+
+[[cases]]
+id = "evil"
+path = "../../etc/passwd"
+expected_cwes = [22]
+is_negative = false
+language = "c"
+"#,
+        )
+        .unwrap();
+
+        let result = GroundTruth::load(&manifest);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(".."));
+    }
+}

--- a/crates/gym/src/history.rs
+++ b/crates/gym/src/history.rs
@@ -1,0 +1,311 @@
+//! Run history storage (SQLite-backed) and comparison.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// A single benchmark run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkRun {
+    pub id: String,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub suite: String,
+    pub skwaq_commit: String,
+    pub precision: f64,
+    pub recall: f64,
+    pub f1: f64,
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub true_negatives: u32,
+}
+
+/// Per-CWE result within a run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CweResult {
+    pub run_id: String,
+    pub cwe_id: u32,
+    pub total_cases: u32,
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub detection_rate: f64,
+    pub precision: f64,
+}
+
+/// Per-test-case result within a run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaseResult {
+    pub run_id: String,
+    pub suite: String,
+    pub case_id: String,
+    pub expected_cwes: Vec<u32>,
+    pub detected_cwes: Vec<u32>,
+    pub matched_finding_ids: Vec<String>,
+    pub unmatched_finding_ids: Vec<String>,
+    pub classification: String,
+}
+
+/// SQLite-backed history database.
+pub struct HistoryDb {
+    conn: rusqlite::Connection,
+}
+
+impl HistoryDb {
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(path.parent().unwrap_or(Path::new(".")))?;
+        let conn = rusqlite::Connection::open(path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+
+        // Set file permissions to 0o600 on Unix.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(metadata) = std::fs::metadata(path) {
+                let mut perms = metadata.permissions();
+                perms.set_mode(0o600);
+                let _ = std::fs::set_permissions(path, perms);
+            }
+        }
+
+        let db = Self { conn };
+        db.ensure_schema()?;
+        Ok(db)
+    }
+
+    pub fn in_memory() -> anyhow::Result<Self> {
+        let conn = rusqlite::Connection::open_in_memory()?;
+        let db = Self { conn };
+        db.ensure_schema()?;
+        Ok(db)
+    }
+
+    fn ensure_schema(&self) -> anyhow::Result<()> {
+        self.conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS runs (
+                id TEXT PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                finished_at TEXT,
+                suite TEXT NOT NULL,
+                skwaq_commit TEXT NOT NULL,
+                precision REAL DEFAULT 0.0,
+                recall REAL DEFAULT 0.0,
+                f1 REAL DEFAULT 0.0,
+                true_positives INTEGER DEFAULT 0,
+                false_positives INTEGER DEFAULT 0,
+                false_negatives INTEGER DEFAULT 0,
+                true_negatives INTEGER DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS cwe_results (
+                run_id TEXT NOT NULL REFERENCES runs(id),
+                cwe_id INTEGER NOT NULL,
+                total_cases INTEGER NOT NULL,
+                true_positives INTEGER DEFAULT 0,
+                false_positives INTEGER DEFAULT 0,
+                false_negatives INTEGER DEFAULT 0,
+                detection_rate REAL DEFAULT 0.0,
+                precision REAL DEFAULT 0.0,
+                PRIMARY KEY (run_id, cwe_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS case_results (
+                run_id TEXT NOT NULL REFERENCES runs(id),
+                suite TEXT NOT NULL,
+                case_id TEXT NOT NULL,
+                expected_cwes TEXT NOT NULL,
+                detected_cwes TEXT NOT NULL,
+                matched_finding_ids TEXT NOT NULL,
+                unmatched_finding_ids TEXT NOT NULL,
+                classification TEXT NOT NULL,
+                PRIMARY KEY (run_id, suite, case_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_cwe_results_cwe ON cwe_results(cwe_id);
+            CREATE INDEX IF NOT EXISTS idx_case_results_suite ON case_results(suite);
+            CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at);
+            ",
+        )?;
+        Ok(())
+    }
+
+    /// Insert a new run record. Returns the run ID.
+    pub fn start_run(&self, suite: &str, skwaq_commit: &str) -> anyhow::Result<String> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO runs (id, started_at, suite, skwaq_commit) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![id, now, suite, skwaq_commit],
+        )?;
+        Ok(id)
+    }
+
+    /// Finish a run with aggregate scores.
+    pub fn finish_run(&self, run: &BenchmarkRun) -> anyhow::Result<()> {
+        let finished = chrono::Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE runs SET finished_at=?1, precision=?2, recall=?3, f1=?4,
+             true_positives=?5, false_positives=?6, false_negatives=?7, true_negatives=?8
+             WHERE id=?9",
+            rusqlite::params![
+                finished,
+                run.precision,
+                run.recall,
+                run.f1,
+                run.true_positives,
+                run.false_positives,
+                run.false_negatives,
+                run.true_negatives,
+                run.id
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Insert per-CWE results.
+    pub fn insert_cwe_result(&self, result: &CweResult) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO cwe_results (run_id, cwe_id, total_cases, true_positives,
+             false_positives, false_negatives, detection_rate, precision)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                result.run_id,
+                result.cwe_id,
+                result.total_cases,
+                result.true_positives,
+                result.false_positives,
+                result.false_negatives,
+                result.detection_rate,
+                result.precision
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Insert per-case result.
+    pub fn insert_case_result(&self, result: &CaseResult) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO case_results (run_id, suite, case_id, expected_cwes,
+             detected_cwes, matched_finding_ids, unmatched_finding_ids, classification)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                result.run_id,
+                result.suite,
+                result.case_id,
+                serde_json::to_string(&result.expected_cwes)?,
+                serde_json::to_string(&result.detected_cwes)?,
+                serde_json::to_string(&result.matched_finding_ids)?,
+                serde_json::to_string(&result.unmatched_finding_ids)?,
+                result.classification
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Load the N most recent runs.
+    pub fn recent_runs(&self, limit: u32) -> anyhow::Result<Vec<BenchmarkRun>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, started_at, finished_at, suite, skwaq_commit,
+                    precision, recall, f1, true_positives, false_positives,
+                    false_negatives, true_negatives
+             FROM runs ORDER BY started_at DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![limit], |row| {
+            Ok(BenchmarkRun {
+                id: row.get(0)?,
+                started_at: row.get::<_, String>(1)?.parse().unwrap_or_default(),
+                finished_at: row
+                    .get::<_, Option<String>>(2)?
+                    .and_then(|s| s.parse().ok()),
+                suite: row.get(3)?,
+                skwaq_commit: row.get(4)?,
+                precision: row.get(5)?,
+                recall: row.get(6)?,
+                f1: row.get(7)?,
+                true_positives: row.get(8)?,
+                false_positives: row.get(9)?,
+                false_negatives: row.get(10)?,
+                true_negatives: row.get(11)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Load per-CWE results for a run.
+    pub fn cwe_results_for_run(&self, run_id: &str) -> anyhow::Result<Vec<CweResult>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT run_id, cwe_id, total_cases, true_positives, false_positives,
+                    false_negatives, detection_rate, precision
+             FROM cwe_results WHERE run_id = ?1 ORDER BY cwe_id",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![run_id], |row| {
+            Ok(CweResult {
+                run_id: row.get(0)?,
+                cwe_id: row.get(1)?,
+                total_cases: row.get(2)?,
+                true_positives: row.get(3)?,
+                false_positives: row.get(4)?,
+                false_negatives: row.get(5)?,
+                detection_rate: row.get(6)?,
+                precision: row.get(7)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_history_db_lifecycle() {
+        let db = HistoryDb::in_memory().unwrap();
+
+        // Start a run.
+        let run_id = db.start_run("fixtures", "abc123").unwrap();
+
+        // Finish it.
+        let run = BenchmarkRun {
+            id: run_id.clone(),
+            started_at: Utc::now(),
+            finished_at: Some(Utc::now()),
+            suite: "fixtures".to_string(),
+            skwaq_commit: "abc123".to_string(),
+            precision: 0.8,
+            recall: 0.6,
+            f1: 0.686,
+            true_positives: 3,
+            false_positives: 1,
+            false_negatives: 2,
+            true_negatives: 1,
+        };
+        db.finish_run(&run).unwrap();
+
+        // Insert CWE result.
+        db.insert_cwe_result(&CweResult {
+            run_id: run_id.clone(),
+            cwe_id: 119,
+            total_cases: 5,
+            true_positives: 3,
+            false_positives: 0,
+            false_negatives: 2,
+            detection_rate: 0.6,
+            precision: 1.0,
+        })
+        .unwrap();
+
+        // Query recent runs.
+        let runs = db.recent_runs(10).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].suite, "fixtures");
+        assert!((runs[0].precision - 0.8).abs() < 0.001);
+
+        // Query CWE results.
+        let cwes = db.cwe_results_for_run(&run_id).unwrap();
+        assert_eq!(cwes.len(), 1);
+        assert_eq!(cwes[0].cwe_id, 119);
+    }
+}

--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -1,0 +1,55 @@
+//! Self-improvement loop: analyze failures, propose changes, validate.
+//!
+//! The improvement loop requires human approval before applying changes
+//! (review finding #2). Proposals are written to a staging directory
+//! for review rather than applied directly.
+
+use crate::scoring::AggregateScore;
+use std::path::PathBuf;
+
+/// A proposed improvement to skwaq.
+#[derive(Debug, Clone)]
+pub struct Improvement {
+    pub kind: ImprovementKind,
+    pub description: String,
+    pub target_cwes: Vec<u32>,
+    pub target_file: PathBuf,
+    pub patch: Patch,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImprovementKind {
+    NewPattern,
+    AgentPrompt,
+    CweMapping,
+    TaintRule,
+}
+
+#[derive(Debug, Clone)]
+pub struct Patch {
+    pub find: String,
+    pub replace: String,
+}
+
+/// Result of an improvement attempt.
+#[derive(Debug)]
+pub struct ImprovementResult {
+    pub improvement: Improvement,
+    pub baseline_score: AggregateScore,
+    pub new_score: AggregateScore,
+    pub accepted: bool,
+    pub reason: String,
+}
+
+/// Check if any CWE's detection rate dropped.
+pub fn has_cwe_regression(baseline: &AggregateScore, new: &AggregateScore) -> bool {
+    for (cwe_id, baseline_cwe) in &baseline.per_cwe {
+        if let Some(new_cwe) = new.per_cwe.get(cwe_id) {
+            // Allow up to 2% regression (noise margin).
+            if new_cwe.detection_rate < baseline_cwe.detection_rate - 0.02 {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -1,0 +1,297 @@
+//! Skwaq Gym: Benchmark harness for measuring vulnerability detection accuracy.
+//!
+//! Measures skwaq against known ground truth datasets, tracks improvement over time,
+//! and drives a self-improvement loop.
+
+pub mod adapters;
+pub mod download;
+pub mod ground_truth;
+pub mod history;
+pub mod improve;
+pub mod reporting;
+pub mod scoring;
+
+use adapters::{BenchmarkAdapter, BenchmarkConfig};
+use history::HistoryDb;
+use std::path::PathBuf;
+
+/// Top-level gym runner that coordinates all suites.
+pub struct Gym {
+    pub history_db: HistoryDb,
+    adapters: Vec<Box<dyn BenchmarkAdapter>>,
+    config: BenchmarkConfig,
+    skwaq_root: PathBuf,
+}
+
+impl Gym {
+    pub fn new(skwaq_root: PathBuf) -> anyhow::Result<Self> {
+        let gym_dir = dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("skwaq")
+            .join("gym");
+
+        let history_db = HistoryDb::open(&gym_dir.join("results.db"))?;
+
+        let gt_dir = skwaq_root.join("data/gym/ground_truth");
+        let cache_dir = gym_dir.join("cache");
+
+        let adapters: Vec<Box<dyn BenchmarkAdapter>> =
+            vec![Box::new(adapters::fixtures::FixturesAdapter::new(
+                gt_dir.join("fixtures.toml"),
+                skwaq_root.join("tests/fixtures"),
+            ))];
+
+        let config = BenchmarkConfig {
+            cache_dir,
+            cwe_filter: None,
+            max_cases: None,
+            quick_mode: true,
+            parallelism: 4,
+            timeout_secs: 30,
+        };
+
+        Ok(Self {
+            history_db,
+            adapters,
+            config,
+            skwaq_root,
+        })
+    }
+
+    /// Setup all benchmark data.
+    pub async fn setup(&self) -> anyhow::Result<()> {
+        for adapter in &self.adapters {
+            if !adapter.is_ready(&self.config) {
+                tracing::info!("Setting up {}...", adapter.name());
+                let data_dir = adapter.setup(&self.config).await?;
+                adapter.compile(&data_dir, &self.config).await?;
+            } else {
+                tracing::info!("{} already set up.", adapter.name());
+            }
+        }
+        Ok(())
+    }
+
+    /// Run a specific suite or all suites.
+    pub async fn run(
+        &mut self,
+        suite: Option<&str>,
+        cwe_filter: Option<Vec<u32>>,
+        max_cases: Option<usize>,
+        full: bool,
+    ) -> anyhow::Result<()> {
+        let commit = get_git_commit(&self.skwaq_root)?;
+
+        let adapters: Vec<&Box<dyn BenchmarkAdapter>> = match suite {
+            Some(name) => self.adapters.iter().filter(|a| a.name() == name).collect(),
+            None => self.adapters.iter().collect(),
+        };
+
+        if adapters.is_empty() {
+            anyhow::bail!("Unknown suite. Available: fixtures");
+        }
+
+        let mut config = self.config.clone();
+        config.cwe_filter = cwe_filter;
+        if let Some(max) = max_cases {
+            config.max_cases = Some(max);
+        }
+        if full {
+            config.quick_mode = false;
+            config.timeout_secs = 300;
+        }
+
+        for adapter in adapters {
+            let suite_name = adapter.name().to_string();
+            tracing::info!("Running {} benchmark...", suite_name);
+
+            let run_id = self.history_db.start_run(&suite_name, &commit)?;
+            let gt = adapter.ground_truth()?;
+            let data_dir = adapter.setup(&config).await?;
+
+            let cases: Vec<_> = gt
+                .cases
+                .iter()
+                .filter(|c| {
+                    config.cwe_filter.as_ref().is_none_or(|f| {
+                        c.expected_cwes.iter().any(|cwe| f.contains(cwe))
+                            || c.expected_cwes.is_empty()
+                    })
+                })
+                .take(config.max_cases.unwrap_or(usize::MAX))
+                .collect();
+
+            let mut outcomes = Vec::new();
+            let total = cases.len();
+
+            for (i, case) in cases.iter().enumerate() {
+                if i % 100 == 0 && i > 0 {
+                    tracing::info!("[{}/{}] Processing {}", i, total, case.id);
+                }
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(config.timeout_secs),
+                    adapter.run_case(case, &data_dir, &config),
+                )
+                .await
+                {
+                    Ok(Ok(findings)) => {
+                        let mut outcome = scoring::score_case(case, &findings, &|f| {
+                            adapter.map_finding_to_cwes(f)
+                        });
+                        outcome.suite = suite_name.clone();
+                        outcomes.push(outcome);
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!("Case {} failed: {}", case.id, e);
+                    }
+                    Err(_) => {
+                        tracing::warn!("Case {} timed out after {}s", case.id, config.timeout_secs);
+                    }
+                }
+            }
+
+            let score = scoring::aggregate(&outcomes);
+
+            let run = history::BenchmarkRun {
+                id: run_id.clone(),
+                started_at: chrono::Utc::now(),
+                finished_at: Some(chrono::Utc::now()),
+                suite: suite_name.clone(),
+                skwaq_commit: commit.clone(),
+                precision: score.precision,
+                recall: score.recall,
+                f1: score.f1,
+                true_positives: score.true_positives,
+                false_positives: score.false_positives,
+                false_negatives: score.false_negatives,
+                true_negatives: score.true_negatives,
+            };
+            self.history_db.finish_run(&run)?;
+
+            for cwe_score in score.per_cwe.values() {
+                self.history_db.insert_cwe_result(&history::CweResult {
+                    run_id: run_id.clone(),
+                    cwe_id: cwe_score.cwe_id,
+                    total_cases: cwe_score.total_cases,
+                    true_positives: cwe_score.true_positives,
+                    false_positives: cwe_score.false_positives,
+                    false_negatives: cwe_score.false_negatives,
+                    detection_rate: cwe_score.detection_rate,
+                    precision: cwe_score.precision,
+                })?;
+            }
+
+            reporting::terminal::print_summary(&score, &suite_name);
+        }
+
+        Ok(())
+    }
+
+    /// Show the most recent report.
+    pub fn report(&self, format: ReportFormat) -> anyhow::Result<String> {
+        let runs = self.history_db.recent_runs(1)?;
+        let run = runs
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("No runs yet. Run `skwaq gym run` first."))?;
+
+        let cwe_results = self.history_db.cwe_results_for_run(&run.id)?;
+        let score = reconstruct_score(run, &cwe_results);
+
+        match format {
+            ReportFormat::Terminal => {
+                reporting::terminal::print_summary(&score, &run.suite);
+                Ok(String::new())
+            }
+            ReportFormat::Json => Ok(reporting::json_report::generate(
+                &score,
+                &run.suite,
+                &run.skwaq_commit,
+            )),
+            ReportFormat::Markdown => Ok(reporting::markdown_report::generate(
+                &score,
+                &run.suite,
+                &run.skwaq_commit,
+            )),
+        }
+    }
+
+    /// Compare the two most recent runs.
+    pub fn compare(&self) -> anyhow::Result<()> {
+        let runs = self.history_db.recent_runs(2)?;
+        if runs.len() < 2 {
+            anyhow::bail!("Need at least 2 runs to compare. Run `skwaq gym run` twice.");
+        }
+        reporting::terminal::print_comparison(&runs[1], &runs[0]);
+        Ok(())
+    }
+
+    /// Show run history.
+    pub fn history(&self, limit: u32) -> anyhow::Result<()> {
+        let runs = self.history_db.recent_runs(limit)?;
+        println!(
+            "\n{:>4} {:>19} {:>8} {:>8} {:>8} {:>8} {:>6}",
+            "#", "Date", "Suite", "Prec%", "Rec%", "F1%", "Commit"
+        );
+        println!("{}", "-".repeat(80));
+        for (i, run) in runs.iter().enumerate() {
+            println!(
+                "{:>4} {:>19} {:>8} {:>7.1}% {:>7.1}% {:>7.1}% {:>6}",
+                i + 1,
+                run.started_at.format("%Y-%m-%d %H:%M"),
+                run.suite,
+                run.precision * 100.0,
+                run.recall * 100.0,
+                run.f1 * 100.0,
+                &run.skwaq_commit[..6.min(run.skwaq_commit.len())]
+            );
+        }
+        println!();
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ReportFormat {
+    Terminal,
+    Json,
+    Markdown,
+}
+
+fn get_git_commit(repo: &std::path::Path) -> anyhow::Result<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(repo)
+        .output()?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn reconstruct_score(
+    run: &history::BenchmarkRun,
+    cwe_results: &[history::CweResult],
+) -> scoring::AggregateScore {
+    let mut per_cwe = std::collections::HashMap::new();
+    for cr in cwe_results {
+        per_cwe.insert(
+            cr.cwe_id,
+            scoring::CweScore {
+                cwe_id: cr.cwe_id,
+                total_cases: cr.total_cases,
+                true_positives: cr.true_positives,
+                false_positives: cr.false_positives,
+                false_negatives: cr.false_negatives,
+                detection_rate: cr.detection_rate,
+                precision: cr.precision,
+            },
+        );
+    }
+    scoring::AggregateScore {
+        true_positives: run.true_positives,
+        false_positives: run.false_positives,
+        false_negatives: run.false_negatives,
+        true_negatives: run.true_negatives,
+        precision: run.precision,
+        recall: run.recall,
+        f1: run.f1,
+        per_cwe,
+    }
+}

--- a/crates/gym/src/reporting/json_report.rs
+++ b/crates/gym/src/reporting/json_report.rs
@@ -1,0 +1,59 @@
+//! Machine-readable JSON report generation.
+
+use crate::scoring::AggregateScore;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct JsonReport {
+    pub suite: String,
+    pub timestamp: String,
+    pub skwaq_commit: String,
+    pub precision: f64,
+    pub recall: f64,
+    pub f1: f64,
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub true_negatives: u32,
+    pub per_cwe: Vec<JsonCweResult>,
+}
+
+#[derive(Serialize)]
+pub struct JsonCweResult {
+    pub cwe_id: u32,
+    pub total_cases: u32,
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub detection_rate: f64,
+    pub precision: f64,
+}
+
+pub fn generate(score: &AggregateScore, suite: &str, commit: &str) -> String {
+    let report = JsonReport {
+        suite: suite.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        skwaq_commit: commit.to_string(),
+        precision: score.precision,
+        recall: score.recall,
+        f1: score.f1,
+        true_positives: score.true_positives,
+        false_positives: score.false_positives,
+        false_negatives: score.false_negatives,
+        true_negatives: score.true_negatives,
+        per_cwe: score
+            .per_cwe
+            .values()
+            .map(|c| JsonCweResult {
+                cwe_id: c.cwe_id,
+                total_cases: c.total_cases,
+                true_positives: c.true_positives,
+                false_positives: c.false_positives,
+                false_negatives: c.false_negatives,
+                detection_rate: c.detection_rate,
+                precision: c.precision,
+            })
+            .collect(),
+    };
+    serde_json::to_string_pretty(&report).unwrap_or_default()
+}

--- a/crates/gym/src/reporting/markdown_report.rs
+++ b/crates/gym/src/reporting/markdown_report.rs
@@ -1,0 +1,71 @@
+//! GitHub-compatible Markdown report generation.
+
+use crate::scoring::AggregateScore;
+
+pub fn generate(score: &AggregateScore, suite: &str, commit: &str) -> String {
+    let mut md = String::new();
+
+    md.push_str(&format!("# Skwaq Gym Results: {}\n\n", suite));
+    md.push_str(&format!("**Commit**: `{}`\n", commit));
+    md.push_str(&format!(
+        "**Date**: {}\n\n",
+        chrono::Utc::now().format("%Y-%m-%d %H:%M UTC")
+    ));
+
+    md.push_str("## Summary\n\n");
+    md.push_str("| Metric | Value |\n");
+    md.push_str("|--------|-------|\n");
+    md.push_str(&format!(
+        "| Precision | {:.1}% |\n",
+        score.precision * 100.0
+    ));
+    md.push_str(&format!("| Recall | {:.1}% |\n", score.recall * 100.0));
+    md.push_str(&format!("| F1 Score | {:.1}% |\n", score.f1 * 100.0));
+    md.push_str(&format!("| True Positives | {} |\n", score.true_positives));
+    md.push_str(&format!(
+        "| False Positives | {} |\n",
+        score.false_positives
+    ));
+    md.push_str(&format!(
+        "| False Negatives | {} |\n",
+        score.false_negatives
+    ));
+    md.push_str(&format!(
+        "| True Negatives | {} |\n\n",
+        score.true_negatives
+    ));
+
+    md.push_str("## Per-CWE Detection Rates\n\n");
+    md.push_str("| CWE | Cases | TP | FN | Detection % | Precision % |\n");
+    md.push_str("|-----|-------|----|----|-------------|-------------|\n");
+
+    let mut cwes: Vec<_> = score.per_cwe.values().collect();
+    cwes.sort_by(|a, b| {
+        a.detection_rate
+            .partial_cmp(&b.detection_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    for cwe in &cwes {
+        let emoji = if cwe.detection_rate >= 0.8 {
+            "+"
+        } else if cwe.detection_rate >= 0.5 {
+            "~"
+        } else {
+            "-"
+        };
+        md.push_str(&format!(
+            "| CWE-{} {} | {} | {} | {} | {:.1}% | {:.1}% |\n",
+            cwe.cwe_id,
+            emoji,
+            cwe.total_cases,
+            cwe.true_positives,
+            cwe.false_negatives,
+            cwe.detection_rate * 100.0,
+            cwe.precision * 100.0
+        ));
+    }
+
+    md.push_str("\n\n_Legend: + >80% detection, ~ 50-80%, - <50%_\n");
+    md
+}

--- a/crates/gym/src/reporting/mod.rs
+++ b/crates/gym/src/reporting/mod.rs
@@ -1,0 +1,5 @@
+//! Report generation in multiple formats.
+
+pub mod json_report;
+pub mod markdown_report;
+pub mod terminal;

--- a/crates/gym/src/reporting/terminal.rs
+++ b/crates/gym/src/reporting/terminal.rs
@@ -1,0 +1,104 @@
+//! Rich terminal output for benchmark results.
+
+use crate::history::BenchmarkRun;
+use crate::scoring::AggregateScore;
+
+/// Print a summary of benchmark results.
+pub fn print_summary(score: &AggregateScore, suite: &str) {
+    println!("\n{}", "=".repeat(70));
+    println!("  SKWAQ GYM RESULTS: {}", suite.to_uppercase());
+    println!("{}", "=".repeat(70));
+    println!();
+    println!("  Precision:  {:.1}%", score.precision * 100.0);
+    println!("  Recall:     {:.1}%", score.recall * 100.0);
+    println!("  F1 Score:   {:.1}%", score.f1 * 100.0);
+    println!();
+    println!(
+        "  TP: {}  FP: {}  FN: {}  TN: {}",
+        score.true_positives, score.false_positives, score.false_negatives, score.true_negatives
+    );
+    println!();
+
+    let mut cwes: Vec<_> = score.per_cwe.values().collect();
+    cwes.sort_by(|a, b| {
+        a.detection_rate
+            .partial_cmp(&b.detection_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    println!(
+        "  {:>8} {:>8} {:>8} {:>8} {:>10} {:>10}",
+        "CWE", "Cases", "TP", "FN", "Detect%", "Prec%"
+    );
+    println!("  {}", "-".repeat(62));
+
+    for cwe in &cwes {
+        let detect_color = if cwe.detection_rate >= 0.8 {
+            "\x1b[32m"
+        } else if cwe.detection_rate >= 0.5 {
+            "\x1b[33m"
+        } else {
+            "\x1b[31m"
+        };
+        println!(
+            "  {:>8} {:>8} {:>8} {:>8} {}{:>9.1}%\x1b[0m {:>9.1}%",
+            cwe.cwe_id,
+            cwe.total_cases,
+            cwe.true_positives,
+            cwe.false_negatives,
+            detect_color,
+            cwe.detection_rate * 100.0,
+            cwe.precision * 100.0
+        );
+    }
+    println!();
+}
+
+/// Print a comparison between two runs.
+pub fn print_comparison(previous: &BenchmarkRun, current: &BenchmarkRun) {
+    println!("\n{}", "=".repeat(70));
+    println!("  IMPROVEMENT COMPARISON");
+    println!("{}", "=".repeat(70));
+    println!();
+
+    let delta_f1 = current.f1 - previous.f1;
+    let delta_p = current.precision - previous.precision;
+    let delta_r = current.recall - previous.recall;
+
+    println!(
+        "  {:>12} {:>10} {:>10} {:>10}",
+        "", "Previous", "Current", "Delta"
+    );
+    println!("  {}", "-".repeat(46));
+    println!(
+        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%",
+        "Precision",
+        previous.precision * 100.0,
+        current.precision * 100.0,
+        delta_p * 100.0
+    );
+    println!(
+        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%",
+        "Recall",
+        previous.recall * 100.0,
+        current.recall * 100.0,
+        delta_r * 100.0
+    );
+    println!(
+        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%",
+        "F1",
+        previous.f1 * 100.0,
+        current.f1 * 100.0,
+        delta_f1 * 100.0
+    );
+    println!();
+
+    if delta_f1 > 0.0 {
+        println!("  Overall: IMPROVED");
+    } else if delta_f1 < 0.0 {
+        println!("  Overall: REGRESSED");
+    } else {
+        println!("  Overall: No change");
+    }
+    println!();
+}

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -1,0 +1,314 @@
+//! Scoring engine: TP/FP/FN computation, precision/recall/F1.
+
+use crate::adapters::DetectedFinding;
+use crate::ground_truth::TestCase;
+use std::collections::{HashMap, HashSet};
+
+/// Outcome for a single test case.
+#[derive(Debug, Clone)]
+pub struct CaseOutcome {
+    pub case_id: String,
+    pub suite: String,
+    pub expected_cwes: Vec<u32>,
+    pub detected_cwes: Vec<u32>,
+    pub matched_finding_ids: Vec<String>,
+    pub unmatched_finding_ids: Vec<String>,
+    /// Per expected CWE: was it detected?
+    pub cwe_hits: HashMap<u32, bool>,
+}
+
+/// Aggregate scores for a set of case outcomes.
+#[derive(Debug, Clone, Default)]
+pub struct AggregateScore {
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub true_negatives: u32,
+    pub precision: f64,
+    pub recall: f64,
+    pub f1: f64,
+    pub per_cwe: HashMap<u32, CweScore>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CweScore {
+    pub cwe_id: u32,
+    pub total_cases: u32,
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub detection_rate: f64,
+    pub precision: f64,
+}
+
+/// Score a single test case against ground truth.
+pub fn score_case(
+    case: &TestCase,
+    findings: &[DetectedFinding],
+    finding_to_cwes: &dyn Fn(&DetectedFinding) -> Vec<u32>,
+) -> CaseOutcome {
+    let detected_cwe_set: HashSet<u32> = findings.iter().flat_map(finding_to_cwes).collect();
+
+    let expected_set: HashSet<u32> = case.expected_cwes.iter().copied().collect();
+
+    let mut cwe_hits = HashMap::new();
+
+    for &expected in &case.expected_cwes {
+        let family = cwe_family(expected);
+        let hit = detected_cwe_set
+            .iter()
+            .any(|&d| cwe_family(d) == family || d == expected);
+        cwe_hits.insert(expected, hit);
+    }
+
+    // Classify findings as matched or unmatched.
+    let mut matched_ids = Vec::new();
+    let mut unmatched_ids = Vec::new();
+
+    for f in findings {
+        let f_cwes: HashSet<u32> = finding_to_cwes(f).into_iter().collect();
+        let matches_any_expected = expected_set.iter().any(|&e| {
+            let family = cwe_family(e);
+            f_cwes.iter().any(|&d| cwe_family(d) == family || d == e)
+        });
+        if matches_any_expected {
+            matched_ids.push(f.id.clone());
+        } else {
+            unmatched_ids.push(f.id.clone());
+        }
+    }
+
+    CaseOutcome {
+        case_id: case.id.clone(),
+        suite: String::new(),
+        expected_cwes: case.expected_cwes.clone(),
+        detected_cwes: detected_cwe_set.into_iter().collect(),
+        matched_finding_ids: matched_ids,
+        unmatched_finding_ids: unmatched_ids,
+        cwe_hits,
+    }
+}
+
+/// Map a specific CWE to its broad family for matching purposes.
+pub fn cwe_family(cwe: u32) -> u32 {
+    match cwe {
+        // Buffer overflow family -> CWE-119
+        120 | 121 | 122 | 124 | 125 | 126 | 127 | 787 => 119,
+        // Use-after-free family -> CWE-416
+        415 => 416,
+        // Injection family -> CWE-74
+        77 | 78 | 79 | 80 | 89 | 90 | 94 | 95 | 96 => 74,
+        // Race condition family -> CWE-362
+        367 => 362,
+        // Integer overflow family -> CWE-190
+        191 | 192 | 194 | 195 | 196 | 197 => 190,
+        // Null pointer family -> CWE-476
+        252 | 253 => 476,
+        // Everything else maps to itself.
+        other => other,
+    }
+}
+
+/// Default mapping from skwaq DangerCategory to CWE IDs.
+pub fn category_to_cwes(category: &str) -> Vec<u32> {
+    match category {
+        "memory" => vec![119, 120, 121, 122, 125, 126, 787, 416, 415],
+        "injection" => vec![78, 89, 90, 94, 77],
+        "format_string" => vec![134],
+        "race" => vec![362, 367],
+        "temp_file" => vec![377],
+        "path_traversal" => vec![22, 23, 36],
+        "deserialization" => vec![502],
+        "crypto" => vec![326, 327, 328, 330],
+        "unsafe_code" => vec![676],
+        "prototype_pollution" => vec![1321],
+        "xss" => vec![79, 80],
+        _ => vec![],
+    }
+}
+
+/// Compute aggregate scores from a list of case outcomes.
+pub fn aggregate(outcomes: &[CaseOutcome]) -> AggregateScore {
+    let mut score = AggregateScore::default();
+    let mut per_cwe: HashMap<u32, CweScore> = HashMap::new();
+
+    for outcome in outcomes {
+        if outcome.expected_cwes.is_empty() {
+            // Negative test case.
+            if outcome.detected_cwes.is_empty() {
+                score.true_negatives += 1;
+            } else {
+                score.false_positives += outcome.unmatched_finding_ids.len() as u32;
+            }
+        } else {
+            // Positive test case.
+            for (&cwe, &hit) in &outcome.cwe_hits {
+                let entry = per_cwe.entry(cwe_family(cwe)).or_insert_with(|| CweScore {
+                    cwe_id: cwe_family(cwe),
+                    ..Default::default()
+                });
+                entry.total_cases += 1;
+                if hit {
+                    entry.true_positives += 1;
+                    score.true_positives += 1;
+                } else {
+                    entry.false_negatives += 1;
+                    score.false_negatives += 1;
+                }
+            }
+            // False positives: findings that don't match any expected CWE.
+            score.false_positives += outcome.unmatched_finding_ids.len() as u32;
+            for &cwe in &outcome.detected_cwes {
+                let family = cwe_family(cwe);
+                if !outcome
+                    .expected_cwes
+                    .iter()
+                    .any(|&e| cwe_family(e) == family)
+                {
+                    let entry = per_cwe.entry(family).or_insert_with(|| CweScore {
+                        cwe_id: family,
+                        ..Default::default()
+                    });
+                    entry.false_positives += 1;
+                }
+            }
+        }
+    }
+
+    // Compute rates.
+    let tp = score.true_positives as f64;
+    let fp = score.false_positives as f64;
+    let fn_ = score.false_negatives as f64;
+
+    score.precision = if tp + fp > 0.0 { tp / (tp + fp) } else { 0.0 };
+    score.recall = if tp + fn_ > 0.0 { tp / (tp + fn_) } else { 0.0 };
+    score.f1 = if score.precision + score.recall > 0.0 {
+        2.0 * score.precision * score.recall / (score.precision + score.recall)
+    } else {
+        0.0
+    };
+
+    for entry in per_cwe.values_mut() {
+        let tp = entry.true_positives as f64;
+        let fp = entry.false_positives as f64;
+        let fn_ = entry.false_negatives as f64;
+        entry.detection_rate = if tp + fn_ > 0.0 { tp / (tp + fn_) } else { 0.0 };
+        entry.precision = if tp + fp > 0.0 { tp / (tp + fp) } else { 0.0 };
+    }
+
+    score.per_cwe = per_cwe;
+    score
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::DetectedFinding;
+
+    fn make_finding(category: &str, cwes: Vec<u32>) -> DetectedFinding {
+        DetectedFinding {
+            id: uuid::Uuid::new_v4().to_string(),
+            category: category.to_string(),
+            severity: "high".to_string(),
+            cwes,
+            file: "test.c".to_string(),
+            function: "main".to_string(),
+            line: Some(10),
+            title: "test finding".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_cwe_family() {
+        assert_eq!(cwe_family(121), 119); // stack overflow -> buffer overflow
+        assert_eq!(cwe_family(122), 119); // heap overflow -> buffer overflow
+        assert_eq!(cwe_family(119), 119); // identity
+        assert_eq!(cwe_family(78), 74); // os command injection -> injection
+        assert_eq!(cwe_family(999), 999); // unknown -> itself
+    }
+
+    #[test]
+    fn test_score_case_true_positive() {
+        let case = TestCase {
+            id: "test".to_string(),
+            path: "test.c".to_string(),
+            expected_cwes: vec![121],
+            is_negative: false,
+            language: "c".to_string(),
+        };
+        let findings = vec![make_finding("memory", vec![119])];
+
+        let outcome = score_case(&case, &findings, &|f| f.cwes.clone());
+        // CWE-119 matches CWE-121 family
+        assert!(outcome.cwe_hits[&121]);
+        assert_eq!(outcome.matched_finding_ids.len(), 1);
+    }
+
+    #[test]
+    fn test_score_case_false_negative() {
+        let case = TestCase {
+            id: "test".to_string(),
+            path: "test.c".to_string(),
+            expected_cwes: vec![121],
+            is_negative: false,
+            language: "c".to_string(),
+        };
+        let findings = vec![]; // no findings
+
+        let outcome = score_case(&case, &findings, &|f| f.cwes.clone());
+        assert!(!outcome.cwe_hits[&121]);
+    }
+
+    #[test]
+    fn test_aggregate_basic() {
+        let outcomes = vec![
+            CaseOutcome {
+                case_id: "hit".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![121],
+                detected_cwes: vec![119],
+                matched_finding_ids: vec!["f1".to_string()],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(121, true)].into_iter().collect(),
+            },
+            CaseOutcome {
+                case_id: "miss".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![134],
+                detected_cwes: vec![],
+                matched_finding_ids: vec![],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(134, false)].into_iter().collect(),
+            },
+        ];
+
+        let score = aggregate(&outcomes);
+        assert_eq!(score.true_positives, 1);
+        assert_eq!(score.false_negatives, 1);
+        assert_eq!(score.precision, 1.0);
+        assert_eq!(score.recall, 0.5);
+    }
+
+    #[test]
+    fn test_aggregate_negative_case() {
+        let outcomes = vec![CaseOutcome {
+            case_id: "clean".to_string(),
+            suite: "test".to_string(),
+            expected_cwes: vec![],
+            detected_cwes: vec![],
+            matched_finding_ids: vec![],
+            unmatched_finding_ids: vec![],
+            cwe_hits: HashMap::new(),
+        }];
+
+        let score = aggregate(&outcomes);
+        assert_eq!(score.true_negatives, 1);
+    }
+
+    #[test]
+    fn test_category_to_cwes() {
+        assert!(!category_to_cwes("memory").is_empty());
+        assert!(!category_to_cwes("injection").is_empty());
+        assert!(category_to_cwes("unknown_category").is_empty());
+    }
+}

--- a/data/gym/ground_truth/fixtures.toml
+++ b/data/gym/ground_truth/fixtures.toml
@@ -1,0 +1,53 @@
+suite = "fixtures"
+version = "1.0"
+download_url = ""
+download_sha256 = ""
+
+[[cases]]
+id = "buffer_overflow"
+path = "buffer_overflow.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "command_injection"
+path = "command_injection.c"
+expected_cwes = [78]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "format_string"
+path = "format_string.c"
+expected_cwes = [134]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "integer_overflow"
+path = "integer_overflow.c"
+expected_cwes = [190]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "use_after_free"
+path = "use_after_free.c"
+expected_cwes = [416]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "vuln_app_py"
+path = "vuln_app.py"
+expected_cwes = [78, 89]
+is_negative = false
+language = "python"
+
+[[cases]]
+id = "vuln_app_js"
+path = "vuln_app.js"
+expected_cwes = [78, 79]
+is_negative = false
+language = "javascript"


### PR DESCRIPTION
## Summary

- Implements the Skwaq Gym benchmark harness as a new `crates/gym` crate
- Adds CLI integration (`skwaq gym run/report/compare/history`)
- 9 unit tests covering scoring, history DB, and ground truth loading
- Baseline F1=50% on fixtures (2/5 CWE families detected)

## What's Included

| Component | File | Purpose |
|-----------|------|---------|
| Adapter trait | `adapters/mod.rs` | BenchmarkAdapter trait + shared analysis |
| Fixtures adapter | `adapters/fixtures.rs` | Tests against skwaq's own fixtures |
| Scoring engine | `scoring.rs` | TP/FP/FN, precision/recall/F1, CWE-family matching |
| History DB | `history.rs` | SQLite-backed run tracking |
| Reports | `reporting/` | Terminal, JSON, Markdown output |
| Download manager | `download.rs` | SHA-256 verified downloads with safe extraction |
| Ground truth | `data/gym/ground_truth/fixtures.toml` | 7 test cases across 5 CWE families |
| CLI | `gym_cmd.rs` | `skwaq gym {setup,run,report,compare,history}` |

## Security Review Findings Addressed

- Mandatory SHA-256 checksums (no empty checksums allowed)
- Safe archive extraction (zip-slip prevention)
- Per-case analysis timeouts
- Path traversal validation in manifests
- DB file permissions (0o600 on Unix)

## Test plan

- [x] `cargo test -p skwaq-gym` (9 tests pass)
- [x] `cargo test` (all tests pass)
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `skwaq gym run fixtures --max-cases 5` (end-to-end works)
- [x] `skwaq self-test` (still passes)

Closes #28
Relates to #25, #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)