### PR TITLE
feat: Java patterns for OWASP + CWE mapping improvements

### DIFF
--- a/crates/core/src/analysis/patterns_source.rs
+++ b/crates/core/src/analysis/patterns_source.rs
@@ -255,6 +255,93 @@ fn java_patterns() -> &'static [SourcePattern] {
             severity: Severity::Critical,
             reason: "ScriptEngine.eval executes arbitrary code; avoid with untrusted input",
         },
+        // SQL injection patterns
+        SourcePattern {
+            regex: r#"\.execute\w*\s*\([^)]*\+\s*"#,
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason:
+                "SQL query built with string concatenation; use PreparedStatement with parameters",
+        },
+        SourcePattern {
+            regex: r"\.createQuery\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason:
+                "Dynamic query creation may be vulnerable to injection; use parameterized queries",
+        },
+        // XSS patterns
+        SourcePattern {
+            regex: r"\bsetHeader\s*\(\s*.*\+",
+            category: DangerCategory::Xss,
+            severity: Severity::High,
+            reason: "HTTP header set with user input; validate and encode output",
+        },
+        SourcePattern {
+            regex: r"\.getWriter\(\)\.write\s*\(",
+            category: DangerCategory::Xss,
+            severity: Severity::High,
+            reason: "Writing directly to response; encode output to prevent XSS",
+        },
+        SourcePattern {
+            regex: r"\.getWriter\(\)\.println\s*\(",
+            category: DangerCategory::Xss,
+            severity: Severity::High,
+            reason: "Writing directly to response; encode output to prevent XSS",
+        },
+        // Weak cryptography patterns
+        SourcePattern {
+            regex: r#"\bCipher\.getInstance\s*\(\s*"DES"#,
+            category: DangerCategory::Crypto,
+            severity: Severity::High,
+            reason: "DES is a weak cipher; use AES-256-GCM or ChaCha20",
+        },
+        SourcePattern {
+            regex: r#"\bCipher\.getInstance\s*\(\s*".*ECB"#,
+            category: DangerCategory::Crypto,
+            severity: Severity::High,
+            reason: "ECB mode is insecure (no IV, reveals patterns); use GCM or CBC with HMAC",
+        },
+        // Weak hash patterns
+        SourcePattern {
+            regex: r#"\bMessageDigest\.getInstance\s*\(\s*"(MD5|SHA-1|SHA1)""#,
+            category: DangerCategory::Crypto,
+            severity: Severity::High,
+            reason: "MD5/SHA-1 are cryptographically broken; use SHA-256 or SHA-3",
+        },
+        // Weak random
+        SourcePattern {
+            regex: r"\bjava\.util\.Random\b",
+            category: DangerCategory::Crypto,
+            severity: Severity::Medium,
+            reason: "java.util.Random is not cryptographically secure; use SecureRandom",
+        },
+        SourcePattern {
+            regex: r"\bMath\.random\s*\(",
+            category: DangerCategory::Crypto,
+            severity: Severity::Medium,
+            reason: "Math.random is not cryptographically secure; use SecureRandom",
+        },
+        // Path traversal
+        SourcePattern {
+            regex: r"\bnew\s+File\s*\([^)]*getParameter\s*\(",
+            category: DangerCategory::PathTraversal,
+            severity: Severity::High,
+            reason: "File path from user input; validate and canonicalize path",
+        },
+        SourcePattern {
+            regex: r"\bgetRequestDispatcher\s*\([^)]*getParameter",
+            category: DangerCategory::PathTraversal,
+            severity: Severity::High,
+            reason: "Request dispatch with user input; validate path to prevent traversal",
+        },
+        // LDAP injection
+        SourcePattern {
+            regex: r"\bsearch\s*\([^)]*\+.*getParameter",
+            category: DangerCategory::Injection,
+            severity: Severity::High,
+            reason: "LDAP query with user input; use parameterized LDAP queries",
+        },
     ]
 }
 

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -113,13 +113,13 @@ pub fn cwe_family(cwe: u32) -> u32 {
 pub fn category_to_cwes(category: &str) -> Vec<u32> {
     match category {
         "memory" => vec![119, 120, 121, 122, 125, 126, 787, 416, 415, 190, 191],
-        "injection" => vec![78, 89, 90, 94, 77],
+        "injection" => vec![77, 78, 89, 90, 94, 501, 643],
         "format_string" => vec![134],
         "race" => vec![362, 367],
         "temp_file" => vec![377],
         "path_traversal" => vec![22, 23, 36],
         "deserialization" => vec![502],
-        "crypto" => vec![326, 327, 328, 330],
+        "crypto" => vec![326, 327, 328, 330, 338],
         "unsafe_code" => vec![676],
         "prototype_pollution" => vec![1321],
         "xss" => vec![79, 80],


### PR DESCRIPTION
## Summary
Add 13 Java vulnerability patterns targeting OWASP Benchmark categories and update CWE mappings.

**New patterns**: SQL injection (concat), XSS (response writing), weak crypto (DES/ECB), weak hash (MD5/SHA-1), weak random (java.util.Random), path traversal, LDAP injection.

**Updated CWE mappings**: +CWE-338 (weak random), +CWE-501 (trust boundary), +CWE-643 (XPath injection)

**OWASP results**: F1=8.5%, P=100%, R=4.4% (50 cases) — precision perfect, recall improvement needed.

## Test plan
- [x] `cargo test` → 177 tests pass
- [x] `cargo clippy` → clean
- [x] Fixtures F1 unaffected
- [x] OWASP benchmark runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)