### PR TITLE
feat(gym): skwaq gym eval — one-command parallel evaluation

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -198,7 +198,23 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
             println!("  Output:      {}", eval_dir.display());
             println!();
 
+            let valid_suites: std::collections::HashSet<&str> = [
+                "fixtures",
+                "juliet",
+                "owasp",
+                "cyberseceval",
+                "cgc",
+                "binpool",
+                "binmetric",
+            ]
+            .into_iter()
+            .collect();
             let suite_list: Vec<&str> = suites.split(',').map(|s| s.trim()).collect();
+            for s in &suite_list {
+                if !valid_suites.contains(s) {
+                    anyhow::bail!("Unknown suite '{}'. Valid: {:?}", s, valid_suites);
+                }
+            }
             let mut all_children: Vec<(String, Vec<std::process::Child>)> = Vec::new();
 
             for suite in &suite_list {

--- a/scripts/gym-eval.sh
+++ b/scripts/gym-eval.sh
@@ -58,14 +58,12 @@ SUITE_CASES[cyberseceval]=578
 SUITE_CASES[cgc]=204
 SUITE_CASES[fixtures]=7
 
-TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-EVAL_DIR="/tmp/gym-eval-${TIMESTAMP}"
-mkdir -p "$EVAL_DIR"
+EVAL_DIR=$(mktemp -d /tmp/gym-eval-XXXXXX)
 
 echo "╔══════════════════════════════════════════════════╗"
 echo "║           SKWAQ GYM EVALUATION                  ║"
 echo "╠══════════════════════════════════════════════════╣"
-echo "║  Mode:        $([ -n "$QUICK" ] && echo "Pattern-only (quick)" || echo "Hybrid (LLM + Pattern)")            ║"
+echo "║  Mode:        $([ -n "${QUICK:+$QUICK}" ] && echo "Pattern-only (quick)" || echo "Hybrid (LLM + Pattern)")            ║"
 echo "║  Processes:   $PROCS per suite                          ║"
 echo "║  Concurrency: $CONCURRENCY per process                        ║"
 echo "║  Output:      $EVAL_DIR  ║"
@@ -80,7 +78,7 @@ fi
 
 # Always run fixtures sequentially (only 7 cases)
 echo "[fixtures] Running fixtures..."
-"$SKWAQ" gym run fixtures $QUICK -j 1 \
+"$SKWAQ" gym run fixtures ${QUICK:+$QUICK} -j 1 \
     --json "$EVAL_DIR/fixtures.json" \
     > "$EVAL_DIR/fixtures.log" 2>&1
 echo "[fixtures] Done"
@@ -109,7 +107,7 @@ for suite in "${SUITE_LIST[@]}"; do
             --skip "$skip" \
             --max-cases "$cases_per" \
             -j "$CONCURRENCY" \
-            $QUICK \
+            ${QUICK:+$QUICK} \
             --json "$suite_dir/shard-${i}.json" \
             > "$suite_dir/shard-${i}.log" 2>&1 &
         pids+=($!)

--- a/scripts/parallel-gym.sh
+++ b/scripts/parallel-gym.sh
@@ -23,12 +23,11 @@ SUITE="${1:?Usage: parallel-gym.sh <suite> <total_cases> <num_procs> [extra_args
 TOTAL="${2:?Specify total cases}"
 NPROCS="${3:?Specify number of processes}"
 shift 3
-EXTRA_ARGS="$*"
+EXTRA_ARGS=("$@")
 
 CASES_PER_PROC=$(( (TOTAL + NPROCS - 1) / NPROCS ))  # ceiling division
 SKWAQ="${SKWAQ:-./target/release/skwaq}"
-OUTDIR="/tmp/gym-parallel-${SUITE}-$(date +%s)"
-mkdir -p "$OUTDIR"
+OUTDIR=$(mktemp -d /tmp/gym-parallel-${SUITE}-XXXXXX)
 
 echo "=== Parallel Gym Run ==="
 echo "Suite:      $SUITE"
@@ -37,7 +36,7 @@ echo "Processes:  $NPROCS"
 echo "Per proc:   $CASES_PER_PROC cases"
 echo "Binary:     $SKWAQ"
 echo "Output:     $OUTDIR"
-echo "Extra args: $EXTRA_ARGS"
+echo "Extra args: ${EXTRA_ARGS[*]}"
 echo ""
 
 # Verify binary exists
@@ -59,7 +58,7 @@ for i in $(seq 0 $((NPROCS - 1))); do
         --skip "$SKIP" \
         --max-cases "$CASES_PER_PROC" \
         --json "$JSON" \
-        $EXTRA_ARGS \
+        "${EXTRA_ARGS[@]}" \
         > "$LOG" 2>&1 &
 
     PIDS+=($!)


### PR DESCRIPTION
## Summary
Adds `skwaq gym eval` command that orchestrates the full evaluation pipeline:

```bash
# Full hybrid eval across all suites (default: 5 procs x 2 concurrent)
skwaq gym eval

# Quick pattern-only eval
skwaq gym eval --quick

# Custom: 10 procs, 4 concurrent, specific suites
skwaq gym eval --procs 10 -j 4 --suites juliet,owasp
```

### Pipeline
1. Spawn N child processes per suite (each handles a case slice via `--skip`)
2. Monitor progress every 30s (cases completed, retries, alive procs)
3. Collect TP/FP/FN from shard logs after completion
4. Compute aggregate Precision/Recall/F1 across all shards
5. Print formatted results table

### Design decisions
- Default concurrency=2 (learned from rate limiting at concurrency=4 with many procs)
- Fixtures always run sequentially (only 7 cases)
- Uses `std::process::Command` to spawn child processes of the same binary
- No shared DB state between processes

Also includes `scripts/gym-eval.sh` shell alternative.

## Test plan
- [x] 195 tests pass
- [x] `skwaq gym eval --help` shows correct flags
- [x] Existing `gym run` with `--skip` and `-j` still works

Relates to #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)