### PR TITLE
feat(gym): parallel benchmarks (--concurrency + --skip + parallel-gym.sh)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,6 +3435,7 @@ dependencies = [
  "chrono",
  "dirs",
  "flate2",
+ "futures",
  "indicatif",
  "rayon",
  "regex",

--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -25,6 +25,15 @@ pub enum GymSub {
         #[arg(long)]
         quick: bool,
 
+        /// Skip the first N cases (for multi-process parallelism)
+        #[arg(long, default_value = "0")]
+        skip: usize,
+
+        /// Number of cases to analyze concurrently (in-process async parallelism).
+        /// Default 4 for hybrid mode, 1 for quick mode.
+        #[arg(long, short = 'j')]
+        concurrency: Option<usize>,
+
         /// Analyze source code only, skip binary analysis (binary is the default for C cases)
         #[arg(long)]
         source_only: bool,
@@ -83,6 +92,8 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
             cwe,
             max_cases,
             quick,
+            skip,
+            concurrency,
             source_only,
             json,
             markdown,
@@ -92,12 +103,16 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
                 .map(|c| parse_cwe_number(c).map(|n| vec![n]))
                 .transpose()?;
             let binary_mode = !*source_only;
+            // Default concurrency: 4 for hybrid mode, 1 for quick mode
+            let conc = concurrency.unwrap_or(if *quick { 1 } else { 4 });
             gym.run(
                 suite.as_deref(),
                 cwe_filter,
                 *max_cases,
                 *quick,
                 binary_mode,
+                *skip,
+                conc,
             )
             .await?;
 
@@ -137,6 +152,8 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
                 quick_mode: true,
                 binary_mode: false,
                 parallelism: 4,
+                skip: 0,
+                concurrency: 1,
                 timeout_secs: 30,
             };
 

--- a/crates/gym/Cargo.toml
+++ b/crates/gym/Cargo.toml
@@ -26,6 +26,7 @@ tar = "0.4"
 zip = "2"
 walkdir = "2"
 rayon = "1"
+futures = "0.3"
 indicatif = "0.17"
 regex = "1"
 

--- a/crates/gym/src/adapters/fixtures.rs
+++ b/crates/gym/src/adapters/fixtures.rs
@@ -126,6 +126,8 @@ mod tests {
             quick_mode: true,
             binary_mode: false,
             parallelism: 1,
+            skip: 0,
+            concurrency: 1,
             timeout_secs: 30,
         }
     }
@@ -225,6 +227,8 @@ mod tests {
             quick_mode: true,
             binary_mode: true,
             parallelism: 1,
+            skip: 0,
+            concurrency: 1,
             timeout_secs: 30,
         }
     }

--- a/crates/gym/src/adapters/mod.rs
+++ b/crates/gym/src/adapters/mod.rs
@@ -27,6 +27,10 @@ pub struct BenchmarkConfig {
     pub binary_mode: bool,
     /// Number of parallel compilation/analysis jobs.
     pub parallelism: usize,
+    /// Number of cases to skip (for multi-process parallelism).
+    pub skip: usize,
+    /// Number of cases to run concurrently (in-process async parallelism).
+    pub concurrency: usize,
     /// Per-case timeout in seconds.
     pub timeout_secs: u64,
 }

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -13,6 +13,9 @@ pub mod improve;
 pub mod reporting;
 pub mod scoring;
 
+use futures::stream::{FuturesUnordered, StreamExt};
+use std::pin::Pin;
+
 use adapters::{BenchmarkAdapter, BenchmarkConfig};
 use history::HistoryDb;
 use std::path::PathBuf;
@@ -97,6 +100,8 @@ impl Gym {
             quick_mode: false,
             binary_mode: true, // Binary analysis is the default for cases with binary_path
             parallelism: 4,
+            skip: 0,
+            concurrency: 1,
             timeout_secs: 1800,
         };
 
@@ -127,6 +132,7 @@ impl Gym {
     /// By default, runs full analysis (pattern detection + AI agents).
     /// Pass `quick_only=true` to use pattern-only mode (faster, no LLM).
     /// Pass `binary_mode=true` to analyze compiled binaries instead of source.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run(
         &mut self,
         suite: Option<&str>,
@@ -134,6 +140,8 @@ impl Gym {
         max_cases: Option<usize>,
         quick_only: bool,
         binary_mode: bool,
+        skip: usize,
+        concurrency: usize,
     ) -> anyhow::Result<()> {
         let commit = get_git_commit(&self.skwaq_root)?;
 
@@ -161,6 +169,8 @@ impl Gym {
             config.timeout_secs = 1800;
         }
         config.binary_mode = binary_mode;
+        config.skip = skip;
+        config.concurrency = concurrency.max(1);
 
         for adapter in adapters {
             let suite_name = adapter.name().to_string();
@@ -170,7 +180,7 @@ impl Gym {
             let gt = adapter.ground_truth()?;
             let data_dir = adapter.setup(&config).await?;
 
-            let cases: Vec<_> = gt
+            let cases: Vec<&ground_truth::TestCase> = gt
                 .cases
                 .iter()
                 .filter(|c| {
@@ -179,34 +189,133 @@ impl Gym {
                             || c.expected_cwes.is_empty()
                     })
                 })
+                .skip(config.skip)
                 .take(config.max_cases.unwrap_or(usize::MAX))
                 .collect();
 
-            let mut outcomes = Vec::new();
             let total = cases.len();
+            let concurrency = config.concurrency;
 
-            for (i, case) in cases.iter().enumerate() {
-                if i % 100 == 0 && i > 0 {
-                    tracing::info!("[{}/{}] Processing {}", i, total, case.id);
+            tracing::info!(
+                "{}: {} cases (skip={}, concurrency={})",
+                suite_name,
+                total,
+                config.skip,
+                concurrency
+            );
+
+            // Run cases with in-process async concurrency.
+            // Each case creates its own in-memory GraphDb, so no shared state.
+            // Concurrency > 1 lets multiple LLM API calls overlap (network I/O).
+            let mut outcomes = Vec::with_capacity(total);
+            let timeout_secs = config.timeout_secs;
+
+            if concurrency <= 1 {
+                // Sequential mode (original behavior)
+                for (i, case) in cases.iter().enumerate() {
+                    if i % 10 == 0 && i > 0 {
+                        tracing::info!("[{}/{}] Processing {}", i, total, case.id);
+                    }
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(timeout_secs),
+                        adapter.run_case(case, &data_dir, &config),
+                    )
+                    .await
+                    {
+                        Ok(Ok(findings)) => {
+                            let mut outcome = scoring::score_case(case, &findings, &|f| {
+                                adapter.map_finding_to_cwes(f)
+                            });
+                            outcome.suite = suite_name.clone();
+                            outcomes.push(outcome);
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!("Case {} failed: {}", case.id, e);
+                        }
+                        Err(_) => {
+                            tracing::warn!("Case {} timed out after {}s", case.id, timeout_secs);
+                        }
+                    }
                 }
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(config.timeout_secs),
-                    adapter.run_case(case, &data_dir, &config),
-                )
-                .await
-                {
-                    Ok(Ok(findings)) => {
-                        let mut outcome = scoring::score_case(case, &findings, &|f| {
-                            adapter.map_finding_to_cwes(f)
-                        });
-                        outcome.suite = suite_name.clone();
-                        outcomes.push(outcome);
+            } else {
+                // Concurrent mode: run N cases at once using FuturesUnordered.
+                // On a single-threaded runtime, this interleaves at await points
+                // (network I/O), giving true concurrency on LLM API calls.
+                // Each case gets its own in-memory GraphDb, so no shared state.
+                type CaseResult<'a> = (
+                    usize,
+                    &'a ground_truth::TestCase,
+                    String,
+                    Result<
+                        anyhow::Result<Vec<adapters::DetectedFinding>>,
+                        tokio::time::error::Elapsed,
+                    >,
+                );
+
+                let data_dir = &data_dir;
+                let config = &config;
+
+                let mut pending: FuturesUnordered<
+                    Pin<Box<dyn std::future::Future<Output = CaseResult<'_>>>>,
+                > = FuturesUnordered::new();
+                let mut case_iter = cases.iter().enumerate();
+                let mut completed = 0usize;
+
+                // Seed the initial batch
+                for _ in 0..concurrency {
+                    if let Some((i, &case)) = case_iter.next() {
+                        let suite = suite_name.clone();
+                        pending.push(Box::pin(async move {
+                            let result = tokio::time::timeout(
+                                std::time::Duration::from_secs(timeout_secs),
+                                adapter.run_case(case, data_dir, config),
+                            )
+                            .await;
+                            (i, case, suite, result)
+                        }));
                     }
-                    Ok(Err(e)) => {
-                        tracing::warn!("Case {} failed: {}", case.id, e);
+                }
+
+                // Process completions and feed new cases
+                while let Some((i, case, suite, result)) = pending.next().await {
+                    completed += 1;
+                    if completed.is_multiple_of(10) {
+                        tracing::info!("[{}/{}] Completed {}", completed, total, case.id);
                     }
-                    Err(_) => {
-                        tracing::warn!("Case {} timed out after {}s", case.id, config.timeout_secs);
+
+                    match result {
+                        Ok(Ok(findings)) => {
+                            let mut outcome = scoring::score_case(case, &findings, &|f| {
+                                adapter.map_finding_to_cwes(f)
+                            });
+                            outcome.suite = suite;
+                            outcomes.push(outcome);
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!("[{}/{}] Case {} failed: {}", i, total, case.id, e);
+                        }
+                        Err(_) => {
+                            tracing::warn!(
+                                "[{}/{}] Case {} timed out after {}s",
+                                i,
+                                total,
+                                case.id,
+                                timeout_secs
+                            );
+                        }
+                    }
+
+                    // Feed next case into the pool
+                    if let Some((next_i, &next_case)) = case_iter.next() {
+                        let suite = suite_name.clone();
+                        pending.push(Box::pin(async move {
+                            let result = tokio::time::timeout(
+                                std::time::Duration::from_secs(timeout_secs),
+                                adapter.run_case(next_case, data_dir, config),
+                            )
+                            .await;
+                            (next_i, next_case, suite, result)
+                        }));
                     }
                 }
             }

--- a/scripts/parallel-gym.sh
+++ b/scripts/parallel-gym.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# parallel-gym.sh — Run gym benchmarks across N parallel processes.
+#
+# Each process handles a slice of cases using --skip and --max-cases.
+# Results are written to separate JSON files, then merged.
+#
+# Usage:
+#   ./scripts/parallel-gym.sh <suite> <total_cases> <num_procs> [extra_args...]
+#
+# Examples:
+#   # 10 processes, 500 cases each for Juliet
+#   ./scripts/parallel-gym.sh juliet 5000 10
+#
+#   # 5 processes, 100 cases each for OWASP with concurrency 4
+#   ./scripts/parallel-gym.sh owasp 500 5 -j 4
+#
+#   # Quick mode (pattern only), 10 procs
+#   ./scripts/parallel-gym.sh juliet 5000 10 --quick
+
+set -euo pipefail
+
+SUITE="${1:?Usage: parallel-gym.sh <suite> <total_cases> <num_procs> [extra_args...]}"
+TOTAL="${2:?Specify total cases}"
+NPROCS="${3:?Specify number of processes}"
+shift 3
+EXTRA_ARGS="$*"
+
+CASES_PER_PROC=$(( (TOTAL + NPROCS - 1) / NPROCS ))  # ceiling division
+SKWAQ="${SKWAQ:-./target/release/skwaq}"
+OUTDIR="/tmp/gym-parallel-${SUITE}-$(date +%s)"
+mkdir -p "$OUTDIR"
+
+echo "=== Parallel Gym Run ==="
+echo "Suite:      $SUITE"
+echo "Total:      $TOTAL cases"
+echo "Processes:  $NPROCS"
+echo "Per proc:   $CASES_PER_PROC cases"
+echo "Binary:     $SKWAQ"
+echo "Output:     $OUTDIR"
+echo "Extra args: $EXTRA_ARGS"
+echo ""
+
+# Verify binary exists
+if [ ! -f "$SKWAQ" ]; then
+    echo "Building release binary..."
+    cargo build --release
+fi
+
+# Launch N processes
+PIDS=()
+for i in $(seq 0 $((NPROCS - 1))); do
+    SKIP=$((i * CASES_PER_PROC))
+    LOG="$OUTDIR/proc-${i}.log"
+    JSON="$OUTDIR/proc-${i}.json"
+
+    echo "  Process $i: skip=$SKIP max=$CASES_PER_PROC -> $LOG"
+
+    "$SKWAQ" gym run "$SUITE" \
+        --skip "$SKIP" \
+        --max-cases "$CASES_PER_PROC" \
+        --json "$JSON" \
+        $EXTRA_ARGS \
+        > "$LOG" 2>&1 &
+
+    PIDS+=($!)
+done
+
+echo ""
+echo "Waiting for $NPROCS processes..."
+
+# Wait and collect exit codes
+FAILURES=0
+for i in "${!PIDS[@]}"; do
+    if wait "${PIDS[$i]}"; then
+        echo "  Process $i: done"
+    else
+        echo "  Process $i: FAILED (exit $?)"
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+
+echo ""
+echo "=== Results ==="
+
+# Show individual results
+for i in $(seq 0 $((NPROCS - 1))); do
+    LOG="$OUTDIR/proc-${i}.log"
+    echo "--- Process $i ---"
+    grep -E "F1|Precision|Recall|TP:|FP:|FN:" "$LOG" 2>/dev/null || echo "  (no results)"
+done
+
+# Merge JSON results if jq is available
+if command -v jq &>/dev/null; then
+    echo ""
+    echo "--- Merged Summary ---"
+    # Sum TP/FP/FN across all process results
+    TP=$(jq -s '[.[].true_positives // 0] | add' "$OUTDIR"/proc-*.json 2>/dev/null || echo 0)
+    FP=$(jq -s '[.[].false_positives // 0] | add' "$OUTDIR"/proc-*.json 2>/dev/null || echo 0)
+    FN=$(jq -s '[.[].false_negatives // 0] | add' "$OUTDIR"/proc-*.json 2>/dev/null || echo 0)
+    TN=$(jq -s '[.[].true_negatives // 0] | add' "$OUTDIR"/proc-*.json 2>/dev/null || echo 0)
+
+    if [ "$TP" != "0" ] || [ "$FP" != "0" ] || [ "$FN" != "0" ]; then
+        PREC=$(echo "scale=3; $TP / ($TP + $FP + 0.001)" | bc 2>/dev/null || echo "?")
+        REC=$(echo "scale=3; $TP / ($TP + $FN + 0.001)" | bc 2>/dev/null || echo "?")
+        echo "  TP=$TP  FP=$FP  FN=$FN  TN=$TN"
+        echo "  Precision: $PREC"
+        echo "  Recall:    $REC"
+    fi
+fi
+
+echo ""
+echo "Logs: $OUTDIR/"
+[ $FAILURES -gt 0 ] && echo "WARNING: $FAILURES processes failed" && exit 1
+exit 0


### PR DESCRIPTION
## Summary
Two complementary parallelism approaches for benchmark execution:

### In-process concurrency (`-j` / `--concurrency`)
```bash
skwaq gym run juliet -j 8 --max-cases 100
```
Uses `FuturesUnordered` on single-threaded async runtime. While case A waits for LLM API response, case B starts its request. Default: 4 for hybrid mode, 1 for quick.

### Multi-process parallelism (`--skip`)
```bash
# Process 1: cases 0-499
skwaq gym run juliet --skip 0 --max-cases 500 -j 4
# Process 2: cases 500-999
skwaq gym run juliet --skip 500 --max-cases 500 -j 4
```
Each process is independent with its own in-memory DBs. No shared state.

### Helper script
```bash
# 10 processes x 500 cases = 5000 Juliet cases
./scripts/parallel-gym.sh juliet 5000 10
```

## Test plan
- [x] 195 tests pass
- [x] \`--skip\` correctly offsets case selection
- [x] \`-j 2\` concurrent execution produces same results as sequential
- [x] \`--help\` shows new flags

Relates to #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)