### PR TITLE
fix: critical audit findings — procs bounds + empty shard guard

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -71,7 +71,7 @@ pub enum GymSub {
         #[arg(long, default_value = "fixtures,juliet,owasp,cyberseceval,cgc")]
         suites: String,
 
-        /// Processes per suite for multi-process parallelism
+        /// Processes per suite for multi-process parallelism (1-50)
         #[arg(long, default_value = "5")]
         procs: usize,
 
@@ -219,7 +219,11 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
 
             for suite in &suite_list {
                 let total = suite_cases.get(suite).copied().unwrap_or(100);
-                let n_procs = if *suite == "fixtures" { 1 } else { *procs };
+                let n_procs = if *suite == "fixtures" {
+                    1
+                } else {
+                    (*procs).clamp(1, 50)
+                };
                 let cases_per = total.div_ceil(n_procs);
                 let suite_dir = eval_dir.join(suite);
                 std::fs::create_dir_all(&suite_dir)?;

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -204,6 +204,20 @@ impl Gym {
                 concurrency
             );
 
+            // Skip empty shards (can happen when skip >= total cases in multi-process mode)
+            if cases.is_empty() {
+                tracing::warn!(
+                    "{}: no cases after skip={}, skipping",
+                    suite_name,
+                    config.skip
+                );
+                reporting::terminal::print_summary(
+                    &scoring::AggregateScore::default(),
+                    &suite_name,
+                );
+                continue;
+            }
+
             // Run cases with in-process async concurrency.
             // Each case creates its own in-memory GraphDb, so no shared state.
             // Concurrency > 1 lets multiple LLM API calls overlap (network I/O).


### PR DESCRIPTION
## Summary
Fixes critical issues found by deep code review and security audit agents:

1. **procs=0 → panic**: `div_ceil(0)` panics. Now clamped to 1-50.
2. **Empty shards pollute history**: When `--skip` >= total cases (common for last shard in multi-process), the empty run was saved to HistoryDb with zero scores. Now skips with a warning.
3. **DoS via --procs**: Unbounded process count could exhaust system resources. Capped at 50.

## Test plan
- [x] 195 tests pass
- [x] `--skip 99999 --max-cases 1` produces warning instead of zero-score entry
- [x] clippy clean

Relates to #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)