### PR TITLE
feat: add allocation/free/file APIs to binary import detector

### DIFF
--- a/crates/core/src/analysis/patterns.rs
+++ b/crates/core/src/analysis/patterns.rs
@@ -236,6 +236,51 @@ pub(crate) const DANGEROUS_APIS: &[DangerousEntry] = &[
         severity: Severity::Low,
         reason: "buffer overflow in some implementations; check buffer size",
     },
+    // Null dereference (CWE-476/690) — allocation APIs that can return NULL
+    DangerousEntry {
+        name: "malloc",
+        category: DangerCategory::NullDeref,
+        severity: Severity::Medium,
+        reason: "returns NULL on failure; check return value before use",
+    },
+    DangerousEntry {
+        name: "calloc",
+        category: DangerCategory::NullDeref,
+        severity: Severity::Medium,
+        reason: "returns NULL on failure; check return value before use",
+    },
+    DangerousEntry {
+        name: "realloc",
+        category: DangerCategory::NullDeref,
+        severity: Severity::Medium,
+        reason: "returns NULL on failure; check return value before use",
+    },
+    // Use-after-free (CWE-416) — free can lead to UAF if pointer reused
+    DangerousEntry {
+        name: "free",
+        category: DangerCategory::Memory,
+        severity: Severity::Medium,
+        reason: "pointer must not be used after free; set to NULL after freeing",
+    },
+    // Resource leak (CWE-401/772/775) — resource-acquiring APIs
+    DangerousEntry {
+        name: "fopen",
+        category: DangerCategory::ResourceLeak,
+        severity: Severity::Medium,
+        reason: "file must be closed with fclose on all paths including error paths",
+    },
+    DangerousEntry {
+        name: "open",
+        category: DangerCategory::ResourceLeak,
+        severity: Severity::Medium,
+        reason: "file descriptor must be closed on all paths including error paths",
+    },
+    DangerousEntry {
+        name: "socket",
+        category: DangerCategory::ResourceLeak,
+        severity: Severity::Medium,
+        reason: "socket must be closed on all paths including error paths",
+    },
 ];
 
 /// A detected use of a dangerous API.

--- a/crates/core/src/analysis/patterns_binary.rs
+++ b/crates/core/src/analysis/patterns_binary.rs
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_false_positives() {
+    fn test_no_false_positives_for_safe_apis() {
         let detector = DangerousApiDetector::new();
         let imports = vec![
             ImportInfo {
@@ -217,11 +217,47 @@ mod tests {
                 library: "libc.so.6".into(),
             },
             ImportInfo {
-                name: "malloc".into(),
+                name: "exit".into(),
                 library: "libc.so.6".into(),
             },
         ];
         let hits = detector.check_imports(&imports);
         assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn test_malloc_detected_as_null_deref() {
+        let detector = DangerousApiDetector::new();
+        let imports = vec![ImportInfo {
+            name: "malloc".into(),
+            library: "libc.so.6".into(),
+        }];
+        let hits = detector.check_imports(&imports);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].danger_category, DangerCategory::NullDeref);
+    }
+
+    #[test]
+    fn test_fopen_detected_as_resource_leak() {
+        let detector = DangerousApiDetector::new();
+        let imports = vec![ImportInfo {
+            name: "fopen".into(),
+            library: "libc.so.6".into(),
+        }];
+        let hits = detector.check_imports(&imports);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].danger_category, DangerCategory::ResourceLeak);
+    }
+
+    #[test]
+    fn test_free_detected_as_memory() {
+        let detector = DangerousApiDetector::new();
+        let imports = vec![ImportInfo {
+            name: "free".into(),
+            library: "libc.so.6".into(),
+        }];
+        let hits = detector.check_imports(&imports);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].danger_category, DangerCategory::Memory);
     }
 }


### PR DESCRIPTION
## Summary
- Add `malloc`/`calloc`/`realloc` as NullDeref entries to `DANGEROUS_APIS`
- Add `free` as Memory entry (use-after-free indicator)
- Add `fopen`/`open`/`socket` as ResourceLeak entries
- Update binary detection tests for new API coverage

## Benchmark Impact
Fixtures benchmark (binary mode, `--quick`):

| Metric | Before | After |
|--------|--------|-------|
| **Recall** | 73.3% | **93.3%** |
| **TP** | 22 | **28** |
| **FN** | 8 | **2** |
| CWE-476 (null_deref) | 0% | **100%** |
| CWE-190 (int_overflow) | 0% | **100%** |
| CWE-416 (use_after_free) | 0% | **66.7%** |

Closes #195

## Test plan
- [x] `cargo test -- --test-threads=1` (all pass)
- [x] `cargo clippy --all-targets` (clean)
- [x] `skwaq gym run fixtures --quick` (recall 73.3% → 93.3%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)