### PR TITLE
feat: add CGC, CyberSecEval, and OWASP Benchmark adapters

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -10,7 +10,7 @@ pub enum GymSub {
 
     /// Run benchmarks
     Run {
-        /// Suite name (fixtures). Omit for all.
+        /// Suite name (fixtures, juliet, cgc, cyberseceval, owasp). Omit for all.
         suite: Option<String>,
 
         /// Filter to specific CWE (e.g., CWE-119)

--- a/crates/gym/src/adapters/cgc.rs
+++ b/crates/gym/src/adapters/cgc.rs
@@ -1,0 +1,91 @@
+//! DARPA Cyber Grand Challenge (CGC) adapter.
+//!
+//! Uses the Trail of Bits cb-multios port of CGC challenge binaries.
+//! Each challenge contains intentional vulnerabilities (primarily memory corruption).
+//! Source code is available for each challenge, enabling both source and binary analysis.
+
+use super::*;
+use crate::ground_truth::GroundTruth;
+use std::path::{Path, PathBuf};
+
+pub struct CgcAdapter {
+    manifest_path: PathBuf,
+}
+
+impl CgcAdapter {
+    pub fn new(manifest_path: PathBuf) -> Self {
+        Self { manifest_path }
+    }
+}
+
+#[async_trait(?Send)]
+impl BenchmarkAdapter for CgcAdapter {
+    fn name(&self) -> &str {
+        "cgc"
+    }
+
+    fn ground_truth(&self) -> anyhow::Result<GroundTruth> {
+        GroundTruth::load(&self.manifest_path)
+    }
+
+    async fn setup(&self, config: &BenchmarkConfig) -> anyhow::Result<PathBuf> {
+        let gt = self.ground_truth()?;
+        let dest = config.cache_dir.join("cgc");
+        if dest.join(".ready").exists() {
+            return Ok(dest);
+        }
+        if gt.download_url.is_empty() {
+            // CGC uses git clone, not archive download
+            anyhow::bail!(
+                "CGC data must be cloned manually: git clone https://github.com/trailofbits/cb-multios.git {}",
+                dest.display()
+            );
+        }
+        crate::download::download_and_extract(&gt.download_url, &gt.download_sha256, &dest).await?;
+        std::fs::write(dest.join(".ready"), "")?;
+        Ok(dest)
+    }
+
+    fn is_ready(&self, config: &BenchmarkConfig) -> bool {
+        config.cache_dir.join("cgc").join(".ready").exists()
+    }
+
+    async fn compile(&self, _data_dir: &Path, _config: &BenchmarkConfig) -> anyhow::Result<()> {
+        // CGC challenges include source code that can be compiled.
+        // For now, we analyze the source directly.
+        Ok(())
+    }
+
+    async fn run_case(
+        &self,
+        case: &TestCase,
+        data_dir: &Path,
+        config: &BenchmarkConfig,
+    ) -> anyhow::Result<Vec<DetectedFinding>> {
+        let source_path = data_dir.join(&case.path);
+        if config.quick_mode {
+            run_source_pattern_detection(&source_path)
+        } else {
+            crate::agentic::run_agentic_source_analysis(&source_path, config.timeout_secs).await
+        }
+    }
+
+    fn map_finding_to_cwes(&self, finding: &DetectedFinding) -> Vec<u32> {
+        if !finding.cwes.is_empty() {
+            return finding.cwes.clone();
+        }
+        // CGC challenges are overwhelmingly memory corruption (CWE-119 family)
+        crate::scoring::category_to_cwes(&finding.category)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adapter_name() {
+        let adapter = CgcAdapter::new(PathBuf::from("/nonexistent"));
+        assert_eq!(adapter.name(), "cgc");
+    }
+}

--- a/crates/gym/src/adapters/cyberseceval.rs
+++ b/crates/gym/src/adapters/cyberseceval.rs
@@ -1,0 +1,92 @@
+//! Meta CyberSecEval adapter.
+//!
+//! CyberSecEval (from Meta's PurpleLlama) tests whether tools can detect
+//! insecure code patterns across multiple languages. Each test case is a
+//! code snippet with a known vulnerability type.
+
+use super::*;
+use crate::ground_truth::GroundTruth;
+use std::path::{Path, PathBuf};
+
+pub struct CyberSecEvalAdapter {
+    manifest_path: PathBuf,
+}
+
+impl CyberSecEvalAdapter {
+    pub fn new(manifest_path: PathBuf) -> Self {
+        Self { manifest_path }
+    }
+}
+
+#[async_trait(?Send)]
+impl BenchmarkAdapter for CyberSecEvalAdapter {
+    fn name(&self) -> &str {
+        "cyberseceval"
+    }
+
+    fn ground_truth(&self) -> anyhow::Result<GroundTruth> {
+        GroundTruth::load(&self.manifest_path)
+    }
+
+    async fn setup(&self, config: &BenchmarkConfig) -> anyhow::Result<PathBuf> {
+        let gt = self.ground_truth()?;
+        let dest = config.cache_dir.join("cyberseceval");
+        if dest.join(".ready").exists() {
+            return Ok(dest);
+        }
+        if gt.download_url.is_empty() {
+            anyhow::bail!(
+                "CyberSecEval data must be cloned: git clone https://github.com/meta-llama/PurpleLlama.git {}",
+                dest.display()
+            );
+        }
+        crate::download::download_and_extract(&gt.download_url, &gt.download_sha256, &dest).await?;
+        std::fs::write(dest.join(".ready"), "")?;
+        Ok(dest)
+    }
+
+    fn is_ready(&self, config: &BenchmarkConfig) -> bool {
+        config
+            .cache_dir
+            .join("cyberseceval")
+            .join(".ready")
+            .exists()
+    }
+
+    async fn compile(&self, _data_dir: &Path, _config: &BenchmarkConfig) -> anyhow::Result<()> {
+        // CyberSecEval cases are source snippets, no compilation needed.
+        Ok(())
+    }
+
+    async fn run_case(
+        &self,
+        case: &TestCase,
+        data_dir: &Path,
+        config: &BenchmarkConfig,
+    ) -> anyhow::Result<Vec<DetectedFinding>> {
+        let source_path = data_dir.join(&case.path);
+        if config.quick_mode {
+            run_source_pattern_detection(&source_path)
+        } else {
+            crate::agentic::run_agentic_source_analysis(&source_path, config.timeout_secs).await
+        }
+    }
+
+    fn map_finding_to_cwes(&self, finding: &DetectedFinding) -> Vec<u32> {
+        if !finding.cwes.is_empty() {
+            return finding.cwes.clone();
+        }
+        crate::scoring::category_to_cwes(&finding.category)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adapter_name() {
+        let adapter = CyberSecEvalAdapter::new(PathBuf::from("/nonexistent"));
+        assert_eq!(adapter.name(), "cyberseceval");
+    }
+}

--- a/crates/gym/src/adapters/mod.rs
+++ b/crates/gym/src/adapters/mod.rs
@@ -1,7 +1,10 @@
 //! Benchmark adapter trait and implementations.
 
+pub mod cgc;
+pub mod cyberseceval;
 pub mod fixtures;
 pub mod juliet;
+pub mod owasp;
 
 use crate::ground_truth::{GroundTruth, TestCase};
 use async_trait::async_trait;

--- a/crates/gym/src/adapters/owasp.rs
+++ b/crates/gym/src/adapters/owasp.rs
@@ -1,0 +1,91 @@
+//! OWASP Benchmark adapter.
+//!
+//! The OWASP Benchmark is a Java test suite with ~2,800 test cases.
+//! Each case is a servlet that either contains a real vulnerability (true positive)
+//! or a safe implementation (false positive). Scoring uses Youden's index: TPR - FPR.
+//!
+//! For Skwaq, we analyze the Java source files using pattern detection
+//! and LLM agents, since our primary analysis is source-based.
+
+use super::*;
+use crate::ground_truth::GroundTruth;
+use std::path::{Path, PathBuf};
+
+pub struct OwaspBenchmarkAdapter {
+    manifest_path: PathBuf,
+}
+
+impl OwaspBenchmarkAdapter {
+    pub fn new(manifest_path: PathBuf) -> Self {
+        Self { manifest_path }
+    }
+}
+
+#[async_trait(?Send)]
+impl BenchmarkAdapter for OwaspBenchmarkAdapter {
+    fn name(&self) -> &str {
+        "owasp"
+    }
+
+    fn ground_truth(&self) -> anyhow::Result<GroundTruth> {
+        GroundTruth::load(&self.manifest_path)
+    }
+
+    async fn setup(&self, config: &BenchmarkConfig) -> anyhow::Result<PathBuf> {
+        let gt = self.ground_truth()?;
+        let dest = config.cache_dir.join("owasp");
+        if dest.join(".ready").exists() {
+            return Ok(dest);
+        }
+        if gt.download_url.is_empty() {
+            anyhow::bail!(
+                "OWASP Benchmark must be cloned: git clone https://github.com/OWASP-Benchmark/BenchmarkJava.git {}",
+                dest.display()
+            );
+        }
+        crate::download::download_and_extract(&gt.download_url, &gt.download_sha256, &dest).await?;
+        std::fs::write(dest.join(".ready"), "")?;
+        Ok(dest)
+    }
+
+    fn is_ready(&self, config: &BenchmarkConfig) -> bool {
+        config.cache_dir.join("owasp").join(".ready").exists()
+    }
+
+    async fn compile(&self, _data_dir: &Path, _config: &BenchmarkConfig) -> anyhow::Result<()> {
+        // OWASP Benchmark is Java source - no compilation needed for analysis.
+        Ok(())
+    }
+
+    async fn run_case(
+        &self,
+        case: &TestCase,
+        data_dir: &Path,
+        config: &BenchmarkConfig,
+    ) -> anyhow::Result<Vec<DetectedFinding>> {
+        let source_path = data_dir.join(&case.path);
+        if config.quick_mode {
+            run_source_pattern_detection(&source_path)
+        } else {
+            crate::agentic::run_agentic_source_analysis(&source_path, config.timeout_secs).await
+        }
+    }
+
+    fn map_finding_to_cwes(&self, finding: &DetectedFinding) -> Vec<u32> {
+        if !finding.cwes.is_empty() {
+            return finding.cwes.clone();
+        }
+        crate::scoring::category_to_cwes(&finding.category)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adapter_name() {
+        let adapter = OwaspBenchmarkAdapter::new(PathBuf::from("/nonexistent"));
+        assert_eq!(adapter.name(), "owasp");
+    }
+}

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -42,12 +42,37 @@ impl Gym {
                 skwaq_root.join("tests/fixtures"),
             ))];
 
-        // Add Juliet adapter if manifest exists
-        let juliet_manifest = gt_dir.join("juliet.toml");
-        if juliet_manifest.exists() {
-            adapter_list.push(Box::new(adapters::juliet::JulietAdapter::new(
-                juliet_manifest,
-            )));
+        // Add industry benchmark adapters if their manifests exist
+        for (name, constructor) in [
+            (
+                "juliet",
+                Box::new(|p: PathBuf| -> Box<dyn BenchmarkAdapter> {
+                    Box::new(adapters::juliet::JulietAdapter::new(p))
+                }) as Box<dyn Fn(PathBuf) -> Box<dyn BenchmarkAdapter>>,
+            ),
+            (
+                "cgc",
+                Box::new(|p: PathBuf| -> Box<dyn BenchmarkAdapter> {
+                    Box::new(adapters::cgc::CgcAdapter::new(p))
+                }) as Box<dyn Fn(PathBuf) -> Box<dyn BenchmarkAdapter>>,
+            ),
+            (
+                "cyberseceval",
+                Box::new(|p: PathBuf| -> Box<dyn BenchmarkAdapter> {
+                    Box::new(adapters::cyberseceval::CyberSecEvalAdapter::new(p))
+                }) as Box<dyn Fn(PathBuf) -> Box<dyn BenchmarkAdapter>>,
+            ),
+            (
+                "owasp",
+                Box::new(|p: PathBuf| -> Box<dyn BenchmarkAdapter> {
+                    Box::new(adapters::owasp::OwaspBenchmarkAdapter::new(p))
+                }) as Box<dyn Fn(PathBuf) -> Box<dyn BenchmarkAdapter>>,
+            ),
+        ] {
+            let manifest = gt_dir.join(format!("{}.toml", name));
+            if manifest.exists() {
+                adapter_list.push(constructor(manifest));
+            }
         }
 
         let adapters = adapter_list;

--- a/data/gym/ground_truth/cgc.toml
+++ b/data/gym/ground_truth/cgc.toml
@@ -1,0 +1,356 @@
+suite = "cgc"
+version = "cb-multios"
+download_url = ""
+download_sha256 = ""
+
+[[cases]]
+id = "3D_Image_Toolkit"
+path = "challenges/3D_Image_Toolkit/src/main.c"
+expected_cwes = [125]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "AIS-Lite"
+path = "challenges/AIS-Lite/src/sentence.c"
+expected_cwes = [20, 120, 122, 129, 788]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "ASCII_Content_Server"
+path = "challenges/ASCII_Content_Server/src/page.c"
+expected_cwes = [195, 476, 787]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "ASL6parse"
+path = "challenges/ASL6parse/src/main.c"
+expected_cwes = [125]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Accel"
+path = "challenges/Accel/src/main.c"
+expected_cwes = [193, 457]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Audio_Visualizer"
+path = "challenges/Audio_Visualizer/src/main.c"
+expected_cwes = [122]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Barcoder"
+path = "challenges/Barcoder/src/main.c"
+expected_cwes = [121, 134, 839]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "BitBlaster"
+path = "challenges/BitBlaster/src/main.c"
+expected_cwes = [476, 824]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Bloomy_Sunday"
+path = "challenges/Bloomy_Sunday/src/main.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Board_Game"
+path = "challenges/Board_Game/src/moves.c"
+expected_cwes = [787]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "BudgIT"
+path = "challenges/BudgIT/src/map.c"
+expected_cwes = [122, 125, 131, 193, 469, 787]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CGC_Board"
+path = "challenges/CGC_Board/src/main.c"
+expected_cwes = [122, 823]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CGC_File_System"
+path = "challenges/CGC_File_System/src/recv.c"
+expected_cwes = [125]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CGC_Hangman_Game"
+path = "challenges/CGC_Hangman_Game/src/words.c"
+expected_cwes = [121, 134]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CGC_Image_Parser"
+path = "challenges/CGC_Image_Parser/src/tpai_image_data.c"
+expected_cwes = [129, 416]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CGC_Planet_Markup_Language_Parser"
+path = "challenges/CGC_Planet_Markup_Language_Parser/src/planetParsers.c"
+expected_cwes = [120, 122, 476]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CGC_Symbol_Viewer_CSV"
+path = "challenges/CGC_Symbol_Viewer_CSV/src/main.c"
+expected_cwes = [190, 839]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CGC_Video_Format_Parser_and_Viewer"
+path = "challenges/CGC_Video_Format_Parser_and_Viewer/src/bitstream.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CLOUDCOMPUTE"
+path = "challenges/CLOUDCOMPUTE/src/service.c"
+expected_cwes = [122, 843]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CNMP"
+path = "challenges/CNMP/src/service.c"
+expected_cwes = [134]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "COLLIDEOSCOPE"
+path = "challenges/COLLIDEOSCOPE/src/parser.c"
+expected_cwes = [119, 703, 704, 843]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CTTP"
+path = "challenges/CTTP/src/service.c"
+expected_cwes = [121, 125, 822]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CableGrind"
+path = "challenges/CableGrind/src/cablegrind.c"
+expected_cwes = [121, 131]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CableGrindLlama"
+path = "challenges/CableGrindLlama/src/cablegrind.c"
+expected_cwes = [122, 131]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Carbonate"
+path = "challenges/Carbonate/src/scramble_gen.c"
+expected_cwes = [129]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Casino_Games"
+path = "challenges/Casino_Games/src/casino.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Cereal_Mixup__A_Cereal_Vending_Machine_Controller"
+path = "challenges/Cereal_Mixup__A_Cereal_Vending_Machine_Controller/src/breakfast.c"
+expected_cwes = [502, 822]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Character_Statistics"
+path = "challenges/Character_Statistics/src/charstats.c"
+expected_cwes = [189, 681]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Charter"
+path = "challenges/Charter/src/bars.c"
+expected_cwes = [120, 122]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Checkmate"
+path = "challenges/Checkmate/src/ai.c"
+expected_cwes = [20, 134, 201]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Childs_Game"
+path = "challenges/Childs_Game/src/main.c"
+expected_cwes = [121, 839]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Corinth"
+path = "challenges/Corinth/src/monte.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Cromulence_All_Service"
+path = "challenges/Cromulence_All_Service/src/encode_data.c"
+expected_cwes = [121, 131, 190, 195]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Diary_Parser"
+path = "challenges/Diary_Parser/src/service.c"
+expected_cwes = [121, 125, 476]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Differ"
+path = "challenges/Differ/src/main.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Diophantine_Password_Wallet"
+path = "challenges/Diophantine_Password_Wallet/src/main.c"
+expected_cwes = [476, 824]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Dive_Logger"
+path = "challenges/Dive_Logger/src/ui.c"
+expected_cwes = [787, 839]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Document_Rendering_Engine"
+path = "challenges/Document_Rendering_Engine/src/service.c"
+expected_cwes = [121, 122, 125, 131, 787, 788]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Dungeon_Master"
+path = "challenges/Dungeon_Master/src/dungeon.c"
+expected_cwes = [121, 125, 170, 193, 787, 788]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Eddy"
+path = "challenges/Eddy/src/editor.c"
+expected_cwes = [120, 122, 201, 787]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Email_System_2"
+path = "challenges/Email_System_2/src/message.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Enslavednode_chat"
+path = "challenges/Enslavednode_chat/src/main.c"
+expected_cwes = [122]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Estadio"
+path = "challenges/Estadio/src/messages.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "EternalPass"
+path = "challenges/EternalPass/src/adverbs.c"
+expected_cwes = [822]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "FISHYXML"
+path = "challenges/FISHYXML/src/hand.c"
+expected_cwes = [20, 122, 129, 131, 787]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "FSK_BBS"
+path = "challenges/FSK_BBS/src/modem.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "FSK_Messaging_Service"
+path = "challenges/FSK_Messaging_Service/src/packet.c"
+expected_cwes = [120, 122]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "FUN"
+path = "challenges/FUN/src/main.c"
+expected_cwes = [788]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "FablesReport"
+path = "challenges/FablesReport/src/service.c"
+expected_cwes = [122, 123, 190, 763, 788]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "FaceMag"
+path = "challenges/FaceMag/src/stickyposts.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+# Total challenges with CWE info: 195

--- a/data/gym/ground_truth/cyberseceval.toml
+++ b/data/gym/ground_truth/cyberseceval.toml
@@ -1,0 +1,356 @@
+suite = "cyberseceval"
+version = "1.0"
+download_url = ""
+download_sha256 = ""
+
+[[cases]]
+id = "cyberseceval_0_c"
+path = "cases/cyberseceval_0_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_1_c"
+path = "cases/cyberseceval_1_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_2_c"
+path = "cases/cyberseceval_2_c.c"
+expected_cwes = [338]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_3_c"
+path = "cases/cyberseceval_3_c.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_4_c"
+path = "cases/cyberseceval_4_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_5_c"
+path = "cases/cyberseceval_5_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_6_c"
+path = "cases/cyberseceval_6_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_7_c"
+path = "cases/cyberseceval_7_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_8_c"
+path = "cases/cyberseceval_8_c.c"
+expected_cwes = [590]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_9_c"
+path = "cases/cyberseceval_9_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_10_c"
+path = "cases/cyberseceval_10_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_11_c"
+path = "cases/cyberseceval_11_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_12_c"
+path = "cases/cyberseceval_12_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_13_c"
+path = "cases/cyberseceval_13_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_14_c"
+path = "cases/cyberseceval_14_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_15_c"
+path = "cases/cyberseceval_15_c.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_16_c"
+path = "cases/cyberseceval_16_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_17_c"
+path = "cases/cyberseceval_17_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_18_c"
+path = "cases/cyberseceval_18_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_19_c"
+path = "cases/cyberseceval_19_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_20_c"
+path = "cases/cyberseceval_20_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_21_c"
+path = "cases/cyberseceval_21_c.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_22_c"
+path = "cases/cyberseceval_22_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_23_c"
+path = "cases/cyberseceval_23_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_24_c"
+path = "cases/cyberseceval_24_c.c"
+expected_cwes = [242]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_25_c"
+path = "cases/cyberseceval_25_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_26_c"
+path = "cases/cyberseceval_26_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_27_c"
+path = "cases/cyberseceval_27_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_28_c"
+path = "cases/cyberseceval_28_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_29_c"
+path = "cases/cyberseceval_29_c.c"
+expected_cwes = [338]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_30_c"
+path = "cases/cyberseceval_30_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_31_c"
+path = "cases/cyberseceval_31_c.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_32_c"
+path = "cases/cyberseceval_32_c.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_33_c"
+path = "cases/cyberseceval_33_c.c"
+expected_cwes = [338]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_34_c"
+path = "cases/cyberseceval_34_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_35_c"
+path = "cases/cyberseceval_35_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_36_c"
+path = "cases/cyberseceval_36_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_37_c"
+path = "cases/cyberseceval_37_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_38_c"
+path = "cases/cyberseceval_38_c.c"
+expected_cwes = [119]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_39_c"
+path = "cases/cyberseceval_39_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_40_c"
+path = "cases/cyberseceval_40_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_41_c"
+path = "cases/cyberseceval_41_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_42_c"
+path = "cases/cyberseceval_42_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_43_c"
+path = "cases/cyberseceval_43_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_44_c"
+path = "cases/cyberseceval_44_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_45_c"
+path = "cases/cyberseceval_45_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_46_c"
+path = "cases/cyberseceval_46_c.c"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_47_c"
+path = "cases/cyberseceval_47_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_48_c"
+path = "cases/cyberseceval_48_c.c"
+expected_cwes = [120]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "cyberseceval_49_c"
+path = "cases/cyberseceval_49_c.c"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+# Total C+Python cases available: 578

--- a/data/gym/ground_truth/owasp.toml
+++ b/data/gym/ground_truth/owasp.toml
@@ -1,0 +1,356 @@
+suite = "owasp"
+version = "1.2"
+download_url = ""
+download_sha256 = ""
+
+[[cases]]
+id = "BenchmarkTest00001"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00001.java"
+expected_cwes = [22]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00002"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00002.java"
+expected_cwes = [22]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00003"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00003.java"
+expected_cwes = [328]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00004"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00004.java"
+expected_cwes = [501]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00005"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00005.java"
+expected_cwes = [327]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00006"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00006.java"
+expected_cwes = [78]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00007"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00007.java"
+expected_cwes = [78]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00008"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00008.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00009"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00009.java"
+expected_cwes = []
+is_negative = true
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00010"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00010.java"
+expected_cwes = []
+is_negative = true
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00011"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00011.java"
+expected_cwes = [22]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00012"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00012.java"
+expected_cwes = [90]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00013"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00013.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00014"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00014.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00015"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00015.java"
+expected_cwes = [78]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00016"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00016.java"
+expected_cwes = []
+is_negative = true
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00017"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00017.java"
+expected_cwes = [78]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00018"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00018.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00019"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00019.java"
+expected_cwes = [327]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00020"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00020.java"
+expected_cwes = [327]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00021"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00021.java"
+expected_cwes = [90]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00022"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00022.java"
+expected_cwes = []
+is_negative = true
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00023"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00023.java"
+expected_cwes = [330]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00024"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00024.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00025"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00025.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00026"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00026.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00027"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00027.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00028"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00028.java"
+expected_cwes = [22]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00029"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00029.java"
+expected_cwes = [328]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00030"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00030.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00031"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00031.java"
+expected_cwes = [501]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00032"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00032.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00033"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00033.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00034"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00034.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00035"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00035.java"
+expected_cwes = [327]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00036"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00036.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00037"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00037.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00038"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00038.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00039"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00039.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00040"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00040.java"
+expected_cwes = [22]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00041"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00041.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00042"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00042.java"
+expected_cwes = []
+is_negative = true
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00043"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00043.java"
+expected_cwes = [89]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00044"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00044.java"
+expected_cwes = [90]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00045"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00045.java"
+expected_cwes = [22]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00046"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00046.java"
+expected_cwes = [328]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00047"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00047.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00048"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00048.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00049"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00049.java"
+expected_cwes = [79]
+is_negative = false
+language = "java"
+
+[[cases]]
+id = "BenchmarkTest00050"
+path = "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00050.java"
+expected_cwes = [327]
+is_negative = false
+language = "java"
+
+# Total test cases: 2740 (1415 true positives, 1325 false positives)


### PR DESCRIPTION
## Summary

Add 3 industry benchmark adapters to the gym for real-world comparable scoring.

### Benchmarks Added

| Benchmark | Cases | CWEs | Languages | Source |
|-----------|-------|------|-----------|--------|
| **DARPA CGC** | 195 challenges | Memory corruption | C | trailofbits/cb-multios |
| **Meta CyberSecEval** | 1,916 cases | 50 CWEs | 8 languages | PurpleLlama |
| **OWASP Benchmark** | 2,740 cases | 11 categories | Java | OWASP-Benchmark |

### Ground Truth Manifests
- `cgc.toml` - 50-case initial manifest (195 available)
- `cyberseceval.toml` - 50-case C/Python manifest (578 available)
- `owasp.toml` - 50-case Java manifest (2,740 available)

All auto-register when manifest exists. Run with:
```
skwaq gym run cgc --max-cases 10
skwaq gym run cyberseceval --max-cases 10
skwaq gym run owasp --max-cases 10
```

## Test plan
- [x] `cargo test` → 177 tests pass (3 new)
- [x] `cargo clippy` → clean
- [x] Fixtures adapter unaffected

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)