### PR TITLE
fix(gym): preserve use-after-free semantic routing

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -119,7 +119,7 @@ impl SemanticPatternClassifier {
         if is_prototype_pollution(&category, &title) {
             classes.insert(SemanticPatternClass::PrototypePollution);
         }
-        if is_use_after_free(&title) {
+        if is_use_after_free(&category, &title) {
             classes.insert(SemanticPatternClass::UseAfterFree);
         }
         if is_race_condition(&category, &title, &function_name) {
@@ -261,8 +261,9 @@ fn is_path_traversal(category: &str, title: &str) -> bool {
         )
 }
 
-fn is_use_after_free(title: &str) -> bool {
-    contains_any(title, &["use-after-free", "use after free", "uaf"])
+fn is_use_after_free(category: &str, title: &str) -> bool {
+    category == "use_after_free"
+        || contains_any(title, &["use-after-free", "use after free", "uaf"])
 }
 
 fn is_race_condition(category: &str, title: &str, function_name: &str) -> bool {
@@ -481,6 +482,17 @@ mod tests {
             "memory",
             "LLM: use-after-free in cleanup",
             "cleanup",
+        );
+
+        assert!(classes.contains(&SemanticPatternClass::UseAfterFree));
+    }
+
+    #[test]
+    fn classifies_use_after_free_from_category() {
+        let classes = SemanticPatternClassifier::new().classify(
+            "use_after_free",
+            "Dangerous API: free",
+            "free",
         );
 
         assert!(classes.contains(&SemanticPatternClass::UseAfterFree));

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -1952,6 +1952,22 @@ mod tests {
     }
 
     #[test]
+    fn test_semantic_prompt_hint_uses_use_after_free_category() {
+        let finding = DetectedFinding {
+            id: "1".into(),
+            category: "use_after_free".into(),
+            severity: "high".into(),
+            cwes: vec![],
+            file: "test.c".into(),
+            function: "free".into(),
+            line: Some(10),
+            title: "Dangerous API: free".into(),
+        };
+
+        assert_eq!(semantic_prompt_hint(&finding), "use_after_free");
+    }
+
+    #[test]
     fn test_dedup_location_key_falls_back_to_id_for_empty_title() {
         let finding = DetectedFinding {
             id: "finding-1".into(),


### PR DESCRIPTION
## Summary
- let semantic classification treat the existing `use_after_free` category as semantic evidence instead of requiring title text to say UAF explicitly
- keep the change narrow so generic `memory` findings still avoid overclassification
- add regressions in core semantic classification and gym semantic prompt routing

## Validation
- cargo fmt --all
- cargo test -q -p skwaq-core semantic_classifier
- cargo test -q -p skwaq-gym agentic::tests
- cargo clippy -q -p skwaq-core --tests -- -D warnings
- cargo clippy -q -p skwaq-gym --tests -- -D warnings
- cargo test -q -p skwaq-core
- RUST_TEST_THREADS=1 cargo test -q -p skwaq-gym  # 176 tests passed; 2 unrelated suite-listing tests hit the known host SQLite xShmMap/disk-full environment flake
- ./tests/qa/bin/gym-semantic-report.sh from a tmpfs copy (passed)

## Notes
The only remaining red in full gym validation on this host was the pre-existing environment failure in `tests::test_available_suite_names_includes_optional_manifests` and `tests::test_unknown_suite_lists_registered_suites`, both failing inside SQLite shared-memory setup under disk pressure rather than in the changed code path.