### PR TITLE
fix: auto-detect LLM backend (Anthropic/Copilot)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -99,7 +99,11 @@ fn default_log_level() -> String {
     "info".into()
 }
 fn default_llm_backend() -> String {
-    "copilot".into()
+    if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+        "anthropic".into()
+    } else {
+        "copilot".into()
+    }
 }
 fn default_ollama() -> String {
     "ollama".into()

--- a/crates/core/src/llm/mod.rs
+++ b/crates/core/src/llm/mod.rs
@@ -172,7 +172,10 @@ mod tests {
 
     #[test]
     fn test_validate_benchmark_copilot_config_requires_opus_model() {
-        let mut config = LlmConfig::default();
+        let mut config = LlmConfig {
+            reasoning: "copilot".into(),
+            ..Default::default()
+        };
         config.copilot.model = "gpt-4o".into();
 
         let err = validate_benchmark_copilot_config(&config).unwrap_err();


### PR DESCRIPTION
Fixes benchmark runs failing because default backend was switched to Copilot but only Anthropic key is available.