### PR TITLE
feat: surface suite-aware gym compare regressions

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -66,7 +66,7 @@ pub enum GymSub {
         format: String,
     },
 
-    /// Compare last two runs
+    /// Compare the latest two finished runs for the most recently run suite
     Compare,
 
     /// Show benchmark history

--- a/crates/gym/src/history.rs
+++ b/crates/gym/src/history.rs
@@ -396,6 +396,51 @@ impl HistoryDb {
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
+    /// Load the N most recent completed runs for a specific suite.
+    pub fn recent_finished_runs_for_suite(
+        &self,
+        suite: &str,
+        limit: u32,
+    ) -> anyhow::Result<Vec<BenchmarkRun>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, started_at, finished_at, suite, skwaq_commit, run_metadata_json,
+                    precision, recall, f1, true_positives, false_positives,
+                    false_negatives, true_negatives
+              FROM runs
+              WHERE finished_at IS NOT NULL AND suite = ?1
+              ORDER BY started_at DESC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![suite, limit], |row| {
+            let metadata_json = row
+                .get::<_, Option<String>>(5)?
+                .unwrap_or_else(|| "{}".to_string());
+            Ok(BenchmarkRun {
+                id: row.get(0)?,
+                started_at: row.get::<_, String>(1)?.parse().unwrap_or_default(),
+                finished_at: row
+                    .get::<_, Option<String>>(2)?
+                    .and_then(|s| s.parse().ok()),
+                suite: row.get(3)?,
+                skwaq_commit: row.get(4)?,
+                metadata: serde_json::from_str(&metadata_json).map_err(|err| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        5,
+                        rusqlite::types::Type::Text,
+                        Box::new(err),
+                    )
+                })?,
+                precision: row.get(6)?,
+                recall: row.get(7)?,
+                f1: row.get(8)?,
+                true_positives: row.get(9)?,
+                false_positives: row.get(10)?,
+                false_negatives: row.get(11)?,
+                true_negatives: row.get(12)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
     fn ensure_run_metadata_column(&self) -> anyhow::Result<()> {
         let mut stmt = self.conn.prepare("PRAGMA table_info(runs)")?;
         let columns = stmt.query_map([], |row| row.get::<_, String>(1))?;
@@ -859,5 +904,71 @@ mod tests {
             )
             .unwrap();
         assert_eq!(unfinished_rows, 0);
+    }
+
+    #[test]
+    fn test_recent_finished_runs_for_suite_filters_other_suites() {
+        let db = HistoryDb::in_memory().unwrap();
+        let metadata = RunMetadata::default();
+
+        let fixtures_old = db.start_run("fixtures", "aaa111", &metadata).unwrap();
+        db.finish_run(&BenchmarkRun {
+            id: fixtures_old.clone(),
+            started_at: Utc::now(),
+            finished_at: Some(Utc::now()),
+            suite: "fixtures".to_string(),
+            skwaq_commit: "aaa111".to_string(),
+            metadata: metadata.clone(),
+            precision: 0.5,
+            recall: 0.5,
+            f1: 0.5,
+            true_positives: 1,
+            false_positives: 1,
+            false_negatives: 1,
+            true_negatives: 0,
+        })
+        .unwrap();
+
+        let juliet = db.start_run("juliet", "bbb222", &metadata).unwrap();
+        db.finish_run(&BenchmarkRun {
+            id: juliet,
+            started_at: Utc::now(),
+            finished_at: Some(Utc::now()),
+            suite: "juliet".to_string(),
+            skwaq_commit: "bbb222".to_string(),
+            metadata: metadata.clone(),
+            precision: 0.8,
+            recall: 0.8,
+            f1: 0.8,
+            true_positives: 4,
+            false_positives: 1,
+            false_negatives: 1,
+            true_negatives: 0,
+        })
+        .unwrap();
+
+        let fixtures_new = db.start_run("fixtures", "ccc333", &metadata).unwrap();
+        db.finish_run(&BenchmarkRun {
+            id: fixtures_new.clone(),
+            started_at: Utc::now(),
+            finished_at: Some(Utc::now()),
+            suite: "fixtures".to_string(),
+            skwaq_commit: "ccc333".to_string(),
+            metadata,
+            precision: 0.9,
+            recall: 0.9,
+            f1: 0.9,
+            true_positives: 9,
+            false_positives: 1,
+            false_negatives: 1,
+            true_negatives: 0,
+        })
+        .unwrap();
+
+        let runs = db.recent_finished_runs_for_suite("fixtures", 2).unwrap();
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].id, fixtures_new);
+        assert_eq!(runs[1].id, fixtures_old);
+        assert!(runs.iter().all(|run| run.suite == "fixtures"));
     }
 }

--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -1664,14 +1664,7 @@ fn store_fn_insights(
 /// Check if any CWE's detection rate dropped beyond the noise margin (2%).
 /// CWEs absent from the new score are ignored (they weren't tested in the new run).
 pub fn has_cwe_regression(baseline: &AggregateScore, new: &AggregateScore) -> bool {
-    for baseline_cwe in baseline.per_cwe.values() {
-        if let Some(new_cwe) = new.per_cwe.get(&baseline_cwe.cwe_id) {
-            if new_cwe.detection_rate < baseline_cwe.detection_rate - 0.02 {
-                return true;
-            }
-        }
-    }
-    false
+    !crate::scoring::cwe_regressions(baseline, new).is_empty()
 }
 
 /// Append successful patterns from improvement proposals to the knowledge pack.

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -557,13 +557,44 @@ impl Gym {
         }
     }
 
-    /// Compare the two most recent runs.
+    /// Compare the two most recent finished runs for the latest suite.
     pub fn compare(&self) -> anyhow::Result<()> {
-        let runs = self.history_db.recent_finished_runs(2)?;
+        let current = self
+            .history_db
+            .recent_finished_runs(1)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No finished runs yet. Run `skwaq gym run` first."))?;
+        let runs = self
+            .history_db
+            .recent_finished_runs_for_suite(&current.suite, 2)?;
         if runs.len() < 2 {
-            anyhow::bail!("Need at least 2 runs to compare. Run `skwaq gym run` twice.");
+            anyhow::bail!(
+                "Need at least 2 finished runs for suite `{}` to compare. Run `skwaq gym run {}` twice.",
+                current.suite,
+                current.suite
+            );
         }
-        reporting::terminal::print_comparison(&runs[1], &runs[0]);
+
+        let previous_run = &runs[1];
+        let current_run = &runs[0];
+        let previous_cwes = self.history_db.cwe_results_for_run(&previous_run.id)?;
+        let previous_semantics = self.history_db.semantic_results_for_run(&previous_run.id)?;
+        let current_cwes = self.history_db.cwe_results_for_run(&current_run.id)?;
+        let current_semantics = self.history_db.semantic_results_for_run(&current_run.id)?;
+        let previous_score = reconstruct_score(previous_run, &previous_cwes, &previous_semantics);
+        let current_score = reconstruct_score(current_run, &current_cwes, &current_semantics);
+        let case_regressions = self
+            .history_db
+            .case_regressions(&previous_run.id, &current_run.id)?;
+
+        reporting::terminal::print_comparison(
+            previous_run,
+            current_run,
+            &previous_score,
+            &current_score,
+            &case_regressions,
+        );
         Ok(())
     }
 

--- a/crates/gym/src/reporting/terminal.rs
+++ b/crates/gym/src/reporting/terminal.rs
@@ -1,7 +1,7 @@
 //! Rich terminal output for benchmark results.
 
-use crate::history::BenchmarkRun;
-use crate::scoring::AggregateScore;
+use crate::history::{BenchmarkRun, CaseRegression};
+use crate::scoring::{self, AggregateScore};
 
 /// Print a summary of benchmark results.
 pub fn print_summary(score: &AggregateScore, suite: &str) {
@@ -91,50 +91,229 @@ pub fn print_summary(score: &AggregateScore, suite: &str) {
 }
 
 /// Print a comparison between two runs.
-pub fn print_comparison(previous: &BenchmarkRun, current: &BenchmarkRun) {
-    println!("\n{}", "=".repeat(70));
-    println!("  IMPROVEMENT COMPARISON");
-    println!("{}", "=".repeat(70));
-    println!();
+pub fn print_comparison(
+    previous: &BenchmarkRun,
+    current: &BenchmarkRun,
+    previous_score: &AggregateScore,
+    current_score: &AggregateScore,
+    case_regressions: &[CaseRegression],
+) {
+    print!(
+        "{}",
+        render_comparison(
+            previous,
+            current,
+            previous_score,
+            current_score,
+            case_regressions,
+        )
+    );
+}
+
+fn render_comparison(
+    previous: &BenchmarkRun,
+    current: &BenchmarkRun,
+    previous_score: &AggregateScore,
+    current_score: &AggregateScore,
+    case_regressions: &[CaseRegression],
+) -> String {
+    let mut output = String::new();
+    output.push_str(&format!("\n{}\n", "=".repeat(70)));
+    output.push_str("  IMPROVEMENT COMPARISON\n");
+    output.push_str(&format!("{}\n\n", "=".repeat(70)));
+    output.push_str(&format!("  Suite: {}\n", current.suite));
+    output.push_str(&format!(
+        "  Commits: {} -> {}\n\n",
+        short_commit(&previous.skwaq_commit),
+        short_commit(&current.skwaq_commit)
+    ));
 
     let delta_f1 = current.f1 - previous.f1;
     let delta_p = current.precision - previous.precision;
     let delta_r = current.recall - previous.recall;
 
-    println!(
-        "  {:>12} {:>10} {:>10} {:>10}",
+    output.push_str(&format!(
+        "  {:>12} {:>10} {:>10} {:>10}\n",
         "", "Previous", "Current", "Delta"
-    );
-    println!("  {}", "-".repeat(46));
-    println!(
-        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%",
+    ));
+    output.push_str(&format!("  {}\n", "-".repeat(46)));
+    output.push_str(&format!(
+        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%\n",
         "Precision",
         previous.precision * 100.0,
         current.precision * 100.0,
         delta_p * 100.0
-    );
-    println!(
-        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%",
+    ));
+    output.push_str(&format!(
+        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%\n",
         "Recall",
         previous.recall * 100.0,
         current.recall * 100.0,
         delta_r * 100.0
-    );
-    println!(
-        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%",
+    ));
+    output.push_str(&format!(
+        "  {:>12} {:>9.1}% {:>9.1}% {:>+9.1}%\n\n",
         "F1",
         previous.f1 * 100.0,
         current.f1 * 100.0,
         delta_f1 * 100.0
-    );
-    println!();
+    ));
 
     if delta_f1 > 0.0 {
-        println!("  Overall: IMPROVED");
+        output.push_str("  Overall: IMPROVED\n");
     } else if delta_f1 < 0.0 {
-        println!("  Overall: REGRESSED");
+        output.push_str("  Overall: REGRESSED\n");
     } else {
-        println!("  Overall: No change");
+        output.push_str("  Overall: No change\n");
     }
-    println!();
+
+    let cwe_regressions = scoring::cwe_regressions(previous_score, current_score);
+    output.push('\n');
+    if cwe_regressions.is_empty() {
+        output.push_str(&format!(
+            "  No per-CWE detection regressions beyond the {:.1}% noise margin.\n",
+            scoring::CWE_REGRESSION_NOISE_MARGIN * 100.0
+        ));
+    } else {
+        output.push_str(&format!(
+            "  Per-CWE detection regressions (> {:.1}% drop):\n",
+            scoring::CWE_REGRESSION_NOISE_MARGIN * 100.0
+        ));
+        output.push_str(&format!(
+            "  {:>8} {:>10} {:>10} {:>10}\n",
+            "CWE", "Previous", "Current", "Delta"
+        ));
+        output.push_str(&format!("  {}\n", "-".repeat(46)));
+        for regression in &cwe_regressions {
+            output.push_str(&format!(
+                "  {:>8} {:>9.1}% {:>9.1}% {:>+9.1}%\n",
+                regression.cwe_id,
+                regression.previous_detection_rate * 100.0,
+                regression.current_detection_rate * 100.0,
+                regression.delta_detection_rate * 100.0
+            ));
+        }
+    }
+
+    output.push('\n');
+    if case_regressions.is_empty() {
+        output.push_str("  No case regressions (TP -> FN).\n\n");
+    } else {
+        output.push_str("  Case regressions (TP -> FN):\n");
+        for regression in case_regressions.iter().take(10) {
+            output.push_str(&format!(
+                "    - {} [{}] expected {:?}, baseline {:?}, current {:?}\n",
+                regression.case_id,
+                regression.suite,
+                regression.expected_cwes,
+                regression.baseline_detected,
+                regression.new_detected
+            ));
+        }
+        if case_regressions.len() > 10 {
+            output.push_str(&format!(
+                "    ... and {} more case regressions\n",
+                case_regressions.len() - 10
+            ));
+        }
+        output.push('\n');
+    }
+
+    output
+}
+
+fn short_commit(commit: &str) -> &str {
+    &commit[..6.min(commit.len())]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn run(
+        id: &str,
+        suite: &str,
+        commit: &str,
+        precision: f64,
+        recall: f64,
+        f1: f64,
+    ) -> BenchmarkRun {
+        BenchmarkRun {
+            id: id.to_string(),
+            started_at: Utc::now(),
+            finished_at: Some(Utc::now()),
+            suite: suite.to_string(),
+            skwaq_commit: commit.to_string(),
+            metadata: crate::history::RunMetadata::default(),
+            precision,
+            recall,
+            f1,
+            true_positives: 0,
+            false_positives: 0,
+            false_negatives: 0,
+            true_negatives: 0,
+        }
+    }
+
+    fn score(per_cwe: Vec<(u32, f64)>) -> AggregateScore {
+        let mut per_cwe_map = HashMap::new();
+        for (cwe_id, detection_rate) in per_cwe {
+            per_cwe_map.insert(
+                cwe_id,
+                crate::scoring::CweScore {
+                    cwe_id,
+                    detection_rate,
+                    ..Default::default()
+                },
+            );
+        }
+        AggregateScore {
+            per_cwe: per_cwe_map,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn render_comparison_surfaces_cwe_and_case_regressions() {
+        let previous = run("run-a", "fixtures", "abcdef123456", 0.8, 0.8, 0.8);
+        let current = run("run-b", "fixtures", "123456abcdef", 0.7, 0.6, 0.64);
+        let previous_score = score(vec![(119, 0.80), (134, 0.60)]);
+        let current_score = score(vec![(119, 0.75), (134, 0.40)]);
+        let case_regressions = vec![CaseRegression {
+            case_id: "overflow".to_string(),
+            suite: "fixtures".to_string(),
+            expected_cwes: vec![121],
+            baseline_detected: vec![119],
+            new_detected: vec![],
+        }];
+
+        let rendered = render_comparison(
+            &previous,
+            &current,
+            &previous_score,
+            &current_score,
+            &case_regressions,
+        );
+
+        assert!(rendered.contains("Suite: fixtures"));
+        assert!(rendered.contains("Per-CWE detection regressions"));
+        assert!(rendered.contains("134"));
+        assert!(rendered.contains("Case regressions (TP -> FN):"));
+        assert!(rendered.contains("overflow [fixtures]"));
+    }
+
+    #[test]
+    fn render_comparison_reports_when_no_regressions_exist() {
+        let previous = run("run-a", "fixtures", "abcdef123456", 0.8, 0.8, 0.8);
+        let current = run("run-b", "fixtures", "123456abcdef", 0.82, 0.81, 0.815);
+        let previous_score = score(vec![(119, 0.80)]);
+        let current_score = score(vec![(119, 0.79)]);
+
+        let rendered = render_comparison(&previous, &current, &previous_score, &current_score, &[]);
+
+        assert!(rendered.contains("No per-CWE detection regressions"));
+        assert!(rendered.contains("No case regressions (TP -> FN)."));
+    }
 }

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -5,6 +5,8 @@ use crate::ground_truth::TestCase;
 use skwaq_core::analysis::{SemanticPatternClass, SemanticPatternClassifier};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
+pub const CWE_REGRESSION_NOISE_MARGIN: f64 = 0.02;
+
 /// Outcome for a single test case.
 #[derive(Debug, Clone)]
 pub struct CaseOutcome {
@@ -52,6 +54,14 @@ pub struct SemanticScore {
     pub false_negatives: u32,
     pub detection_rate: f64,
     pub precision: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CweRegressionDelta {
+    pub cwe_id: u32,
+    pub previous_detection_rate: f64,
+    pub current_detection_rate: f64,
+    pub delta_detection_rate: f64,
 }
 
 /// Score a single test case against ground truth.
@@ -402,6 +412,34 @@ pub fn aggregate(outcomes: &[CaseOutcome]) -> AggregateScore {
     score
 }
 
+pub fn cwe_regressions(baseline: &AggregateScore, new: &AggregateScore) -> Vec<CweRegressionDelta> {
+    let mut regressions: Vec<_> = baseline
+        .per_cwe
+        .values()
+        .filter_map(|baseline_cwe| {
+            let new_cwe = new.per_cwe.get(&baseline_cwe.cwe_id)?;
+            let delta = new_cwe.detection_rate - baseline_cwe.detection_rate;
+            if delta < -CWE_REGRESSION_NOISE_MARGIN {
+                Some(CweRegressionDelta {
+                    cwe_id: baseline_cwe.cwe_id,
+                    previous_detection_rate: baseline_cwe.detection_rate,
+                    current_detection_rate: new_cwe.detection_rate,
+                    delta_detection_rate: delta,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+    regressions.sort_by(|a, b| {
+        a.delta_detection_rate
+            .partial_cmp(&b.delta_detection_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.cwe_id.cmp(&b.cwe_id))
+    });
+    regressions
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -741,5 +779,42 @@ mod tests {
         assert_eq!(overflow.false_positives, 1);
         assert_eq!(overflow.true_positives, 0);
         assert_eq!(overflow.precision, 0.0);
+    }
+
+    fn make_score(per_cwe: Vec<(u32, f64)>) -> AggregateScore {
+        let mut score = AggregateScore::default();
+        for (cwe_id, detection_rate) in per_cwe {
+            score.per_cwe.insert(
+                cwe_id,
+                CweScore {
+                    cwe_id,
+                    detection_rate,
+                    ..Default::default()
+                },
+            );
+        }
+        score
+    }
+
+    #[test]
+    fn test_cwe_regressions_reports_only_drops_beyond_margin() {
+        let baseline = make_score(vec![(119, 0.75), (134, 0.50), (190, 0.40)]);
+        let new = make_score(vec![(119, 0.72), (134, 0.49), (190, 0.39)]);
+
+        let regressions = cwe_regressions(&baseline, &new);
+
+        assert_eq!(regressions.len(), 1);
+        assert_eq!(regressions[0].cwe_id, 119);
+        assert!((regressions[0].delta_detection_rate + 0.03).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_cwe_regressions_ignores_missing_cwe_in_new_score() {
+        let baseline = make_score(vec![(119, 0.75), (134, 0.50)]);
+        let new = make_score(vec![(119, 0.75)]);
+
+        let regressions = cwe_regressions(&baseline, &new);
+
+        assert!(regressions.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- make `skwaq gym compare` compare the latest two finished runs from the same suite instead of the latest two runs overall
- surface stored per-CWE detection regressions and case regressions in the terminal comparison output
- reuse the new shared CWE regression helper across compare output and the improvement loop, with targeted regression coverage

## Testing
- cargo test -q -p skwaq-gym
- cargo clippy -q -p skwaq-gym --tests -- -D warnings