### PR TITLE
fix: increase full-mode timeout to 30min for agentic analysis

### DIFF
--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -99,7 +99,9 @@ impl Gym {
         }
         if full {
             config.quick_mode = false;
-            config.timeout_secs = 300;
+            // Agentic analysis with 5 LLM agents can take 10+ minutes per case.
+            // 30 minutes is generous but prevents infinite hangs.
+            config.timeout_secs = 1800;
         }
 
         for adapter in adapters {


### PR DESCRIPTION
## Summary

LLM agent pipelines with 5 agents can take 10+ minutes per case. The 300s timeout was causing premature termination. Increased to 1800s (30 min) for full agentic mode.

Quick mode (patterns only) stays at 30s.

## Test plan
- [x] `cargo test` → 172 tests pass
- [x] `cargo clippy` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)