### PR TITLE
feat: wire gym to agentic analysis pipeline (100% recall)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,7 +3437,6 @@ dependencies = [
  "flate2",
  "indicatif",
  "rayon",
- "regex",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/crates/gym/Cargo.toml
+++ b/crates/gym/Cargo.toml
@@ -27,7 +27,6 @@ zip = "2"
 walkdir = "2"
 rayon = "1"
 indicatif = "0.17"
-regex = "1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -82,7 +82,7 @@ fn run_sync_analysis(path: &Path) -> anyhow::Result<Vec<DetectedFinding>> {
     if let Ok(hits) = detector.detect_in_source(path, &parsed.language) {
         for hit in &hits {
             let finding_id = uuid::Uuid::new_v4().to_string();
-            let _ = db.execute(
+            if let Err(e) = db.execute(
                 "INSERT INTO findings (id, title, evidence, agent, timestamp, investigation_id, \
                  status, severity, category) \
                  VALUES (?1, ?2, ?3, 'source-pattern-detector', ?4, ?5, 'new', ?6, ?7)",
@@ -103,7 +103,9 @@ fn run_sync_analysis(path: &Path) -> anyhow::Result<Vec<DetectedFinding>> {
                     &hit.severity.to_string().to_lowercase().as_str(),
                     &hit.danger_category.to_string().as_str(),
                 ],
-            );
+            ) {
+                tracing::warn!("Failed to store finding for {}: {}", hit.function_name, e);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Wire the Skwaq Gym to the multi-cycle analysis orchestrator for deeper vulnerability detection beyond regex patterns.

**New module: `agentic.rs`** bridges gym benchmarks with skwaq's analysis pipeline:
- Ingests test cases into fresh in-memory graph DB
- Builds code property graph (functions, calls, sources, sinks)
- Runs pattern detection + dataflow analysis + context validation
- Extracts non-invalidated findings

## Results

| Mode | F1 | Precision | Recall | CWEs Detected |
|------|-----|-----------|--------|---------------|
| Quick (patterns) | 80.0% | 80.0% | 80.0% | 4/5 |
| Full (agentic) | 58.8% | 41.7% | **100.0%** | **5/5** |

Key win: **CWE-416 (use-after-free) now detected** via taint/dataflow analysis — impossible with regex patterns alone.

## Step 13: Local Testing Results

1. `skwaq gym run fixtures --max-cases 5` → F1=80% (quick) ✅
2. `skwaq gym run fixtures --max-cases 5 --full` → Recall=100% (full) ✅
3. `skwaq self-test` → PASS ✅
4. `cargo test` → 172 tests pass ✅

## Step 19: Outside-In Testing

**Interface Type**: CLI
1. Quick mode: `skwaq gym run fixtures` → Patterns only, fast ✅
2. Full mode: `skwaq gym run fixtures --full` → Deeper analysis, all CWEs ✅
3. Compare: `skwaq gym compare` → Shows both runs ✅
4. History: `skwaq gym history` → Tracks progression ✅

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)