### PR TITLE
feat(core): add wide-string buffer APIs for ~2,200 Juliet CWE-121 cases

### DIFF
--- a/crates/core/src/analysis/patterns.rs
+++ b/crates/core/src/analysis/patterns.rs
@@ -124,6 +124,49 @@ pub(crate) const DANGEROUS_APIS: &[DangerousEntry] = &[
         severity: Severity::Low,
         reason: "size semantics are error-prone; prefer strlcat",
     },
+    // Wide-string memory safety (wchar_t equivalents)
+    DangerousEntry {
+        name: "wcscpy",
+        category: DangerCategory::Memory,
+        severity: Severity::Critical,
+        reason: "unbounded wide-string copy; use wcsncpy or wcslcpy",
+    },
+    DangerousEntry {
+        name: "wcscat",
+        category: DangerCategory::Memory,
+        severity: Severity::Critical,
+        reason: "unbounded wide-string concatenation; use wcsncat or wcslcat",
+    },
+    DangerousEntry {
+        name: "wmemcpy",
+        category: DangerCategory::Memory,
+        severity: Severity::Medium,
+        reason: "no bounds checking on wide chars; verify size parameter",
+    },
+    DangerousEntry {
+        name: "wmemmove",
+        category: DangerCategory::Memory,
+        severity: Severity::Medium,
+        reason: "no bounds checking on wide chars; verify size parameter",
+    },
+    DangerousEntry {
+        name: "wcsncpy",
+        category: DangerCategory::Memory,
+        severity: Severity::Low,
+        reason: "may not null-terminate wide string; prefer wcslcpy",
+    },
+    DangerousEntry {
+        name: "wcsncat",
+        category: DangerCategory::Memory,
+        severity: Severity::Low,
+        reason: "size semantics are error-prone for wide strings; prefer wcslcat",
+    },
+    DangerousEntry {
+        name: "swprintf",
+        category: DangerCategory::Memory,
+        severity: Severity::Medium,
+        reason: "wide-string format output; verify buffer size parameter",
+    },
     // Format string
     DangerousEntry {
         name: "sprintf",

--- a/crates/core/src/analysis/patterns_binary.rs
+++ b/crates/core/src/analysis/patterns_binary.rs
@@ -260,4 +260,32 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].danger_category, DangerCategory::Memory);
     }
+
+    #[test]
+    fn test_wide_string_apis_detected_as_memory() {
+        let detector = DangerousApiDetector::new();
+        for api in &[
+            "wcscpy", "wcscat", "wmemcpy", "wmemmove", "wcsncpy", "wcsncat", "swprintf",
+        ] {
+            let imports = vec![ImportInfo {
+                name: (*api).into(),
+                library: "libc.so.6".into(),
+            }];
+            let hits = detector.check_imports(&imports);
+            assert_eq!(
+                hits.len(),
+                1,
+                "Expected 1 hit for wide-string API '{}', got {}",
+                api,
+                hits.len()
+            );
+            assert_eq!(
+                hits[0].danger_category,
+                DangerCategory::Memory,
+                "Expected Memory category for '{}', got {:?}",
+                api,
+                hits[0].danger_category
+            );
+        }
+    }
 }

--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -200,6 +200,8 @@ fn is_function(function_name: &str, names: &[&str]) -> bool {
 fn is_buffer_overflow(category: &str, title: &str, function_name: &str) -> bool {
     const BUFFER_APIS: &[&str] = &[
         "strcpy", "strcat", "gets", "memcpy", "memmove", "strncpy", "strncat",
+        // Wide-string equivalents (wchar_t)
+        "wcscpy", "wcscat", "wmemcpy", "wmemmove", "wcsncpy", "wcsncat", "swprintf",
     ];
     const BUFFER_TERMS: &[&str] = &[
         "buffer overflow",
@@ -747,5 +749,36 @@ mod tests {
             "loop_body",
         );
         assert!(classes.contains(&SemanticPatternClass::UninitializedVar));
+    }
+
+    #[test]
+    fn classifies_buffer_overflow_from_wide_string_apis() {
+        let classifier = SemanticPatternClassifier::new();
+
+        for api in &[
+            "wcscpy", "wcscat", "wmemcpy", "wmemmove", "wcsncpy", "wcsncat", "swprintf",
+        ] {
+            let classes = classifier.classify(
+                "memory",
+                &format!("Dangerous pattern: {} (test.c:10)", api),
+                api,
+            );
+            assert!(
+                classes.contains(&SemanticPatternClass::BufferOverflow),
+                "Expected BufferOverflow for wide-string API '{}', got {:?}",
+                api,
+                classes
+            );
+        }
+    }
+
+    #[test]
+    fn wide_string_apis_do_not_misclassify() {
+        let classifier = SemanticPatternClassifier::new();
+
+        let classes = classifier.classify("memory", "Dangerous pattern: wcscpy", "wcscpy");
+        assert!(classes.contains(&SemanticPatternClass::BufferOverflow));
+        assert!(!classes.contains(&SemanticPatternClass::CommandInjection));
+        assert!(!classes.contains(&SemanticPatternClass::FormatString));
     }
 }


### PR DESCRIPTION
## Summary

- Add 7 wide-string (wchar_t) C library APIs to dangerous pattern detection: `wcscpy`, `wcscat`, `wmemcpy`, `wmemmove`, `wcsncpy`, `wcsncat`, `swprintf`
- These are the direct wchar_t equivalents of the narrow-string APIs already detected (`strcpy`, `strcat`, `memcpy`, etc.)
- **2,232 Juliet CWE-121 test cases** use wide-string APIs that previously had zero pattern detection coverage
- Added to both `DANGEROUS_APIS` (binary import scanning) and `BUFFER_APIS` (semantic classifier)

## Why

CWE-121 (stack-based buffer overflow) is the single largest CWE in Juliet with 5,906 test cases. Of these, 2,232 use wide-string APIs (wcscpy, wcscat, wmemcpy, etc.) that were completely invisible to pattern detection. The narrow-string equivalents were already covered — this closes the gap for the wchar_t variants.

## Test plan

- [x] All 307 existing skwaq-core tests pass
- [x] All 160 existing skwaq-gym tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Pre-commit and pre-push hooks pass
- [x] New test: all 7 wide-string APIs detected as Memory category in binary imports
- [x] New test: all 7 APIs classify as BufferOverflow in semantic classifier
- [x] New test: wide-string APIs don't misclassify as CommandInjection or FormatString
- [ ] Run Juliet benchmark to confirm CWE-121 detection rate increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)