### PR TITLE
feat(gym): CGC agentic understanding + zero-pattern fallback

### DIFF
--- a/crates/gym/src/adapters/cgc.rs
+++ b/crates/gym/src/adapters/cgc.rs
@@ -60,7 +60,7 @@ impl BenchmarkAdapter for CgcAdapter {
         &self,
         case: &TestCase,
         data_dir: &Path,
-        _config: &BenchmarkConfig,
+        config: &BenchmarkConfig,
     ) -> anyhow::Result<Vec<DetectedFinding>> {
         // CGC challenges span multiple source files. Analyze ALL .c files
         // in the challenge's src/ directory, not just the one listed in path.
@@ -77,8 +77,14 @@ impl BenchmarkAdapter for CgcAdapter {
                 let entry = entry?;
                 let path = entry.path();
                 if path.extension().and_then(|e| e.to_str()) == Some("c") {
-                    match run_source_pattern_detection(&path) {
-                        Ok(findings) => all_findings.extend(findings),
+                    let findings = if config.quick_mode {
+                        run_source_pattern_detection(&path)
+                    } else {
+                        crate::agentic::run_agentic_source_analysis(&path, config.timeout_secs)
+                            .await
+                    };
+                    match findings {
+                        Ok(f) => all_findings.extend(f),
                         Err(e) => tracing::debug!("CGC file {} failed: {}", path.display(), e),
                     }
                 }
@@ -87,7 +93,13 @@ impl BenchmarkAdapter for CgcAdapter {
 
         // Fallback: analyze just the listed file if directory walk found nothing
         if all_findings.is_empty() && source_path.exists() {
-            all_findings = run_source_pattern_detection(&source_path)?;
+            if config.quick_mode {
+                all_findings = run_source_pattern_detection(&source_path)?;
+            } else {
+                all_findings =
+                    crate::agentic::run_agentic_source_analysis(&source_path, config.timeout_secs)
+                        .await?;
+            }
         }
 
         Ok(all_findings)

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -138,12 +138,23 @@ pub async fn run_agentic_source_analysis(
         return Ok(pattern_findings);
     }
 
+    // When patterns found nothing (e.g. CGC custom APIs like cgc_allocate),
+    // trust LLM-only findings. The LLM can understand non-standard APIs
+    // that patterns don't cover, providing semantic "understanding" over
+    // syntactic matching.
+    let no_patterns = pattern_categories.is_empty();
+
     // Dual-judge: keep findings where the category's CWE family was
     // also found by pattern detection. This means patterns anchor the
     // detection (precision) while LLM provides the semantic validation (recall).
+    // Exception: when patterns found nothing, trust LLM findings directly.
     let confirmed: Vec<DetectedFinding> = all_findings
         .into_iter()
         .filter(|f| {
+            // If patterns found nothing, trust all LLM findings
+            if no_patterns {
+                return true;
+            }
             // Keep if the finding's category was also detected by patterns
             if pattern_categories.contains(&f.category) {
                 return true;


### PR DESCRIPTION
## Summary
- CGC adapter now uses agentic (LLM) analysis in non-quick mode, enabling semantic understanding of custom APIs like `cgc_allocate`, `cgc_receive`, `cgc_read`, `cgc_transmit` that standard regex patterns don't cover
- Agentic dual-judge pipeline falls back to LLM-only findings when pattern detection finds nothing — trusting understanding over pattern matching
- No quick-mode behavior changes: pattern-only benchmarks remain identical

## Motivation
CGC is at F1=0% because challenges use non-standard APIs that patterns can't match. Rather than adding more regex patterns (hitting the pattern ceiling per iteration 5 findings), this enables the LLM pipeline to reason about code semantically.

## Test plan
- [x] All 32 tests pass
- [x] Fixtures benchmark: 100% F1 (unchanged)
- [x] Juliet quick-mode: 94.7% F1 (unchanged)  
- [x] OWASP quick-mode: 85.7% F1 (unchanged)
- [x] CyberSecEval quick-mode: 78.8% F1 (unchanged)
- [ ] CGC full-mode with LLM: expected improvement from 0%

Relates to #70, #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)