### PR TITLE
feat: inject KB guidance into gym improve loop

### DIFF
--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -16,9 +16,10 @@ use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-const IMPROVE_KB_QUERY_LIMIT: usize = 6;
+const IMPROVE_KB_MAX_CWE_QUERIES: usize = 6;
 const IMPROVE_KB_HITS_PER_QUERY: usize = 2;
 const IMPROVE_KB_SNIPPET_CHAR_LIMIT: usize = 700;
+const IMPROVE_KB_FIXED_QUERIES: [&str; 2] = ["methodology", "cwe-families"];
 
 /// A proposed improvement from the failure-analyst agent.
 #[derive(Debug, Clone)]
@@ -300,21 +301,8 @@ async fn run_failure_analyst_agent(
             kb_context,
         );
 
-        // Create an in-memory DB for the agent to use
-        let db = skwaq_core::graph::GraphDb::in_memory()?;
         let inv_id = format!("improve-{}", i);
-        let now = chrono::Utc::now().to_rfc3339();
-        db.execute(
-            "INSERT INTO investigations (id, name, target, status, created_at, updated_at) \
-             VALUES (?1, ?2, ?3, 'active', ?4, ?5)",
-            &[
-                &inv_id.as_str(),
-                &fn_case.case_id.as_str(),
-                &fn_case.source_path.display().to_string().as_str(),
-                &now.as_str(),
-                &now.as_str(),
-            ],
-        )?;
+        let db = prepare_improvement_agent_db(&inv_id, &fn_case.case_id, &fn_case.source_path)?;
 
         tracing::info!(
             "Running failure-analyst on case {} ({}/{})",
@@ -810,8 +798,7 @@ fn build_false_negative_knowledge_context(
     knowledge_db: &skwaq_core::graph::GraphDb,
     fn_case: &FalseNegativeCase,
 ) -> anyhow::Result<String> {
-    let mut queries = vec!["methodology".to_string(), "cwe-families".to_string()];
-    queries.extend(fn_case.expected_cwes.iter().map(|cwe| format!("cwe-{cwe}")));
+    let queries = build_improvement_knowledge_queries(fn_case.expected_cwes.iter().copied());
     tracing::info!(
         "Building KB guidance for false negative case {} with queries {:?}",
         fn_case.case_id,
@@ -824,12 +811,11 @@ fn build_overfitting_knowledge_context(
     knowledge_db: &skwaq_core::graph::GraphDb,
     proposals: &[Improvement],
 ) -> anyhow::Result<String> {
-    let mut queries = vec!["methodology".to_string(), "cwe-families".to_string()];
-    let target_cwes: BTreeSet<u32> = proposals
+    let target_cwes = proposals
         .iter()
         .flat_map(|proposal| proposal.target_cwes.iter().copied())
-        .collect();
-    queries.extend(target_cwes.into_iter().map(|cwe| format!("cwe-{cwe}")));
+        .collect::<BTreeSet<_>>();
+    let queries = build_improvement_knowledge_queries(target_cwes);
     tracing::info!(
         "Building KB guidance for overfitting review with queries {:?}",
         queries
@@ -844,11 +830,7 @@ fn render_knowledge_context(
     let mut sections = Vec::new();
     let mut seen_hits = std::collections::HashSet::new();
 
-    for query in queries
-        .iter()
-        .filter(|query| !query.trim().is_empty())
-        .take(IMPROVE_KB_QUERY_LIMIT)
-    {
+    for query in queries.iter().filter(|query| !query.trim().is_empty()) {
         let hits = skwaq_core::knowledge::search::search_knowledge(Some(knowledge_db), query)?;
         tracing::info!(
             "KB query '{}' returned {} hit(s) for improve cycle context",
@@ -874,10 +856,10 @@ fn render_knowledge_context(
     }
 
     if sections.is_empty() {
-        return Ok(
-            "No matching KB guidance was found for the requested methodology/CWE queries."
-                .to_string(),
-        );
+        return Err(anyhow::anyhow!(
+            "KB returned no hits for improve-cycle queries {:?}",
+            queries
+        ));
     }
 
     tracing::info!(
@@ -885,6 +867,62 @@ fn render_knowledge_context(
         sections.len()
     );
     Ok(sections.join("\n"))
+}
+
+fn build_improvement_knowledge_queries<I>(cwes: I) -> Vec<String>
+where
+    I: IntoIterator<Item = u32>,
+{
+    let unique_cwes = cwes.into_iter().collect::<BTreeSet<_>>();
+    let mut queries = IMPROVE_KB_FIXED_QUERIES
+        .iter()
+        .map(|query| query.to_string())
+        .collect::<Vec<_>>();
+
+    if unique_cwes.len() > IMPROVE_KB_MAX_CWE_QUERIES {
+        let dropped = unique_cwes
+            .iter()
+            .copied()
+            .skip(IMPROVE_KB_MAX_CWE_QUERIES)
+            .collect::<Vec<_>>();
+        tracing::warn!(
+            "Truncating improve-cycle CWE KB queries from {} to {}; dropped {:?}",
+            unique_cwes.len(),
+            IMPROVE_KB_MAX_CWE_QUERIES,
+            dropped
+        );
+    }
+
+    queries.extend(
+        unique_cwes
+            .into_iter()
+            .take(IMPROVE_KB_MAX_CWE_QUERIES)
+            .map(|cwe| format!("cwe-{cwe}")),
+    );
+    queries
+}
+
+fn prepare_improvement_agent_db(
+    investigation_id: &str,
+    investigation_name: &str,
+    target_path: &Path,
+) -> anyhow::Result<skwaq_core::graph::GraphDb> {
+    let db = skwaq_core::graph::GraphDb::in_memory()?;
+    skwaq_core::knowledge::search::initialize_cwe_catalog(&db)?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let target = target_path.display().to_string();
+    db.execute(
+        "INSERT INTO investigations (id, name, target, status, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, 'active', ?4, ?5)",
+        &[
+            &investigation_id,
+            &investigation_name,
+            &target.as_str(),
+            &now.as_str(),
+            &now.as_str(),
+        ],
+    )?;
+    Ok(db)
 }
 
 fn proposal_is_rejected(output: &str, proposal_number: usize, description: &str) -> bool {
@@ -1267,14 +1305,8 @@ pub fn append_learned_patterns(cycle: &ImprovementCycle) {
 /// experiences that agents can recall in future runs. The overfitting guard
 /// strips benchmark-specific details (file paths, case IDs, addresses) before
 /// storage.
-pub fn store_improvement_lessons(cycle: &ImprovementCycle) {
-    let memory = match skwaq_core::memory::MemoryStore::open_default() {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::warn!("Cannot open durable memory for lesson storage: {e}");
-            return;
-        }
-    };
+pub fn store_improvement_lessons(cycle: &ImprovementCycle) -> anyhow::Result<()> {
+    let memory = skwaq_core::memory::MemoryStore::open_default()?;
 
     let detector = skwaq_core::memory::PatternDetector::new(&memory);
     let mut stored = 0u32;
@@ -1327,12 +1359,16 @@ pub fn store_improvement_lessons(cycle: &ImprovementCycle) {
             }
         );
 
-        if memory
+        memory
             .store(agent, exp_type, &context, &outcome, 0.7, &tag_refs)
-            .is_ok()
-        {
-            stored += 1;
-        }
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to store generalized lesson for {} from case {}: {e}",
+                    agent,
+                    proposal.source_case
+                )
+            })?;
+        stored += 1;
     }
 
     // Store generalized lessons from false negatives (what was missed and why)
@@ -1362,7 +1398,7 @@ pub fn store_improvement_lessons(cycle: &ImprovementCycle) {
         let tags: Vec<String> = missed_cwes.iter().map(|cwe| format!("cwe-{cwe}")).collect();
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
 
-        if memory
+        memory
             .store(
                 "failure-analyst",
                 skwaq_core::memory::ExperienceType::Failure,
@@ -1371,18 +1407,22 @@ pub fn store_improvement_lessons(cycle: &ImprovementCycle) {
                 0.6,
                 &tag_refs,
             )
-            .is_ok()
-        {
-            stored += 1;
-        }
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to store missed-CWE lesson for {}: {e}",
+                    fn_case.case_id
+                )
+            })?;
+        stored += 1;
     }
 
     // Run pattern detection to promote recurring lessons
     for agent in &["vuln-hunter", "failure-analyst", "orchestrator"] {
-        if let Ok(new) = detector.detect_patterns(agent) {
-            if new > 0 {
-                tracing::info!("Detected {new} new patterns for agent '{agent}'");
-            }
+        let new = detector.detect_patterns(agent).map_err(|e| {
+            anyhow::anyhow!("failed to detect durable-memory patterns for {agent}: {e}")
+        })?;
+        if new > 0 {
+            tracing::info!("Detected {new} new patterns for agent '{agent}'");
         }
     }
 
@@ -1392,6 +1432,7 @@ pub fn store_improvement_lessons(cycle: &ImprovementCycle) {
             cycle.suite
         );
     }
+    Ok(())
 }
 
 /// Print improvement proposals in a human-readable format.
@@ -1673,6 +1714,22 @@ Regex: \bscanf\s*\(
     }
 
     #[test]
+    fn test_improvement_knowledge_queries_deduplicate_and_preserve_fixed_queries() {
+        let queries = build_improvement_knowledge_queries(vec![121, 120, 121, 122]);
+
+        assert_eq!(
+            queries,
+            vec![
+                "methodology".to_string(),
+                "cwe-families".to_string(),
+                "cwe-120".to_string(),
+                "cwe-121".to_string(),
+                "cwe-122".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn test_overfitting_knowledge_context_deduplicates_repeated_cwes() {
         let knowledge_db = prepare_improvement_knowledge_db().unwrap();
         let proposals = vec![
@@ -1695,6 +1752,30 @@ Regex: \bscanf\s*\(
 
         assert_eq!(context.matches("### Query: cwe-119").count(), 1);
         assert_eq!(context.matches("### Query: cwe-120").count(), 1);
+    }
+
+    #[test]
+    fn test_prepare_improvement_agent_db_seeds_cwe_catalog() {
+        let db = prepare_improvement_agent_db("inv-1", "case-1", Path::new("sample.c")).unwrap();
+        let cwe_119 = db
+            .conn()
+            .query_row(
+                "SELECT cwe_id FROM cwes WHERE cwe_id = 'CWE-119' LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap();
+
+        assert_eq!(cwe_119, "CWE-119");
+    }
+
+    #[test]
+    fn test_render_knowledge_context_errors_when_queries_have_no_hits() {
+        let knowledge_db = prepare_improvement_knowledge_db().unwrap();
+        let error = render_knowledge_context(&knowledge_db, &["cwe-999999".to_string()])
+            .expect_err("missing KB hits should fail closed");
+
+        assert!(error.to_string().contains("KB returned no hits"));
     }
 
     #[test]

--- a/tests/qa/bin/gym-improve-kb-context.sh
+++ b/tests/qa/bin/gym-improve-kb-context.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 run_dir="$(mktemp -d "$repo_root/.tmp-gym-improve-kb-XXXXXX")"
-github_token="$(gh auth token)"
+host_home="${HOME:-}"
+
+if ! github_token="$(gh auth token)"; then
+  echo "ERROR: failed to retrieve a GitHub token via 'gh auth token'" >&2
+  exit 1
+fi
 
 cleanup() {
   rm -rf "$run_dir"
@@ -11,8 +16,15 @@ cleanup() {
 
 trap cleanup EXIT
 
+cd "$repo_root"
+cargo build -q -p skwaq
+
 export HOME="$run_dir/home"
 export GITHUB_TOKEN="$github_token"
+if [[ -n "$host_home" ]]; then
+  export CARGO_HOME="${CARGO_HOME:-$host_home/.cargo}"
+  export RUSTUP_HOME="${RUSTUP_HOME:-$host_home/.rustup}"
+fi
 mkdir -p "$HOME/.skwaq"
 ln -s "$repo_root/agents" "$run_dir/agents"
 ln -s "$repo_root/data" "$run_dir/data"
@@ -26,4 +38,22 @@ model = "claude-opus-4.6"
 EOF
 
 cd "$run_dir"
-"$repo_root/target/debug/skwaq" gym improve cyberseceval --max-cases 5
+output="$("$repo_root/target/debug/skwaq" gym improve cyberseceval --max-cases 5 2>&1)"
+printf '%s\n' "$output"
+
+printf '%s\n' "$output" | grep -Eq "KB query 'methodology' returned [1-9][0-9]* hit\\(s\\)" || {
+  echo "ERROR: methodology KB query did not return a positive hit count" >&2
+  exit 1
+}
+printf '%s\n' "$output" | grep -Eq "KB query 'cwe-families' returned [1-9][0-9]* hit\\(s\\)" || {
+  echo "ERROR: cwe-families KB query did not return a positive hit count" >&2
+  exit 1
+}
+printf '%s\n' "$output" | grep -Eq "Prepared [1-9][0-9]* KB guidance snippet\\(s\\) for improve cycle context" || {
+  echo "ERROR: improve cycle did not prepare non-empty KB guidance snippets" >&2
+  exit 1
+}
+
+echo "QA CHECK: methodology KB query returned positive hits"
+echo "QA CHECK: cwe-families KB query returned positive hits"
+echo "QA CHECK: improve cycle prepared non-empty KB guidance snippets"

--- a/tests/qa/gym-improve-kb-context.yaml
+++ b/tests/qa/gym-improve-kb-context.yaml
@@ -12,7 +12,7 @@ agents:
     type: "system"
     config:
       shell: "bash"
-      cwd: "/home/azureuser/src/skwaq-worktrees/issue-155-kb-improve-context"
+      cwd: "."
       timeout: 240000
       capture_output: true
 
@@ -25,11 +25,9 @@ steps:
     expect:
       exit_code: 0
       stdout_contains:
-        - "SELF-IMPROVEMENT PROPOSALS: CYBERSECEVAL"
-        - "Building KB guidance for false negative case"
-        - "KB query 'methodology' returned"
-        - "KB query 'cwe-families' returned"
-        - "Prepared"
+        - "QA CHECK: methodology KB query returned positive hits"
+        - "QA CHECK: cwe-families KB query returned positive hits"
+        - "QA CHECK: improve cycle prepared non-empty KB guidance snippets"
     timeout: 240000
 
 assertions:
@@ -45,9 +43,9 @@ assertions:
     params:
       step: "Run KB-informed gym improve sample"
       required_strings:
-        - "Building KB guidance for false negative case"
-        - "KB query 'methodology' returned"
-        - "KB query 'cwe-families' returned"
+        - "QA CHECK: methodology KB query returned positive hits"
+        - "QA CHECK: cwe-families KB query returned positive hits"
+        - "QA CHECK: improve cycle prepared non-empty KB guidance snippets"
 
 metadata:
   tags:


### PR DESCRIPTION
## Summary

Relates to #155 and #70.

This change makes `skwaq gym improve` explicitly KB-informed instead of relying only on raw case context plus whatever the agent happens to remember.

Delivered in this branch:
- seed an in-memory KB search DB for improve cycles
- inject KB guidance into failure-analyst prompts using methodology + CWE-focused queries
- inject KB guidance into overfitting-review prompts using methodology + proposal target CWEs
- require durable memory for the failure-analyst improve path instead of silently downgrading to a no-memory run
- remove the hidden `failure-analyst unavailable -> heuristics only` downgrade so the LLM stage is now required, while heuristics remain an explicit second signal after the analyst stage succeeds
- seed the per-agent improve DB with the CWE catalog so `lookup_cwe` is actually available when the prompt tells the agent to use it
- refactor improve-cycle KB query construction so fixed guidance does not crowd out CWE-specific lookups
- fail closed if improve-cycle KB queries return no hits instead of synthesizing a fake no-guidance context string
- make durable-memory lesson storage propagate errors explicitly instead of swallowing them
- add KB-query tracing so CLI improve runs produce visible evidence of KB usage
- add unit tests for KB context rendering, query deduplication, query building, agent DB seeding, and fail-closed no-hit behavior
- add a Gadugi outside-in CLI scenario covering the KB-informed improve flow on a real false negative

## Why

The repo already had durable memory and a shared KB search surface, but the self-improvement loop was not grounding proposal generation or the overfitting gate in that shared knowledge. That left quality on the table and made it harder to audit why a proposal was accepted or rejected.

This change moves the improve loop toward a better agentic pattern: shared explicit context at the decision points that matter most, rather than more hidden orchestration.

## Outside-in QA

Scenario files added:
- `tests/qa/gym-improve-kb-context.yaml`
- `tests/qa/bin/gym-improve-kb-context.sh`

Commands run:
- `gadugi-test validate -f tests/qa/gym-improve-kb-context.yaml`
- `gadugi-test run -d tests/qa -s gym-improve-kb-context`

Passing evidence on current branch head `be64a825`:
- session artifact: `outputs/sessions/session_bd68b0a9-136f-478b-9ad2-c5d807f20d23_2026-03-15T04-43-44-033Z.json`
- output included:
  - `QA CHECK: methodology KB query returned positive hits`
  - `QA CHECK: cwe-families KB query returned positive hits`
  - `QA CHECK: improve cycle prepared non-empty KB guidance snippets`

## Validation

Local validation completed:
- `cargo fmt --all`
- `cargo test -q -p skwaq-gym improve::tests -- --test-threads=1`
- `cargo clippy -q -p skwaq-gym --tests -- -D warnings`
- `cargo test -q -p skwaq-gym -- --test-threads=1`
- `cargo test -q -p skwaq -- --test-threads=1`
- `cargo run -q -p skwaq -- gym improve fixtures --max-cases 1`
- `cargo run -q -p skwaq -- gym improve juliet --max-cases 20`
- `cargo run -q -p skwaq -- gym improve cgc --max-cases 5`
- `RUST_LOG=info cargo run -q -p skwaq -- gym improve cyberseceval --max-cases 5`
- final QA reruns on the audited branch state:
  - `gadugi-test validate -f tests/qa/gym-improve-kb-context.yaml`
  - `gadugi-test run -d tests/qa -s gym-improve-kb-context`

## Quality Audit

Minimum 3-cycle SEEK -> VALIDATE -> FIX loop completed, with final convergence rerun on the latest diff.

Cycle 1
- confirmed issues: machine-bound QA `cwd`, and QA proof that only checked query execution rather than positive KB hits
- fixes: switched scenario `cwd` to `.`; added explicit positive-hit checks and explicit auth failure handling in the harness; rebuilt the current `skwaq` binary inside the harness while preserving Rust toolchain homes
- verification: `cargo fmt --all`; `cargo test -q -p skwaq-gym improve::tests -- --test-threads=1`; `gadugi-test validate -f tests/qa/gym-improve-kb-context.yaml`; `gadugi-test run -d tests/qa -s gym-improve-kb-context`

Cycle 2
- confirmed issues: prompt promised `lookup_cwe` even though the per-agent DB was unseeded; fixed KB guidance queries could crowd out real CWE lookups
- fixes: seeded the per-agent DB via `prepare_improvement_agent_db()`; refactored KB query construction to keep fixed guidance plus a separate capped CWE budget; deduplicated CWE query inputs; added unit tests covering query construction and DB seeding
- verification: `cargo fmt --all`; `cargo test -q -p skwaq-gym improve::tests -- --test-threads=1`; `gadugi-test validate -f tests/qa/gym-improve-kb-context.yaml`; `gadugi-test run -d tests/qa -s gym-improve-kb-context`

Cycle 3
- confirmed issues: benchmark-specific QA assertion remained; improve path still had two silent-degradation pockets (`render_knowledge_context` synthesized a fake no-guidance string and `store_improvement_lessons` swallowed durable-memory failures)
- fixes: removed the benchmark-specific QA assertion; changed `render_knowledge_context` to fail closed when KB returns no hits; changed `store_improvement_lessons` to return `Result` and propagate durable-memory store/detect errors; added a negative-path unit test for missing KB hits
- verification: `cargo fmt --all`; `cargo test -q -p skwaq-gym improve::tests -- --test-threads=1`; `gadugi-test validate -f tests/qa/gym-improve-kb-context.yaml`; `gadugi-test run -d tests/qa -s gym-improve-kb-context`

Final convergence
- reran independent review on the latest audited diff under the repo's explicit fail-closed / no-fallback policy
- final independent validators reported no material remaining issues

## CI

CI was green on the previous pushed head and has been re-triggered for the current audited head `be64a825`. This PR is ready for CI observation on the latest commit.
