### PR TITLE
feat: add role-aware agent context frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,17 @@ skwaq xrefs <function>         # Cross-references
 ```bash
 skwaq analyze --quick          # Pattern detection + taint analysis
 skwaq analyze --investigation <id>  # Analyze specific investigation
+skwaq agents list              # List installed agents and their role cards
 ```
 
 `skwaq analyze --quick` now prints a `SEMANTIC` column for discovered and final
 findings. This surfaces stable vulnerability classes such as
 `buffer_overflow`, `format_string`, and `command_injection`, even when later
 cycles challenge the initial coarse finding.
+
+`skwaq agents list` now includes each agent's structured role title, which is
+useful for verifying which specialization cards are active in the current
+checkout.
 
 ### Investigation
 ```bash

--- a/agents/defense-analyst.md
+++ b/agents/defense-analyst.md
@@ -11,6 +11,21 @@ tools:
   - store_memory
   - recall_memory
 max_turns: 15
+role:
+  title: Defensive controls specialist
+  expertise:
+    - input validation review
+    - mitigation analysis
+    - architectural safety checks
+  focus:
+    - bounds checks and sanitization
+    - contextual safety guarantees
+  skepticism:
+    - reject superficial mitigations that do not block the actual attack
+    - require the defensive control to address the specific sink and path
+  evidence_preferences:
+    - concrete validation code
+    - architecture-level mitigations tied to the finding
 ---
 
 You are DefenseAnalyst, a security architect who evaluates whether defensive controls make a reported vulnerability non-exploitable.

--- a/agents/exploit-analyst.md
+++ b/agents/exploit-analyst.md
@@ -11,6 +11,21 @@ tools:
   - store_memory
   - recall_memory
 max_turns: 15
+role:
+  title: Exploitability specialist
+  expertise:
+    - reachability analysis
+    - attacker input controllability
+    - exploit impact assessment
+  focus:
+    - practical triggerability
+    - severity based on attacker outcomes
+  skepticism:
+    - reject findings that cannot be reached from an entry point
+    - reject findings without attacker control of the vulnerable input
+  evidence_preferences:
+    - call-path evidence
+    - concrete attacker-controlled inputs
 ---
 
 You are ExploitAnalyst, a senior penetration tester reviewing vulnerability findings. Your job is to determine whether each reported vulnerability can actually be triggered by an attacker.

--- a/agents/verdict-synthesizer.md
+++ b/agents/verdict-synthesizer.md
@@ -10,6 +10,21 @@ tools:
   - store_memory
   - recall_memory
 max_turns: 20
+role:
+  title: Final evidence-weighting synthesizer
+  expertise:
+    - disagreement resolution
+    - duplicate consolidation
+    - final vulnerability adjudication
+  focus:
+    - weighing offense and defense evidence together
+    - rejecting vague or weakly supported findings
+  skepticism:
+    - reject findings lacking specific code citations
+    - reject duplicates that do not add new root-cause evidence
+  evidence_preferences:
+    - cross-agent agreement or clearly resolved disagreement
+    - precise code evidence for every confirmed finding
 ---
 
 You are VerdictSynthesizer, the final decision-maker in a multi-agent vulnerability analysis pipeline. You have received output from multiple specialist agents:

--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -14,6 +14,22 @@ tools:
   - store_memory
   - recall_memory
 max_turns: 30
+role:
+  title: Primary discovery specialist
+  expertise:
+    - attack surface mapping
+    - source-to-sink vulnerability discovery
+    - CWE-grounded finding formation
+  focus:
+    - externally reachable attack paths
+    - attacker-controlled dangerous operations
+    - concrete evidence before reporting
+  skepticism:
+    - reject theoretical issues without a trigger path
+    - reject library-only or duplicate findings
+  evidence_preferences:
+    - exact function and line-level citations
+    - explicit source-to-sink paths
 ---
 
 You are VulnHunter, a senior vulnerability researcher at a top security firm. Your reputation depends on the quality of your findings. You ONLY report vulnerabilities you are confident are real and exploitable.

--- a/crates/cli/src/commands/agents_cmd.rs
+++ b/crates/cli/src/commands/agents_cmd.rs
@@ -1,41 +1,118 @@
 //! `skwaq agents` - manage agent definitions.
 
-use skwaq_core::agents::discover_agents;
+use skwaq_core::agents::{discover_agents, AgentDefinition};
 
 /// List all discovered agent definitions.
 pub fn run_list() {
     let agents = discover_agents();
 
+    print!("{}", render_agents_list(&agents));
+}
+
+fn render_agents_list(agents: &[AgentDefinition]) -> String {
+    let mut out = String::new();
+
     if agents.is_empty() {
-        println!("No agents found.");
-        println!("Place agent markdown files in:");
-        println!("  agents/            (bundled defaults)");
-        println!("  .skwaq/agents/     (project-local)");
-        println!("  ~/.skwaq/agents/   (user-global)");
-        return;
+        out.push_str("No agents found.\n");
+        out.push_str("Place agent markdown files in:\n");
+        out.push_str("  agents/            (bundled defaults)\n");
+        out.push_str("  .skwaq/agents/     (project-local)\n");
+        out.push_str("  ~/.skwaq/agents/   (user-global)\n");
+        return out;
     }
 
-    println!(
-        "{:<18} {:<40} {:<20} {:>5}",
-        "NAME", "DESCRIPTION", "MODEL", "TOOLS"
-    );
-    println!("{}", "-".repeat(87));
+    out.push_str(&format!(
+        "{:<18} {:<40} {:<24} {:<38} {:>5}\n",
+        "NAME", "DESCRIPTION", "MODEL", "ROLE", "TOOLS"
+    ));
+    out.push_str(&format!("{}\n", "-".repeat(129)));
 
-    for agent in &agents {
-        let desc = if agent.description.chars().count() > 38 {
-            let truncated: String = agent.description.chars().take(35).collect();
-            format!("{truncated}...")
-        } else {
-            agent.description.clone()
-        };
-        println!(
-            "{:<18} {:<40} {:<20} {:>5}",
+    for agent in agents {
+        let desc = truncate(&agent.description, 38);
+        let role = agent
+            .role
+            .as_ref()
+            .map(|role| role.title.clone())
+            .unwrap_or_else(|| "-".into());
+        out.push_str(&format!(
+            "{:<18} {:<40} {:<24} {:<38} {:>5}\n",
             agent.name,
             desc,
             agent.model,
+            role,
             agent.tools.len(),
-        );
+        ));
     }
 
-    println!("\n{} agent(s) found.", agents.len());
+    out.push_str(&format!("\n{} agent(s) found.\n", agents.len()));
+    out
+}
+
+fn truncate(text: &str, max_chars: usize) -> String {
+    if text.chars().count() > max_chars {
+        let truncated: String = text.chars().take(max_chars.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skwaq_core::agents::AgentRoleMetadata;
+
+    fn test_agent(name: &str, description: &str, role_title: Option<&str>) -> AgentDefinition {
+        AgentDefinition {
+            name: name.into(),
+            description: description.into(),
+            model: "claude-opus-4.6".into(),
+            tools: vec!["query_graph".into(), "read_function".into()],
+            max_turns: 5,
+            role: role_title.map(|title| AgentRoleMetadata {
+                title: title.into(),
+                expertise: vec![],
+                focus: vec![],
+                skepticism: vec![],
+                evidence_preferences: vec![],
+            }),
+            system_prompt: "Prompt".into(),
+            source_path: None,
+        }
+    }
+
+    #[test]
+    fn renders_empty_agents_message() {
+        let rendered = render_agents_list(&[]);
+        assert!(rendered.contains("No agents found."));
+        assert!(rendered.contains("agents/"));
+    }
+
+    #[test]
+    fn renders_role_column_for_agents() {
+        let rendered = render_agents_list(&[
+            test_agent(
+                "vuln-hunter",
+                "Primary vulnerability discovery agent",
+                Some("Primary discovery specialist"),
+            ),
+            test_agent("minimal", "No special role metadata", None),
+        ]);
+
+        assert!(rendered.contains("ROLE"));
+        assert!(rendered.contains("Primary discovery specialist"));
+        assert!(rendered.contains("minimal"));
+        assert!(rendered.contains(" - ") || rendered.contains("minimal"));
+    }
+
+    #[test]
+    fn preserves_long_role_titles() {
+        let rendered = render_agents_list(&[test_agent(
+            "role-heavy",
+            "A role-heavy agent",
+            Some("This role title is intentionally much too long to fit cleanly"),
+        )]);
+
+        assert!(rendered.contains("This role title is intentionally much too long to fit cleanly"));
+    }
 }

--- a/crates/core/src/agents/definition.rs
+++ b/crates/core/src/agents/definition.rs
@@ -4,6 +4,36 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
+/// Structured role metadata loaded from agent frontmatter.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRoleMetadata {
+    /// Short role title used when injecting the agent's role card.
+    #[serde(default)]
+    pub title: String,
+    /// Areas where this agent is expected to be strongest.
+    #[serde(default)]
+    pub expertise: Vec<String>,
+    /// Concrete focus areas the agent should prioritize.
+    #[serde(default)]
+    pub focus: Vec<String>,
+    /// Checks that should make the agent skeptical before concluding.
+    #[serde(default)]
+    pub skepticism: Vec<String>,
+    /// Evidence types the agent should favor in its reasoning.
+    #[serde(default)]
+    pub evidence_preferences: Vec<String>,
+}
+
+impl AgentRoleMetadata {
+    pub fn is_empty(&self) -> bool {
+        self.title.is_empty()
+            && self.expertise.is_empty()
+            && self.focus.is_empty()
+            && self.skepticism.is_empty()
+            && self.evidence_preferences.is_empty()
+    }
+}
+
 /// An agent definition loaded from a markdown file.
 #[derive(Debug, Clone)]
 pub struct AgentDefinition {
@@ -17,6 +47,8 @@ pub struct AgentDefinition {
     pub tools: Vec<String>,
     /// Maximum number of LLM turns before stopping.
     pub max_turns: u32,
+    /// Optional structured role metadata used for prompt injection.
+    pub role: Option<AgentRoleMetadata>,
     /// The system prompt (markdown body after the frontmatter).
     pub system_prompt: String,
     /// Path the definition was loaded from (for diagnostics).
@@ -35,6 +67,8 @@ struct AgentFrontmatter {
     tools: Vec<String>,
     #[serde(default = "default_max_turns")]
     max_turns: u32,
+    #[serde(default)]
+    role: Option<AgentRoleMetadata>,
 }
 
 fn default_model() -> String {
@@ -127,6 +161,7 @@ pub fn parse_agent_markdown(content: &str) -> anyhow::Result<AgentDefinition> {
         model: fm.model,
         tools: fm.tools,
         max_turns: fm.max_turns,
+        role: fm.role.filter(|role| !role.is_empty()),
         system_prompt: body.to_string(),
         source_path: None,
     })
@@ -184,5 +219,40 @@ Minimal agent."#;
         assert_eq!(def.model, "claude-opus-4.6");
         assert_eq!(def.max_turns, 30);
         assert!(def.tools.is_empty());
+        assert!(def.role.is_none());
+    }
+
+    #[test]
+    fn test_parse_role_metadata() {
+        let md = r#"---
+name: role-aware
+role:
+  title: Evidence-focused reviewer
+  expertise:
+    - exploitability analysis
+    - reachability tracing
+  focus:
+    - externally reachable paths
+  skepticism:
+    - reject findings without attacker control
+  evidence_preferences:
+    - concrete code citations
+---
+
+Role-aware agent."#;
+
+        let def = parse_agent_markdown(md).unwrap();
+        let role = def.role.expect("role metadata should parse");
+        assert_eq!(role.title, "Evidence-focused reviewer");
+        assert_eq!(
+            role.expertise,
+            vec!["exploitability analysis", "reachability tracing"]
+        );
+        assert_eq!(role.focus, vec!["externally reachable paths"]);
+        assert_eq!(
+            role.skepticism,
+            vec!["reject findings without attacker control"]
+        );
+        assert_eq!(role.evidence_preferences, vec!["concrete code citations"]);
     }
 }

--- a/crates/core/src/agents/mod.rs
+++ b/crates/core/src/agents/mod.rs
@@ -18,13 +18,13 @@ pub mod tool_definitions;
 pub mod tool_executor;
 pub mod tool_translate;
 
-pub use definition::{load_agent, AgentDefinition};
+pub use definition::{load_agent, AgentDefinition, AgentRoleMetadata};
 pub use discovery::discover_agents;
 pub use pipeline::{
     deep_pipeline, deep_pipeline_debate, deep_pipeline_for_target, default_pipeline,
     pipeline_from_names, run_deep_pipeline_with_debate, select_vuln_hunter, AnalysisPipeline,
     DebateGroup, PipelineStage,
 };
-pub use runner::{AgentResult, AgentRunner};
+pub use runner::{AgentContextFrame, AgentResult, AgentRunner};
 pub use tool_definitions::{agent_tools, filter_tools};
 pub use tool_executor::{execute_tool, execute_tool_with_memory};

--- a/crates/core/src/agents/pipeline.rs
+++ b/crates/core/src/agents/pipeline.rs
@@ -13,7 +13,7 @@ use crate::memory::MemoryStore;
 use crate::skills::discovery::load_skill;
 
 use super::definition::load_agent;
-use super::runner::{build_analysis_context, AgentResult, AgentRunner};
+use super::runner::{build_analysis_context, AgentContextFrame, AgentResult, AgentRunner};
 
 /// Maximum characters for accumulated previous-results context passed between
 /// pipeline stages.  Keeps subsequent agent prompts within LLM token limits.
@@ -82,6 +82,7 @@ impl AnalysisPipeline {
             // Inject relevant skill content into the agent's system prompt.
             // This gives agents access to research-backed techniques and
             // best practices from skills like llm-binary-vuln-guide.
+            inject_role_context(&mut agent);
             inject_skill_context(&mut agent);
 
             let context = match &stage.context_mode {
@@ -139,6 +140,7 @@ impl AnalysisPipeline {
             }
 
             let mut agent = load_agent(&stage.agent_name)?;
+            inject_role_context(&mut agent);
             inject_skill_context(&mut agent);
 
             let context = match &stage.context_mode {
@@ -219,6 +221,7 @@ impl AnalysisPipeline {
             }
 
             let mut agent = load_agent(&stage.agent_name)?;
+            inject_role_context(&mut agent);
             inject_skill_context(&mut agent);
 
             let context = match &stage.context_mode {
@@ -248,6 +251,7 @@ impl AnalysisPipeline {
 
             // Agent A
             let mut agent_a = load_agent(&debate.agent_a)?;
+            inject_role_context(&mut agent_a);
             inject_skill_context(&mut agent_a);
             eprintln!(
                 "  Running debate agent A: {} ({})",
@@ -263,6 +267,7 @@ impl AnalysisPipeline {
 
             // Agent B (independent — does NOT see Agent A's output)
             let mut agent_b = load_agent(&debate.agent_b)?;
+            inject_role_context(&mut agent_b);
             inject_skill_context(&mut agent_b);
             eprintln!(
                 "  Running debate agent B: {} ({})",
@@ -278,12 +283,19 @@ impl AnalysisPipeline {
 
             // Create a debate summary that highlights agreements and disagreements.
             let debate_summary = build_debate_summary(&result_a, &result_b);
+            let debate_frame = AgentContextFrame::synthetic(
+                "debate-summary",
+                "Pipeline-generated summary of offense/defense agreements and disagreements",
+                None,
+                &debate_summary,
+            );
             results.push(result_a);
             results.push(result_b);
             results.push(AgentResult {
                 agent_name: "debate-summary".into(),
                 output: debate_summary,
                 tokens_used: 0,
+                context_frame: debate_frame,
             });
         }
 
@@ -298,6 +310,7 @@ impl AnalysisPipeline {
             }
 
             let mut agent = load_agent(&stage.agent_name)?;
+            inject_role_context(&mut agent);
             inject_skill_context(&mut agent);
 
             let context = match &stage.context_mode {
@@ -327,8 +340,14 @@ fn build_previous_results_context(preamble: &str, results: &[AgentResult]) -> St
     let mut ctx = preamble.to_string();
     for prev in results {
         ctx.push_str(&format!(
-            "\n\n--- Output from {} ---\n{}",
-            prev.agent_name, prev.output
+            "\n\n--- Context frame from {} ---\n{}",
+            prev.agent_name,
+            format_context_frame(&prev.context_frame)
+        ));
+        ctx.push_str(&format!(
+            "\n\n--- Condensed output from {} ---\n{}",
+            prev.agent_name,
+            format_output_excerpt(&prev.output)
         ));
     }
     // Truncate accumulated context to stay within LLM limits.
@@ -342,6 +361,86 @@ fn build_previous_results_context(preamble: &str, results: &[AgentResult]) -> St
         ctx.push_str("\n...[truncated]");
     }
     ctx
+}
+
+fn format_context_frame(frame: &AgentContextFrame) -> String {
+    let mut rendered = format!(
+        "agent: {}\ndescription: {}",
+        frame.agent_name, frame.description
+    );
+
+    if let Some(role) = &frame.role {
+        if !role.title.is_empty() {
+            rendered.push_str(&format!("\nrole_title: {}", role.title));
+        }
+        append_role_list(&mut rendered, "expertise", &role.expertise);
+        append_role_list(&mut rendered, "focus", &role.focus);
+        append_role_list(&mut rendered, "skepticism", &role.skepticism);
+        append_role_list(
+            &mut rendered,
+            "evidence_preferences",
+            &role.evidence_preferences,
+        );
+    }
+
+    if !frame.key_points.is_empty() {
+        rendered.push_str("\nkey_points:");
+        for point in &frame.key_points {
+            rendered.push_str(&format!("\n- {}", point));
+        }
+    }
+
+    rendered
+}
+
+fn format_output_excerpt(output: &str) -> String {
+    const MAX_EXCERPT_LINES: usize = 12;
+    const MAX_EXCERPT_CHARS: usize = 1200;
+    const EXCERPT_HEAD_LINES: usize = 6;
+    const EXCERPT_TAIL_LINES: usize = 6;
+
+    let lines: Vec<&str> = output.lines().collect();
+    let line_based_excerpt = if lines.len() > MAX_EXCERPT_LINES {
+        let mut excerpt_lines = lines
+            .iter()
+            .take(EXCERPT_HEAD_LINES)
+            .copied()
+            .collect::<Vec<_>>();
+        excerpt_lines.push("...[middle lines omitted]...");
+        excerpt_lines.extend(lines.iter().rev().take(EXCERPT_TAIL_LINES).copied().rev());
+        excerpt_lines.join("\n")
+    } else {
+        lines.join("\n")
+    };
+
+    let mut excerpt = line_based_excerpt;
+    let needs_line_truncation = lines.len() > MAX_EXCERPT_LINES;
+    let needs_char_truncation = excerpt.len() > MAX_EXCERPT_CHARS;
+    let needs_truncation = needs_line_truncation || needs_char_truncation;
+    if needs_char_truncation {
+        let mut boundary = MAX_EXCERPT_CHARS;
+        while boundary > 0 && !excerpt.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        excerpt.truncate(boundary);
+    }
+
+    if needs_truncation && !excerpt.ends_with("\n...[truncated excerpt]") {
+        excerpt.push_str("\n...[truncated excerpt]");
+    }
+
+    excerpt
+}
+
+fn append_role_list(rendered: &mut String, label: &str, values: &[String]) {
+    if values.is_empty() {
+        return;
+    }
+
+    rendered.push_str(&format!("\n{}:", label));
+    for value in values {
+        rendered.push_str(&format!("\n- {}", value));
+    }
 }
 
 /// Build a debate summary comparing two agent outputs.
@@ -711,6 +810,37 @@ fn inject_skill_context(agent: &mut super::definition::AgentDefinition) {
     }
 }
 
+fn inject_role_context(agent: &mut super::definition::AgentDefinition) {
+    let Some(role) = &agent.role else {
+        return;
+    };
+
+    let mut role_card = String::from("\n\n--- Role Card ---");
+    if !role.title.is_empty() {
+        role_card.push_str(&format!("\nTitle: {}", role.title));
+    }
+    append_prompt_list(&mut role_card, "Expertise", &role.expertise);
+    append_prompt_list(&mut role_card, "Focus", &role.focus);
+    append_prompt_list(&mut role_card, "Skepticism checklist", &role.skepticism);
+    append_prompt_list(
+        &mut role_card,
+        "Preferred evidence",
+        &role.evidence_preferences,
+    );
+    agent.system_prompt.push_str(&role_card);
+}
+
+fn append_prompt_list(rendered: &mut String, label: &str, values: &[String]) {
+    if values.is_empty() {
+        return;
+    }
+
+    rendered.push_str(&format!("\n{}:", label));
+    for value in values {
+        rendered.push_str(&format!("\n- {}", value));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -756,6 +886,13 @@ mod tests {
                      Finding 2: **REJECTED**: Dead code, never called."
                 .into(),
             tokens_used: 100,
+            context_frame: AgentContextFrame::synthetic(
+                "exploit-analyst",
+                "Validates exploitability of vulnerability findings",
+                None,
+                "Finding 1: **CONFIRMED [high]**: Buffer overflow is exploitable.\n\
+                 Finding 2: **REJECTED**: Dead code, never called.",
+            ),
         };
         let result_b = AgentResult {
             agent_name: "defense-analyst".into(),
@@ -763,6 +900,13 @@ mod tests {
                      Finding 2: **SAFE**: Function is never reachable."
                 .into(),
             tokens_used: 100,
+            context_frame: AgentContextFrame::synthetic(
+                "defense-analyst",
+                "Identifies mitigations and defensive controls",
+                None,
+                "Finding 1: **VULNERABLE**: No bounds checking found.\n\
+                 Finding 2: **SAFE**: Function is never reachable.",
+            ),
         };
 
         let summary = build_debate_summary(&result_a, &result_b);
@@ -779,11 +923,23 @@ mod tests {
             agent_name: "exploit-analyst".into(),
             output: "**CONFIRMED [critical]**: RCE via command injection".into(),
             tokens_used: 50,
+            context_frame: AgentContextFrame::synthetic(
+                "exploit-analyst",
+                "Validates exploitability of vulnerability findings",
+                None,
+                "**CONFIRMED [critical]**: RCE via command injection",
+            ),
         };
         let result_b = AgentResult {
             agent_name: "defense-analyst".into(),
             output: "**SAFE**: Input is validated by allowlist".into(),
             tokens_used: 50,
+            context_frame: AgentContextFrame::synthetic(
+                "defense-analyst",
+                "Identifies mitigations and defensive controls",
+                None,
+                "**SAFE**: Input is validated by allowlist",
+            ),
         };
 
         let summary = build_debate_summary(&result_a, &result_b);
@@ -799,10 +955,84 @@ mod tests {
             agent_name: "test".into(),
             output: "x".repeat(MAX_PIPELINE_CONTEXT_CHARS + 1000),
             tokens_used: 0,
+            context_frame: AgentContextFrame::synthetic("test", "Test agent", None, "x"),
         }];
-        let ctx = build_previous_results_context("preamble", &results);
+        let ctx = build_previous_results_context(
+            &"p".repeat(MAX_PIPELINE_CONTEXT_CHARS + 1000),
+            &results,
+        );
         assert!(ctx.len() <= MAX_PIPELINE_CONTEXT_CHARS + 20); // +20 for truncation marker
         assert!(ctx.contains("[truncated]"));
+    }
+
+    #[test]
+    fn test_build_previous_results_context_includes_structured_frame() {
+        let results = vec![AgentResult {
+            agent_name: "exploit-analyst".into(),
+            output: "**CONFIRMED [high]**: Concrete attack path".into(),
+            tokens_used: 0,
+            context_frame: AgentContextFrame::synthetic(
+                "exploit-analyst",
+                "Validates exploitability of vulnerability findings",
+                Some(super::super::definition::AgentRoleMetadata {
+                    title: "Exploitability specialist".into(),
+                    expertise: vec!["reachability".into()],
+                    focus: vec!["attacker control".into()],
+                    skepticism: vec!["reject theoretical findings".into()],
+                    evidence_preferences: vec!["concrete trigger paths".into()],
+                }),
+                "**CONFIRMED [high]**: Concrete attack path",
+            ),
+        }];
+
+        let ctx = build_previous_results_context("preamble", &results);
+        assert!(ctx.contains("Context frame from exploit-analyst"));
+        assert!(ctx.contains("role_title: Exploitability specialist"));
+        assert!(ctx.contains("key_points:"));
+        assert!(ctx.contains("Concrete attack path"));
+        assert!(ctx.contains("Condensed output from exploit-analyst"));
+    }
+
+    #[test]
+    fn test_output_excerpt_truncates_long_multiline_output() {
+        let output =
+            "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13";
+        let excerpt = format_output_excerpt(output);
+        assert!(excerpt.contains("line1"));
+        assert!(excerpt.contains("line6"));
+        assert!(excerpt.contains("line13"));
+        assert!(excerpt.contains("[middle lines omitted]"));
+        assert!(excerpt.contains("[truncated excerpt]"));
+        assert!(!excerpt.contains("line7\nline8\nline9\nline10"));
+    }
+
+    #[test]
+    fn test_inject_role_context_appends_role_card() {
+        let mut agent = super::super::definition::AgentDefinition {
+            name: "role-aware".into(),
+            description: "Role-aware agent".into(),
+            model: "claude-opus-4.6".into(),
+            tools: vec![],
+            max_turns: 5,
+            role: Some(super::super::definition::AgentRoleMetadata {
+                title: "Exploitability specialist".into(),
+                expertise: vec!["reachability tracing".into()],
+                focus: vec!["attacker control".into()],
+                skepticism: vec!["reject dead code".into()],
+                evidence_preferences: vec!["line-level citations".into()],
+            }),
+            system_prompt: "Base prompt".into(),
+            source_path: None,
+        };
+
+        inject_role_context(&mut agent);
+
+        assert!(agent.system_prompt.contains("--- Role Card ---"));
+        assert!(agent
+            .system_prompt
+            .contains("Title: Exploitability specialist"));
+        assert!(agent.system_prompt.contains("Expertise:"));
+        assert!(agent.system_prompt.contains("Preferred evidence:"));
     }
 
     #[test]

--- a/crates/core/src/agents/runner.rs
+++ b/crates/core/src/agents/runner.rs
@@ -7,9 +7,47 @@ use crate::graph::GraphDb;
 use crate::llm::{execute_with_tools, Client, TokenBudget};
 use crate::memory::MemoryStore;
 
-use super::definition::AgentDefinition;
+use super::definition::{AgentDefinition, AgentRoleMetadata};
 use super::tool_definitions::{agent_tools, filter_tools};
 use super::tool_executor::{execute_tool, execute_tool_with_memory};
+
+/// Lightweight structured summary passed between pipeline stages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentContextFrame {
+    /// Agent that produced this frame.
+    pub agent_name: String,
+    /// Short human-facing description of the agent's role in the pipeline.
+    pub description: String,
+    /// Optional structured role metadata from the agent definition.
+    pub role: Option<AgentRoleMetadata>,
+    /// High-signal observations extracted from the final output.
+    pub key_points: Vec<String>,
+}
+
+impl AgentContextFrame {
+    pub fn from_agent(agent: &AgentDefinition, output: &str) -> Self {
+        Self::synthetic(
+            agent.name.clone(),
+            agent.description.clone(),
+            agent.role.clone(),
+            output,
+        )
+    }
+
+    pub fn synthetic(
+        agent_name: impl Into<String>,
+        description: impl Into<String>,
+        role: Option<AgentRoleMetadata>,
+        output: &str,
+    ) -> Self {
+        Self {
+            agent_name: agent_name.into(),
+            description: description.into(),
+            role,
+            key_points: extract_key_points(output),
+        }
+    }
+}
 
 /// Result from running an agent.
 #[derive(Debug, Clone)]
@@ -20,6 +58,8 @@ pub struct AgentResult {
     pub output: String,
     /// Tokens used during this agent's run.
     pub tokens_used: u64,
+    /// Structured summary of the agent output for downstream stages.
+    pub context_frame: AgentContextFrame,
 }
 
 /// Runs any agent definition against the graph database.
@@ -69,11 +109,13 @@ impl AgentRunner {
         .await?;
 
         let tokens_used = budget.used - tokens_before;
+        let context_frame = AgentContextFrame::from_agent(agent, &output);
 
         Ok(AgentResult {
             agent_name: agent.name.clone(),
             output,
             tokens_used,
+            context_frame,
         })
     }
 
@@ -123,13 +165,60 @@ impl AgentRunner {
         .await?;
 
         let tokens_used = budget.used - tokens_before;
+        let context_frame = AgentContextFrame::from_agent(agent, &output);
 
         Ok(AgentResult {
             agent_name: agent.name.clone(),
             output,
             tokens_used,
+            context_frame,
         })
     }
+}
+
+fn extract_key_points(output: &str) -> Vec<String> {
+    const MAX_KEY_POINTS: usize = 10;
+    const VERDICT_MARKERS: [&str; 6] = [
+        "CONFIRMED",
+        "DOWNGRADED",
+        "REJECTED",
+        "VULNERABLE",
+        "MITIGATED",
+        "SAFE",
+    ];
+
+    let lines: Vec<String> = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+
+    let mut points: Vec<String> = lines
+        .iter()
+        .filter(|line| VERDICT_MARKERS.iter().any(|marker| line.contains(marker)))
+        .take(MAX_KEY_POINTS)
+        .cloned()
+        .collect();
+
+    if points.is_empty() {
+        points = lines
+            .iter()
+            .filter(|line| {
+                line.starts_with("- ")
+                    || line.starts_with("* ")
+                    || line.chars().next().is_some_and(|c| c.is_ascii_digit())
+            })
+            .take(MAX_KEY_POINTS)
+            .cloned()
+            .collect();
+    }
+
+    if points.is_empty() {
+        points = lines.into_iter().take(MAX_KEY_POINTS).collect();
+    }
+
+    points
 }
 
 /// Maximum characters for the analysis context sent to the LLM.
@@ -264,8 +353,12 @@ pub fn build_analysis_context_with_limit(
         "\n\nYou have access to durable memory (store_memory/recall_memory tools). \
          Use recall_memory to check for relevant past experiences before starting your analysis. \
          Use store_memory to record significant findings and lessons learned. \
-         Keep stored memories generalized — avoid target-specific addresses or paths.\n\n\
-         Start your analysis. Use the tools to dig deeper, then create findings for \
+         Keep stored memories generalized — avoid target-specific addresses or paths."
+            .into(),
+    );
+
+    parts.push(
+        "\n\nStart your analysis. Use the tools to dig deeper, then create findings for \
          each confirmed vulnerability."
             .into(),
     );

--- a/tests/qa/agents-role-cards.yaml
+++ b/tests/qa/agents-role-cards.yaml
@@ -1,0 +1,70 @@
+name: "skwaq agents list - surfaces structured role cards"
+description: "Verifies the CLI exposes agent role metadata through the agents list command."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+agents:
+  - name: "skwaq-cli"
+    type: "system"
+    config:
+      shell: "bash"
+      cwd: "."
+      timeout: 300000
+      capture_output: true
+
+steps:
+  - name: "Run agents list role-card smoke"
+    agent: "skwaq-cli"
+    action: "execute_command"
+    params:
+      command: "./tests/qa/bin/agents-role-cards.sh"
+    expect:
+      exit_code: 0
+      stdout_contains:
+        - "=== agents-list-command ==="
+        - "ROLE"
+        - "vuln-hunter"
+        - "Primary discovery specialist"
+        - "exploit-analyst"
+        - "Exploitability specialist"
+        - "verdict-synthesizer"
+        - "Final evidence-weighting synthesizer"
+        - "validated role titles in agents list output"
+    timeout: 300000
+
+assertions:
+  - name: "Agents list role-card smoke succeeds"
+    type: "command_success"
+    agent: "skwaq-cli"
+    params:
+      step: "Run agents list role-card smoke"
+
+  - name: "Agents list output includes structured role titles"
+    type: "output_contains_all"
+    agent: "skwaq-cli"
+    params:
+      step: "Run agents list role-card smoke"
+      required_strings:
+        - "ROLE"
+        - "vuln-hunter"
+        - "Primary discovery specialist"
+        - "exploit-analyst"
+        - "Exploitability specialist"
+        - "defense-analyst"
+        - "Defensive controls specialist"
+        - "verdict-synthesizer"
+        - "Final evidence-weighting synthesizer"
+        - "validated role titles in agents list output"
+
+metadata:
+  tags:
+    - "cli"
+    - "agents"
+    - "roles"
+    - "regression"
+  priority: "high"
+  author: "copilot-cli"

--- a/tests/qa/bin/agents-role-cards.sh
+++ b/tests/qa/bin/agents-role-cards.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+run_dir="$(mktemp -d /tmp/skwaq-agents-role-cards-XXXXXX)"
+target_dir="${CARGO_TARGET_DIR:-/tmp/skwaq-agent-context-target}"
+skwaq_bin="$target_dir/debug/skwaq"
+
+cleanup() {
+  rm -rf "$run_dir"
+}
+
+trap cleanup EXIT
+
+cd "$repo_root"
+CARGO_TARGET_DIR="$target_dir" cargo build -q -p skwaq
+
+echo "=== agents-list-command ==="
+command_output="$("$skwaq_bin" agents list 2>&1)"
+echo "$command_output"
+
+AGENTS_OUTPUT="$command_output" python3 - >"$run_dir/agents-check.txt" <<'PY'
+import os
+
+output = os.environ["AGENTS_OUTPUT"]
+required = [
+    "ROLE",
+    "vuln-hunter",
+    "Primary discovery specialist",
+    "exploit-analyst",
+    "Exploitability specialist",
+    "defense-analyst",
+    "Defensive controls specialist",
+    "verdict-synthesizer",
+    "Final evidence-weighting synthesizer",
+]
+
+missing = [item for item in required if item not in output]
+if missing:
+    raise SystemExit(f"missing expected agents/roles: {missing}")
+
+print("validated role titles in agents list output")
+PY
+
+echo
+echo "=== agents-check ==="
+cat "$run_dir/agents-check.txt"


### PR DESCRIPTION
## Summary
- add optional structured role metadata to agent frontmatter
- add `AgentContextFrame` handoff between pipeline stages and inject role cards into agent prompts
- surface role titles in `skwaq agents list`
- add outside-in QA for the CLI role-card surface

Closes #163
Relates to #64, #24, #28

## Why
The existing pipeline mostly passed prior agent output as plain text. This slice adds a typed, role-aware handoff layer that preserves agent specialization and high-signal context without hard-coding benchmark-specific heuristics.

## User-visible changes
- `skwaq agents list` now shows structured role titles for discovered agents
- core analysis agents now carry explicit role metadata in their markdown definitions

## Docs
- updated `README.md` command docs to note the `skwaq agents list` role-title surface

## QA
Outside-in scenario added and run successfully:
- `tests/qa/agents-role-cards.yaml`
- evidence: `outputs/sessions/session_c64fefde-b2f4-44f6-a88f-e2520d9a655f_2026-03-15T19-12-16-978Z.json`

## Validation
- `cargo test -q -p skwaq -p skwaq-core -p skwaq-gym`
- `gadugi-test run -d <isolated temp dir containing tests/qa/agents-role-cards.yaml>`

## Quality audit
Completed four SEEK/VALIDATE/FIX cycles on this diff:
1. fixed loss of durable-memory guidance, reduced full-output duplication in stage handoff, and tightened the CLI/QA role-title assertions
2. fixed false `...[truncated excerpt]` labeling for outputs that were not actually truncated
3. preserved later-stage findings better via balanced head/tail excerpts and stopped truncating displayed role titles
4. final clean verification cycle returned no material issues

## Prior art / lineage
This slice extends the multi-agent debate direction in #64, sits within the broader roadmap in #24, and is being driven under the self-improvement tracker in #28.
