### PR TITLE
feat(gym): per-case dedup, non-overlapping shards, CI benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,8 @@ jobs:
         run: |
           ./target/debug/skwaq self-test
           echo "Self-analysis passed"
+
+      - name: Gym benchmark (pattern-only)
+        run: |
+          ./target/debug/skwaq gym run fixtures --quick
+          echo "Pattern-only benchmark passed"

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -172,11 +172,23 @@ pub fn category_to_cwes(category: &str) -> Vec<u32> {
 }
 
 /// Compute aggregate scores from a list of case outcomes.
+///
+/// Deduplicates outcomes by `case_id` so that overlapping parallel shards
+/// do not double-count the same test case. When duplicates exist, the first
+/// occurrence is kept (arbitrary but deterministic for a given input order).
 pub fn aggregate(outcomes: &[CaseOutcome]) -> AggregateScore {
     let mut score = AggregateScore::default();
     let mut per_cwe: HashMap<u32, CweScore> = HashMap::new();
+    let mut seen_case_ids: HashSet<String> = HashSet::new();
 
     for outcome in outcomes {
+        if !seen_case_ids.insert(outcome.case_id.clone()) {
+            tracing::debug!(
+                "Dedup: skipping duplicate case_id={} (already aggregated)",
+                outcome.case_id
+            );
+            continue;
+        }
         if outcome.expected_cwes.is_empty() {
             // Negative test case.
             if outcome.detected_cwes.is_empty() {
@@ -420,6 +432,47 @@ mod tests {
         assert_eq!(cwe_family(242), 676);
         // Type confusion → memory safety
         assert_eq!(cwe_family(843), 119);
+    }
+
+    #[test]
+    fn test_aggregate_dedup_by_case_id() {
+        // Simulate overlapping shards: same case_id appears twice
+        let outcomes = vec![
+            CaseOutcome {
+                case_id: "case1".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![121],
+                detected_cwes: vec![119],
+                matched_finding_ids: vec!["f1".to_string()],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(121, true)].into_iter().collect(),
+            },
+            CaseOutcome {
+                case_id: "case1".to_string(), // duplicate
+                suite: "test".to_string(),
+                expected_cwes: vec![121],
+                detected_cwes: vec![119],
+                matched_finding_ids: vec!["f1".to_string()],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(121, true)].into_iter().collect(),
+            },
+            CaseOutcome {
+                case_id: "case2".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![134],
+                detected_cwes: vec![],
+                matched_finding_ids: vec![],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(134, false)].into_iter().collect(),
+            },
+        ];
+
+        let score = aggregate(&outcomes);
+        // Without dedup this would be TP=2, FN=1. With dedup: TP=1, FN=1.
+        assert_eq!(score.true_positives, 1);
+        assert_eq!(score.false_negatives, 1);
+        assert_eq!(score.precision, 1.0);
+        assert_eq!(score.recall, 0.5);
     }
 
     #[test]

--- a/scripts/parallel-gym.sh
+++ b/scripts/parallel-gym.sh
@@ -33,7 +33,7 @@ echo "=== Parallel Gym Run ==="
 echo "Suite:      $SUITE"
 echo "Total:      $TOTAL cases"
 echo "Processes:  $NPROCS"
-echo "Per proc:   $CASES_PER_PROC cases"
+echo "Per proc:   $CASES_PER_PROC cases (last shard may be smaller)"
 echo "Binary:     $SKWAQ"
 echo "Output:     $OUTDIR"
 echo "Extra args: ${EXTRA_ARGS[*]}"
@@ -45,18 +45,34 @@ if [ ! -f "$SKWAQ" ]; then
     cargo build --release
 fi
 
-# Launch N processes
+# Launch N processes with non-overlapping shard ranges.
+# Each shard gets exactly [SKIP, SKIP+COUNT) where COUNT is capped so the
+# last shard never extends beyond TOTAL, preventing double-counting.
 PIDS=()
+ASSIGNED=0
 for i in $(seq 0 $((NPROCS - 1))); do
-    SKIP=$((i * CASES_PER_PROC))
+    SKIP=$ASSIGNED
+    REMAINING=$((TOTAL - ASSIGNED))
+
+    # Cap this shard's size so it never exceeds the remaining cases
+    if [ "$REMAINING" -le 0 ]; then
+        echo "  Process $i: skipped (no remaining cases)"
+        continue
+    fi
+    COUNT=$CASES_PER_PROC
+    if [ "$COUNT" -gt "$REMAINING" ]; then
+        COUNT=$REMAINING
+    fi
+    ASSIGNED=$((ASSIGNED + COUNT))
+
     LOG="$OUTDIR/proc-${i}.log"
     JSON="$OUTDIR/proc-${i}.json"
 
-    echo "  Process $i: skip=$SKIP max=$CASES_PER_PROC -> $LOG"
+    echo "  Process $i: skip=$SKIP count=$COUNT -> $LOG"
 
     "$SKWAQ" gym run "$SUITE" \
         --skip "$SKIP" \
-        --max-cases "$CASES_PER_PROC" \
+        --max-cases "$COUNT" \
         --json "$JSON" \
         "${EXTRA_ARGS[@]}" \
         > "$LOG" 2>&1 &


### PR DESCRIPTION
## Summary

Closes #137 — Group A: Aggregation & Infrastructure.

- **Per-case dedup**: `scoring::aggregate` now tracks seen `case_id` values in a `HashSet` and skips duplicates, preventing double-counting when parallel shards overlap
- **Non-overlapping shards**: `parallel-gym.sh` caps each shard's count so the last process never extends beyond TOTAL; skips processes when no cases remain
- **CI benchmark**: Adds a `skwaq gym run fixtures --quick` step to the CI workflow after the build step

## Test plan

- [x] New unit test `test_aggregate_dedup_by_case_id` verifies dedup behavior
- [x] All 61 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI runs the new benchmark step on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)