### PR TITLE
docs: update dashboard with Cycle 6 multi-suite benchmark results

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,19 +47,19 @@
 
         <div class="stats">
             <div class="stat">
-                <div class="value">92.9%</div>
-                <div class="label">F1 Score (Pattern Mode)</div>
+                <div class="value">81.0%</div>
+                <div class="label">Juliet F1 (Pattern Mode)</div>
             </div>
             <div class="stat">
                 <div class="value">100%</div>
-                <div class="label">Precision</div>
+                <div class="label">Precision (All Suites)</div>
             </div>
             <div class="stat">
-                <div class="value">9</div>
-                <div class="label">Specialist Agents</div>
+                <div class="value">6,675</div>
+                <div class="label">Benchmark Cases</div>
             </div>
             <div class="stat">
-                <div class="value">174</div>
+                <div class="value">183</div>
                 <div class="label">Tests Passing</div>
             </div>
         </div>
@@ -83,7 +83,22 @@
                 <tr><td>+improved hunter</td><td>Full (LLM)</td><td>27.3%</td><td>15.8%</td><td>100.0%</td><td>5/5</td><td>Prompt refinement</td></tr>
                 <tr><td>Dual-Judge</td><td>Full (LLM)</td><td>66.7%</td><td>50.0%</td><td>100.0%</td><td>5/5</td><td>-81% FPs</td></tr>
                 <tr><td>+query expansion</td><td>Full (LLM)</td><td>66.7%</td><td>50.0%</td><td>100.0%</td><td>5/5</td><td>0 unsupported warnings</td></tr>
-                <tr style="background:#3fb95022"><td>Enriched GT</td><td>Patterns</td><td><strong>92.9%</strong></td><td><strong>100.0%</strong></td><td>86.7%</td><td>8/10</td><td>0 false positives</td></tr>
+                <tr><td>Enriched GT</td><td>Patterns</td><td>92.9%</td><td>100.0%</td><td>86.7%</td><td>8/10</td><td>0 false positives</td></tr>
+                <tr style="background:#3fb95022"><td>Cycle 6: Per-CWE Dedup</td><td>Patterns</td><td><strong>81.0%</strong></td><td><strong>100.0%</strong></td><td>68.0%</td><td>112 CWEs</td><td>Juliet +32pp, CGC first score</td></tr>
+            </tbody>
+        </table>
+
+        <h2>Multi-Suite Benchmark Results (Cycle 6)</h2>
+        <table>
+            <thead>
+                <tr><th>Suite</th><th>Cases</th><th>F1</th><th>Precision</th><th>Recall</th><th>TP</th><th>FP</th><th>FN</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>Fixtures</td><td>7</td><td><strong>100.0%</strong></td><td>100.0%</td><td>100.0%</td><td>15</td><td>0</td><td>0</td></tr>
+                <tr><td>OWASP</td><td>2,740</td><td><strong>85.7%</strong></td><td>100.0%</td><td>75.0%</td><td>96</td><td>0</td><td>32</td></tr>
+                <tr><td>Juliet</td><td>3,288</td><td><strong>81.0%</strong></td><td>100.0%</td><td>68.0%</td><td>340</td><td>0</td><td>160</td></tr>
+                <tr><td>CGC</td><td>204</td><td><strong>42.9%</strong></td><td>100.0%</td><td>27.3%</td><td>30</td><td>0</td><td>80</td></tr>
+                <tr><td>CyberSecEval</td><td>443</td><td><strong>11.3%</strong></td><td>100.0%</td><td>6.0%</td><td>3</td><td>0</td><td>47</td></tr>
             </tbody>
         </table>
 
@@ -152,7 +167,10 @@
 
         <h3>Benchmarks</h3>
         <p><strong>Fixtures:</strong> 7 hand-crafted test cases (C, Python, JavaScript) covering 5 CWE families: buffer overflow (CWE-121), command injection (CWE-78), format string (CWE-134), integer overflow (CWE-190), use-after-free (CWE-416).</p>
-        <p><strong>NIST Juliet:</strong> 45,324 test cases across 116 CWEs (adapter implemented, data download pending).</p>
+        <p><strong>NIST Juliet:</strong> 3,288 test cases across 112 CWEs from the Juliet C/C++ 1.3 suite.</p>
+        <p><strong>OWASP Benchmark:</strong> 2,740 Java test cases across 11 vulnerability categories (BenchmarkJava 1.2).</p>
+        <p><strong>DARPA CGC:</strong> 204 challenges from the Cyber Grand Challenge cb-multios corpus.</p>
+        <p><strong>CyberSecEval:</strong> 443 C + Python test cases from Meta's PurpleLlama CybersecurityBenchmarks.</p>
 
         <h3>Scoring</h3>
         <p>Standard information retrieval metrics: Precision = TP/(TP+FP), Recall = TP/(TP+FN), F1 = harmonic mean. CWE-family matching allows CWE-121 findings to match CWE-119 ground truth (same vulnerability family).</p>
@@ -168,11 +186,11 @@
         new Chart(ctx, {
             type: 'line',
             data: {
-                labels: ['Baseline', '+Patterns', '+Orchestrator', '+LLM', '+Verdict', '+Hunter', 'Dual-Judge', '+Tools', 'Enriched GT'],
+                labels: ['Baseline', '+Patterns', '+Orchestrator', '+LLM', '+Verdict', '+Hunter', 'Dual-Judge', '+Tools', 'Enriched GT', 'Cycle 6'],
                 datasets: [
                     {
                         label: 'F1 Score',
-                        data: [50, 76.2, 58.8, 31.1, 21.1, 27.3, 66.7, 66.7, 92.9],
+                        data: [50, 76.2, 58.8, 31.1, 21.1, 27.3, 66.7, 66.7, 92.9, 81.0],
                         borderColor: '#58a6ff',
                         backgroundColor: '#58a6ff22',
                         tension: 0.3,
@@ -180,13 +198,13 @@
                     },
                     {
                         label: 'Precision',
-                        data: [66.7, 66.7, 41.7, 18.4, 11.8, 15.8, 50, 50, 100],
+                        data: [66.7, 66.7, 41.7, 18.4, 11.8, 15.8, 50, 50, 100, 100],
                         borderColor: '#3fb950',
                         tension: 0.3,
                     },
                     {
                         label: 'Recall',
-                        data: [40, 88.9, 100, 100, 100, 100, 100, 100, 86.7],
+                        data: [40, 88.9, 100, 100, 100, 100, 100, 100, 86.7, 68.0],
                         borderColor: '#f85149',
                         tension: 0.3,
                     },


### PR DESCRIPTION
## Summary
- Update docs/index.html with Cycle 6 benchmark results across all 5 suites
- Add new multi-suite results table showing F1, precision, recall, TP/FP/FN for each suite
- Update trajectory chart with Cycle 6 data point
- Update benchmark descriptions with actual case counts

## Benchmark Results
| Suite | Cases | F1 | Precision | Recall |
|-------|-------|-----|-----------|--------|
| Fixtures | 7 | **100.0%** | 100% | 100% |
| OWASP | 2,740 | **85.7%** | 100% | 75.0% |
| Juliet | 3,288 | **81.0%** | 100% | 68.0% |
| CGC | 204 | **42.9%** | 100% | 27.3% |
| CyberSecEval | 443 | **11.3%** | 100% | 6.0% |

## Test plan
- [x] Dashboard renders correctly with new data
- [x] Chart.js data points aligned

Part of #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)