### PR TITLE
fix: accept both Anthropic and Copilot for hybrid benchmarks

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -467,10 +467,10 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
 
 async fn ensure_hybrid_benchmark_ready() -> anyhow::Result<()> {
     let config = skwaq_core::config::Config::load()?;
-    skwaq_core::llm::ensure_benchmark_copilot_ready(&config.llm)
+    skwaq_core::llm::ensure_benchmark_llm_ready(&config.llm)
         .await
         .context(
-            "Hybrid benchmark runs require explicit Copilot configuration and auth. \
+            "Hybrid benchmark runs require a working LLM (ANTHROPIC_API_KEY or Copilot auth). \
              Use `skwaq gym run --quick` for pattern-only smoke tests.",
         )
 }

--- a/crates/core/src/llm/mod.rs
+++ b/crates/core/src/llm/mod.rs
@@ -44,38 +44,43 @@ pub async fn create_client(config: &LlmConfig) -> anyhow::Result<Client> {
     }
 }
 
-pub fn validate_benchmark_copilot_config(config: &LlmConfig) -> anyhow::Result<()> {
+/// Validate that the LLM configuration can support hybrid benchmark runs.
+/// Accepts both Anthropic and Copilot backends.
+pub fn validate_benchmark_llm_config(config: &LlmConfig) -> anyhow::Result<()> {
     validate_backend_selection(config)?;
 
     let backend = normalized_backend(config);
-    if backend != "copilot" {
-        anyhow::bail!(
-            "Hybrid benchmark runs require [llm].reasoning = \"copilot\", found {:?}",
-            config.reasoning
-        );
+    match backend.as_str() {
+        "anthropic" => {
+            // Anthropic: just need the API key (checked at client creation)
+            Ok(())
+        }
+        "copilot" => {
+            let model = config.copilot.model.trim();
+            if model.is_empty() || !model.to_ascii_lowercase().contains("opus") {
+                anyhow::bail!(
+                    "Copilot benchmark runs require an Opus-class model, found {:?}. \
+                     Set [llm.copilot].model = \"claude-opus-4.6\".",
+                    config.copilot.model
+                );
+            }
+            Ok(())
+        }
+        other => {
+            anyhow::bail!(
+                "Hybrid benchmark runs require 'anthropic' or 'copilot' backend, found {:?}",
+                other
+            );
+        }
     }
-
-    let model = config.copilot.model.trim();
-    if model.is_empty() || !model.to_ascii_lowercase().contains("opus") {
-        anyhow::bail!(
-            "Hybrid benchmark runs require an Opus-class Copilot model, found {:?}. \
-             Set [llm.copilot].model = \"claude-opus-4.6\".",
-            config.copilot.model
-        );
-    }
-
-    Ok(())
 }
 
-pub async fn ensure_benchmark_copilot_ready(config: &LlmConfig) -> anyhow::Result<()> {
-    validate_benchmark_copilot_config(config)?;
+pub async fn ensure_benchmark_llm_ready(config: &LlmConfig) -> anyhow::Result<()> {
+    validate_benchmark_llm_config(config)?;
     create_client(config)
         .await
         .map(|_| ())
-        .context(
-            "Hybrid benchmark runs require working GitHub Copilot authentication. \
-             Run `gh auth login` / `gh auth refresh --scopes copilot`, or set GH_TOKEN/GITHUB_TOKEN with Copilot access.",
-        )
+        .context("Hybrid benchmark runs require a working LLM client. Check ANTHROPIC_API_KEY or Copilot auth.")
 }
 
 /// Build an Anthropic-backend client from the environment key.
@@ -158,27 +163,34 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_benchmark_copilot_config_requires_copilot() {
+    fn test_validate_benchmark_llm_config_accepts_anthropic() {
         let config = LlmConfig {
             reasoning: "anthropic".into(),
             ..Default::default()
         };
-
-        let err = validate_benchmark_copilot_config(&config).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("require [llm].reasoning = \"copilot\""));
+        // Anthropic is now a valid benchmark backend
+        assert!(validate_benchmark_llm_config(&config).is_ok());
     }
 
     #[test]
-    fn test_validate_benchmark_copilot_config_requires_opus_model() {
+    fn test_validate_benchmark_llm_config_rejects_unknown() {
+        let config = LlmConfig {
+            reasoning: "ollama".into(),
+            ..Default::default()
+        };
+        let err = validate_benchmark_llm_config(&config).unwrap_err();
+        assert!(err.to_string().contains("Unsupported"));
+    }
+
+    #[test]
+    fn test_validate_benchmark_llm_config_requires_opus_model() {
         let mut config = LlmConfig {
             reasoning: "copilot".into(),
             ..Default::default()
         };
         config.copilot.model = "gpt-4o".into();
 
-        let err = validate_benchmark_copilot_config(&config).unwrap_err();
-        assert!(err.to_string().contains("Opus-class Copilot model"));
+        let err = validate_benchmark_llm_config(&config).unwrap_err();
+        assert!(err.to_string().contains("Opus-class model"));
     }
 }

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -972,7 +972,7 @@ mod tests {
         }
 
         let config = Config::load().unwrap_or_default();
-        if skwaq_core::llm::ensure_benchmark_copilot_ready(&config.llm)
+        if skwaq_core::llm::ensure_benchmark_llm_ready(&config.llm)
             .await
             .is_err()
         {


### PR DESCRIPTION
Fixes benchmark validation to accept Anthropic backend (not just Copilot). Renames validate_benchmark_copilot_config → validate_benchmark_llm_config.