### PR TITLE
feat: add LLM binary vuln detection skill and enhance agents

### DIFF
--- a/agents/decompile-analyst.md
+++ b/agents/decompile-analyst.md
@@ -14,21 +14,32 @@ You are DecompileAnalyst, a specialist in analyzing decompiled binary code. You 
 Your analysis process:
 1. Query for functions in the investigation
 2. Read the decompiled code of each function
-3. Analyze the decompiled code for vulnerability patterns
-4. Search for similar code patterns across the codebase
+3. **Optimize your understanding**: Before analyzing for vulnerabilities, mentally reconstruct the code:
+   - Infer meaningful variable names from usage context (e.g., `param_1` used as a size → `buf_size`)
+   - Identify struct layouts from field access patterns
+   - Recognize compiler-generated code vs programmer-written code
+4. Analyze the optimized mental model for vulnerability patterns
+5. Search for similar code patterns across the codebase
 
 Focus on identifying:
 - Stack buffer operations that may overflow (local arrays with unchecked copies)
 - Heap operations without proper size validation
 - Type confusion from decompiler artifacts vs actual vulnerabilities
 - Reconstructed control flow that reveals exploitable conditions
-- Inlined function calls that obscure dangerous operations
+- Inlined function calls that obscure dangerous operations (compiler may inline strcpy, memcpy)
 - Compiler-generated code vs programmer-written code
+- Security-sensitive memset/bzero removed by dead store elimination (CWE-14)
+- Integer truncation on casts before allocation (64→32 bit, CWE-197)
 
 When analyzing decompiled code, account for:
 - Decompiler confidence levels (low confidence may indicate complex or obfuscated code)
-- Variable naming artifacts (var_1, param_1, etc.)
+- Variable naming artifacts (var_1, param_1, etc.) — these obscure semantics but are not themselves bugs
 - Reconstructed types that may not match the original source
 - Optimized-away checks that the compiler removed
+- Tail call optimization blurring function boundaries
+- Loop unrolling that may partially eliminate bounds checks
+- Inlined library calls that look like custom code
 
-Report your findings with clear distinction between high-confidence issues (clear vulnerability pattern) and low-confidence issues (suspicious pattern that needs manual review).
+**Evidence standard**: For every finding, cite the specific function, the relevant decompiled code excerpt, and explain why it is a real vulnerability rather than a decompiler artifact.
+
+Report your findings with clear distinction between high-confidence issues (clear vulnerability pattern with evidence) and low-confidence issues (suspicious pattern that needs manual review).

--- a/agents/taint-tracer.md
+++ b/agents/taint-tracer.md
@@ -25,6 +25,14 @@ Focus on:
 - External data reaching format string arguments (format string vulnerability)
 - Untrusted data reaching SQL query construction (SQL injection)
 - File content reaching memory allocation sizes (integer overflow)
+- recv/read data reaching stack buffers without length validation (firmware pattern)
+- Environment variables reaching dlopen/LoadLibrary paths (CWE-427)
+- Attacker-controlled integers feeding realloc/malloc sizes (CWE-190)
+
+When tracing through decompiled code, be aware that:
+- Compiler inlining may hide function boundaries — a taint path may pass through inlined code without a call graph edge
+- Tail call optimization may make callee appear as part of caller
+- Optimized builds may eliminate intermediate variables, making taint propagation less visible
 
 For each traced path, report:
 - Source function and type
@@ -32,3 +40,4 @@ For each traced path, report:
 - Intermediate functions in the path
 - Whether any sanitization was observed
 - The risk level of the unsanitized flow
+- Confidence level (high if clear data flow, low if inferred through complex control flow)

--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -19,26 +19,38 @@ You are VulnHunter, a senior vulnerability researcher at a top security firm. Yo
 
 1. **Map the attack surface**: Query the graph for functions, identify entry points (main, exported functions, callbacks), and map external interfaces (network, file, stdin, env vars).
 
-2. **Identify dangerous operations**: Query for known dangerous functions (strcpy, sprintf, gets, system, exec, free, malloc, atoi). Note their locations.
+2. **Assess decompiled code quality**: When reading decompiled code, account for:
+   - Decompiler artifacts (var_1, param_1 naming) — these obscure semantics but do not indicate bugs
+   - Compiler optimizations (-O2/-O3) that inline functions, unroll loops, or eliminate dead stores
+   - Inlined dangerous calls that are harder to spot than direct API usage
+   - Security-relevant memset/bzero that may have been optimized away (CWE-14)
 
-3. **Trace data flow for EACH dangerous operation**:
+3. **Identify dangerous operations**: Query for known dangerous functions (strcpy, sprintf, gets, system, exec, free, malloc, atoi, memcpy, realloc, dlopen). Also look for:
+   - Indirect patterns: inlined copies, manual byte-by-byte loops without bounds
+   - Integer arithmetic feeding allocation sizes (CWE-190)
+   - Signed/unsigned comparison in bounds checks (CWE-681)
+   - Firmware-specific: hardcoded credentials in .rodata, recv/read into stack buffers without length checks
+
+4. **Trace data flow for EACH dangerous operation**:
    - Use get_callers to trace backwards: WHO calls this function?
    - Is the caller reachable from untrusted input (user input, network, file)?
    - Use read_function to examine the actual code around the dangerous call
    - Is the dangerous parameter controlled by the attacker?
+   - Check for sanitization along the path (bounds checks, input validation, safe wrappers)
 
-4. **Apply the THREE-QUESTION TEST before creating ANY finding**:
+5. **Apply the THREE-QUESTION TEST before creating ANY finding**:
    - Q1: Can an attacker REACH this code from an external entry point?
    - Q2: Can an attacker CONTROL the specific input that triggers the vulnerability?
    - Q3: If triggered, does it cause REAL HARM (code execution, data corruption, info leak)?
 
    **If ANY answer is NO, DO NOT create a finding.**
 
-5. **Only use create_finding for HIGH-CONFIDENCE vulnerabilities** where:
+6. **Only use create_finding for HIGH-CONFIDENCE vulnerabilities** where:
    - You have read the actual code (not just seen a function name)
    - You can describe the specific attack path (source → ... → sink)
    - The vulnerability is in the code being analyzed (not in a library)
    - You have a specific CWE classification backed by evidence
+   - You cite the exact code location (function name, relevant lines) as evidence
 
 **What NOT to report:**
 - A function named "strcpy" existing somewhere (that's a pattern, not a vulnerability)

--- a/prompts/vuln_hunter.md
+++ b/prompts/vuln_hunter.md
@@ -9,9 +9,16 @@ You have access to these tools:
 
 Your analysis process:
 1. Start by examining the attack surface (entry points, network listeners, parsers)
-2. Trace data flow from untrusted inputs to dangerous operations
-3. Look for: buffer overflows, format strings, injection, use-after-free, integer overflows
-4. For each potential vulnerability, verify the evidence
-5. Create findings with specific evidence (function name, address, code excerpt)
+2. Read decompiled code carefully — distinguish decompiler artifacts from real vulnerabilities
+3. Trace data flow from untrusted inputs to dangerous operations
+4. Look for: buffer overflows, format strings, injection, use-after-free, integer overflows, command injection
+5. Also check for: inlined dangerous calls, compiler-eliminated security checks (dead store of sensitive data), integer truncation before allocation, signed/unsigned confusion in bounds checks
+6. For each potential vulnerability, verify the evidence using the THREE-QUESTION TEST:
+   - Can an attacker REACH this code?
+   - Can they CONTROL the vulnerable input?
+   - Does it cause REAL HARM?
+7. Create findings with specific evidence (function name, address, code excerpt, data flow path)
+
+Evidence standard: Every finding MUST cite the exact code location and quote the relevant decompiled lines. Do not create findings based only on function names or API presence — you must demonstrate attacker-controlled data reaching the vulnerable operation.
 
 Be precise. Every finding must include evidence. Do not guess.

--- a/skills/llm-binary-vuln-guide/SKILL.md
+++ b/skills/llm-binary-vuln-guide/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: llm-binary-vuln-guide
+description: Reference guide for LLM-based vulnerability detection in binary code. Provides best practices, techniques, and prompting strategies for using LLMs to find vulnerabilities in stripped binaries, firmware, and decompiled code. Use when analyzing binaries with AI, writing vulnerability analysis prompts, or optimizing detection pipelines.
+user-invocable: false
+---
+
+# LLM-Based Binary Vulnerability Detection Guide
+
+This skill provides research-backed techniques for using LLMs to detect
+vulnerabilities in binary code. It is loaded automatically when skwaq agents
+perform binary analysis to enhance their effectiveness.
+
+## Core Principle: Decompilation First
+
+LLMs cannot effectively reason about raw bytes or assembly. Always decompile to
+pseudo-C before LLM analysis. Raw assembly has 98% cosine similarity across
+different CWE types, making classification impossible without lifting.
+
+**Pipeline**: Binary → Disassembly → Decompilation (Ghidra) → LLM Enhancement → Vulnerability Analysis
+
+## Decompiled Code Optimization
+
+Before sending decompiled output to an LLM, optimize it:
+
+1. **Variable renaming**: Replace `var_1`, `param_1` with meaningful names inferred from usage context
+2. **Type recovery**: Infer struct layouts, array sizes, and pointer types from access patterns
+3. **Code restructuring**: Normalize control flow flattened by optimization
+4. **Vulnerability annotation**: Mark dangerous API calls, unchecked arithmetic, and trust boundaries
+
+This preprocessing step alone can improve detection accuracy by 20-40% (VulBinLLM, 2025).
+
+## The Two-Prompt Strategy for Patch Diffing
+
+For analyzing patches between binary versions (Bishop Fox, 2025):
+
+**Prompt 1 (Characterization)**:
+- Provide decompiled functions from both versions
+- Ask the LLM to suggest function names, summarize purpose, and describe changes
+
+**Prompt 2 (Ranking)**:
+- Provide security advisory text plus Prompt 1 output
+- Ask the LLM to rank functions by relevance to the advisory
+
+This places vulnerable functions in the Top 5 results 100% of the time.
+
+## Evidence-First Prompting
+
+When analyzing decompiled code, require the LLM to:
+- Back every claim with a quote from the code, including function name and offset
+- Avoid cosmetic rewriting — verify findings against actual code
+- Distinguish decompiler artifacts from real vulnerabilities
+- Explicitly state confidence level per finding
+
+## Function-Level Analysis with Memory Management
+
+Large binaries exceed context windows. Use a function analysis queue:
+
+1. **Prioritize**: Rank functions by attack surface exposure × sink danger
+2. **Analyze individually**: One function per LLM call with relevant caller/callee context
+3. **Archive summaries**: Store per-function summaries for cross-function reasoning
+4. **Second pass**: Re-analyze high-risk functions with enriched cross-function context
+
+## Hybrid Analysis: LLM + Traditional Tools
+
+The highest-quality results combine LLMs with traditional analysis. Key combinations:
+
+| LLM Strength | Traditional Tool | Combined Approach |
+|---|---|---|
+| Semantic reasoning | Fuzzing (AFL, libFuzzer) | Fuzzer finds crash sites, LLM reasons about root cause (FirmAgent: 91% precision) |
+| Pattern recognition | Symbolic execution (angr) | LLM predicts vulnerable paths, symbex verifies reachability |
+| Code understanding | Taint analysis | LLM generates taint propagation rules automatically (LATTE: 37 zero-days) |
+| Natural language | SARIF/CodeQL | LLM enriches static analysis findings with exploitability assessment |
+
+## Dangerous API Patterns in Decompiled Code
+
+When reviewing decompiled code, look for these patterns that frequently indicate vulnerabilities:
+
+### Memory Corruption
+- `strcpy`/`strcat` with non-constant source (CWE-120)
+- `sprintf` with `%s` and user-influenced argument (CWE-134)
+- `memcpy` where size derives from attacker-controlled data (CWE-122)
+- `malloc` with attacker-influenced size followed by unchecked copy (CWE-122)
+- `realloc` to zero (implementation-defined free, CWE-131)
+
+### Use-After-Free / Double-Free
+- `free()` followed by access through aliased pointer (CWE-416)
+- `free()` in error path, then again in cleanup (CWE-415)
+- Pointer stored in global/struct, freed locally, accessed later (CWE-416)
+
+### Integer Issues
+- `atoi`/`strtol` result used as allocation size without range check (CWE-190)
+- Signed/unsigned comparison in bounds checks (CWE-681)
+- Integer truncation on 64→32 bit cast before allocation (CWE-197)
+
+### Command / Code Injection
+- `system()` with user-influenced argument (CWE-78)
+- `exec*()` family with unsanitized path or arguments (CWE-78)
+- `dlopen`/`LoadLibrary` with user-controlled path (CWE-427)
+
+### Firmware / IoT Specific
+- Hardcoded credentials in `.rodata` section (CWE-798)
+- Default keys/IVs adjacent to crypto function calls (CWE-321)
+- `recv`/`read` directly into stack buffer without length check (CWE-120)
+- UART/serial handlers with no authentication (CWE-306)
+
+## Compiler Optimization Awareness
+
+Decompiled code from optimized binaries (-O2, -O3) exhibits patterns that can
+confuse LLMs:
+
+- **Inlined functions**: Dangerous calls may be inlined and harder to spot
+- **Loop unrolling**: Bounds checks may be partially eliminated by the compiler
+- **Dead store elimination**: Security-relevant memset/bzero of sensitive data may be optimized away (CWE-14)
+- **Tail call optimization**: Function boundaries may not match source, affecting call graph analysis
+
+## Prompting Tips for Binary Vulnerability Analysis
+
+1. **Never label code as "malicious"** in the prompt — it introduces analytical bias
+2. **Provide CWE definitions** in context for the CWE categories relevant to the binary type
+3. **Use explicit iteration**: Force processing of all functions using count/offset — local models stop after ~12 functions otherwise
+4. **Decompose for local models**: Cloud models handle comprehensive prompts; local models need smaller, focused tasks
+5. **Include caller/callee context**: A function is only vulnerable if reachable from untrusted input — always provide call chain context
+6. **Specify architecture**: ARM vs x86 vs MIPS decompilation has different artifacts and calling conventions
+
+## Model Selection Guidance
+
+| Use Case | Recommended | Notes |
+|---|---|---|
+| Deep vulnerability reasoning | Cloud (Claude Opus/Sonnet) | Best accuracy, $1-35/analysis |
+| Function naming/typing | Specialized (LLM4Decompile, ReCopilot) | 13%+ improvement over general LLMs |
+| Air-gapped/offline | Ollama (Qwen3:32b, Devstral 24b) | Free, slower, less thorough |
+| Batch triage | Cloud (fast tier) | Balance cost and throughput |
+
+Code-specific LLMs outperform general-purpose LLMs by 76.45% on binary analysis
+tasks (BinMetric, IJCAI 2025).
+
+## False Positive Management
+
+LLMs generate more false positives than traditional static analyzers. Mitigate by:
+
+1. **Three-Question Test**: Can attacker REACH it? CONTROL the input? Cause REAL HARM?
+2. **Multi-agent validation**: VulnHunter finds → Critic validates → only concordant findings reported
+3. **Evidence requirement**: Every finding must cite specific code, address, and data flow
+4. **Confidence scoring**: Flag low-confidence findings separately for human triage
+5. **Decompiler artifact filtering**: Distinguish real vulnerabilities from decompiler noise
+
+## Key References
+
+- VulBinLLM (2025): LLM framework for stripped binary vuln detection — https://arxiv.org/html/2505.22010
+- LATTE (2025): LLM-powered static binary taint analysis, 37 zero-days — https://dl.acm.org/doi/10.1145/3711816
+- FirmAgent (NDSS 2026): Fuzzing + LLM for IoT firmware, 91% precision — https://www.ndss-symposium.org/ndss-paper/firmagent-leveraging-fuzzing-to-assist-llm-agents-with-iot-firmware-vulnerability-discovery/
+- ClearAgent (2025): Agentic binary analysis framework — https://dl.acm.org/doi/10.1145/3759425.3763397
+- LLM4Decompile (2024-2025): Open-source decompilation models — https://github.com/albertan017/LLM4Decompile
+- Bishop Fox (2025): LLM-powered patch diffing — https://bishopfox.com/blog/vulnerability-discovery-with-llm-powered-patch-diffing
+- BinMetric (IJCAI 2025): Binary analysis benchmark — https://arxiv.org/html/2505.07360v1
+- DeGPT (NDSS 2024): Decompiler output optimization — https://www.ndss-symposium.org/wp-content/uploads/2024-401-paper.pdf
+- Cisco Talos (2025): LLMs as RE sidekick — https://blog.talosintelligence.com/using-llm-as-a-reverse-engineering-sidekick/
+- Check Point (2025): Generative AI for RE — https://research.checkpoint.com/2025/generative-ai-for-reverse-engineering/
+- NCC Group (2025): AI vs traditional static analysis — https://www.nccgroup.com/research-blog/comparing-ai-against-traditional-static-analysis-tools-to-highlight-buffer-overflows/


### PR DESCRIPTION
## Summary

- **New skill**: `llm-binary-vuln-guide` — research-backed reference guide for LLM-based vulnerability detection in binary code. Auto-loaded during binary analysis to enhance agent effectiveness.
- **Enhanced vuln-hunter agent**: Added decompiled code quality assessment, compiler optimization awareness, expanded dangerous API detection (firmware, integer issues), evidence citation requirements.
- **Enhanced decompile-analyst agent**: Added VulBinLLM-inspired code optimization approach, dead store elimination and integer truncation detection, stronger evidence standards.
- **Enhanced taint-tracer agent**: Added compiler artifact awareness, firmware-specific taint patterns (recv→stack buffer, env→dlopen), confidence levels.
- **Enhanced vuln_hunter prompt**: Added THREE-QUESTION TEST, evidence-first standard, expanded vulnerability categories.

### Research Sources

Synthesized from 20+ academic papers, industry blog posts, and tools (2024-2026):
- VulBinLLM (2025), LATTE/TOSEM (2025), FirmAgent (NDSS 2026), ClearAgent (2025)
- Bishop Fox patch diffing (2025), Cisco Talos RE sidekick (2025)
- LLM4Decompile, BinMetric (IJCAI 2025), DeGPT (NDSS 2024)
- NCC Group, Check Point Research, and more

### How It Works

The new skill (`user-invocable: false`) is auto-discovered by the skill system and provides reference knowledge that agents can draw on during binary vulnerability analysis. No Rust code changes — only markdown skill/agent definitions.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (32/32 tests)
- [x] `skwaq skills list` shows the new skill (8 skills total)
- [ ] Run binary analysis benchmarks to compare quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)