### PR TITLE
fix: agent model names — dots for Copilot API

### DIFF
--- a/agents/decompile-renamer.md
+++ b/agents/decompile-renamer.md
@@ -1,7 +1,11 @@
 ---
 name: decompile-renamer
 description: Rename decompiler-generated variables to meaningful names before vulnerability analysis
+<<<<<<< Updated upstream
 model: claude-haiku-4.5
+=======
+model: claude-opus-4.6
+>>>>>>> Stashed changes
 tools:
   - query_graph
   - read_function

--- a/agents/overfitting-reviewer.md
+++ b/agents/overfitting-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: overfitting-reviewer
 description: Reviews proposed pattern changes and scoring modifications for benchmark overfitting
-model: claude-opus-4-6
+model: claude-opus-4.6
 tools:
   - query_graph
   - read_function


### PR DESCRIPTION
All 13 agents: claude-opus-4-6 → claude-opus-4.6 (Copilot API requires dot notation)