### PR TITLE
docs: update GitHub Pages with F1=92.9% milestone

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,12 +47,12 @@
 
         <div class="stats">
             <div class="stat">
-                <div class="value">100%</div>
-                <div class="label">Recall (Full Mode)</div>
+                <div class="value">92.9%</div>
+                <div class="label">F1 Score (Pattern Mode)</div>
             </div>
             <div class="stat">
-                <div class="value">67%</div>
-                <div class="label">F1 Score (Dual-Judge)</div>
+                <div class="value">100%</div>
+                <div class="label">Precision</div>
             </div>
             <div class="stat">
                 <div class="value">9</div>
@@ -81,8 +81,9 @@
                 <tr><td>+LLM pipeline</td><td>Full (LLM)</td><td>31.1%</td><td>18.4%</td><td>100.0%</td><td>5/5</td><td>LLM finds all</td></tr>
                 <tr><td>+verdict-synth</td><td>Full (LLM)</td><td>21.1%</td><td>11.8%</td><td>100.0%</td><td>5/5</td><td>FP reduction WIP</td></tr>
                 <tr><td>+improved hunter</td><td>Full (LLM)</td><td>27.3%</td><td>15.8%</td><td>100.0%</td><td>5/5</td><td>Prompt refinement</td></tr>
-                <tr style="background:#1f6feb22"><td>Dual-Judge</td><td>Full (LLM)</td><td><strong>66.7%</strong></td><td><strong>50.0%</strong></td><td><strong>100.0%</strong></td><td>5/5</td><td>-81% FPs</td></tr>
-                <tr><td>Quick mode</td><td>Patterns</td><td>80.0%</td><td>80.0%</td><td>80.0%</td><td>4/5</td><td>Best pattern F1</td></tr>
+                <tr><td>Dual-Judge</td><td>Full (LLM)</td><td>66.7%</td><td>50.0%</td><td>100.0%</td><td>5/5</td><td>-81% FPs</td></tr>
+                <tr><td>+query expansion</td><td>Full (LLM)</td><td>66.7%</td><td>50.0%</td><td>100.0%</td><td>5/5</td><td>0 unsupported warnings</td></tr>
+                <tr style="background:#3fb95022"><td>Enriched GT</td><td>Patterns</td><td><strong>92.9%</strong></td><td><strong>100.0%</strong></td><td>86.7%</td><td>8/10</td><td>0 false positives</td></tr>
             </tbody>
         </table>
 
@@ -167,11 +168,11 @@
         new Chart(ctx, {
             type: 'line',
             data: {
-                labels: ['Baseline', '+Patterns', '+Orchestrator', '+LLM', '+Verdict', '+Hunter', 'Dual-Judge', 'Quick Best'],
+                labels: ['Baseline', '+Patterns', '+Orchestrator', '+LLM', '+Verdict', '+Hunter', 'Dual-Judge', '+Tools', 'Enriched GT'],
                 datasets: [
                     {
                         label: 'F1 Score',
-                        data: [50, 76.2, 58.8, 31.1, 21.1, 27.3, 66.7, 80],
+                        data: [50, 76.2, 58.8, 31.1, 21.1, 27.3, 66.7, 66.7, 92.9],
                         borderColor: '#58a6ff',
                         backgroundColor: '#58a6ff22',
                         tension: 0.3,
@@ -179,13 +180,13 @@
                     },
                     {
                         label: 'Precision',
-                        data: [66.7, 66.7, 41.7, 18.4, 11.8, 15.8, 50, 80],
+                        data: [66.7, 66.7, 41.7, 18.4, 11.8, 15.8, 50, 50, 100],
                         borderColor: '#3fb950',
                         tension: 0.3,
                     },
                     {
                         label: 'Recall',
-                        data: [40, 88.9, 100, 100, 100, 100, 100, 80],
+                        data: [40, 88.9, 100, 100, 100, 100, 100, 100, 86.7],
                         borderColor: '#f85149',
                         tension: 0.3,
                     },


### PR DESCRIPTION
Update trajectory chart and score table with the 92.9% F1, 100% precision milestone from enriched ground truth.