### PR TITLE
fix: use Opus for all agents (decompile-renamer was Haiku)

### DIFF
--- a/agents/decompile-renamer.md
+++ b/agents/decompile-renamer.md
@@ -1,7 +1,7 @@
 ---
 name: decompile-renamer
 description: Rename decompiler-generated variables to meaningful names before vulnerability analysis
-model: claude-haiku-4.5
+model: claude-opus-4-6
 tools:
   - query_graph
   - read_function


### PR DESCRIPTION
Security analysis needs Opus reasoning. Haiku was causing model-not-found errors on Anthropic API.