### PR TITLE
feat(gym): harden benchmark sharding and per-case dedup

### DIFF
--- a/.github/workflows/gym-smoke.yml
+++ b/.github/workflows/gym-smoke.yml
@@ -1,6 +1,11 @@
 name: Gym Smoke
 on: [pull_request]
 
+env:
+  # Minimum F1 score (0.0-1.0) required to pass the benchmark gate.
+  # Adjust as detection improves. Current baseline: 0.10 (10%).
+  GYM_F1_THRESHOLD: "0.10"
+
 jobs:
   gym-smoke:
     runs-on: ubuntu-latest
@@ -26,3 +31,59 @@ jobs:
         with:
           name: gym-smoke-results
           path: gym-smoke-results.json
+
+  ci-benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build
+
+      - name: Run fixtures benchmark (pattern mode)
+        run: |
+          ./target/debug/skwaq gym run fixtures --quick
+          echo "Fixtures benchmark completed"
+
+      - name: Run juliet subset benchmark (20 cases, pattern mode)
+        run: |
+          ./target/debug/skwaq gym run juliet --max-cases 20 --quick || true
+          echo "Juliet subset benchmark completed (may skip if data not available)"
+
+      - name: Generate benchmark report
+        run: |
+          ./target/debug/skwaq gym report --format json > ci-benchmark-results.json
+          cat ci-benchmark-results.json
+
+      - name: Check F1 threshold
+        run: |
+          F1=$(python3 -c "
+          import json, sys
+          try:
+              data = json.load(open('ci-benchmark-results.json'))
+              f1 = float(data.get('f1', data.get('F1', 0)))
+              print(f'{f1:.4f}')
+          except Exception as e:
+              print(f'Warning: could not parse results: {e}', file=sys.stderr)
+              print('0.0')
+          ")
+          echo "F1 score: $F1"
+          echo "Threshold: $GYM_F1_THRESHOLD"
+          python3 -c "
+          import sys
+          f1 = float('$F1')
+          threshold = float('$GYM_F1_THRESHOLD')
+          if f1 < threshold:
+              print(f'FAIL: F1 {f1:.4f} is below threshold {threshold:.4f}')
+              sys.exit(1)
+          else:
+              print(f'PASS: F1 {f1:.4f} >= threshold {threshold:.4f}')
+          "
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ci-benchmark-results
+          path: ci-benchmark-results.json

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -314,25 +314,78 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
     }
 }
 
+/// Deduplicate outcomes by case ID, merging results when the same case
+/// appears in multiple shards/processes. When duplicates exist, findings
+/// are merged (union of matched/unmatched IDs, union of detected CWEs,
+/// and CWE hits use logical OR so a hit in any shard counts).
+pub fn deduplicate_outcomes(outcomes: Vec<CaseOutcome>) -> Vec<CaseOutcome> {
+    let mut by_case: HashMap<String, CaseOutcome> = HashMap::new();
+
+    for outcome in outcomes {
+        by_case
+            .entry(outcome.case_id.clone())
+            .and_modify(|existing| {
+                assert_eq!(
+                    existing.suite, outcome.suite,
+                    "duplicate case {} had inconsistent suites during deduplication",
+                    existing.case_id
+                );
+
+                let existing_expected: HashSet<u32> =
+                    existing.expected_cwes.iter().copied().collect();
+                let incoming_expected: HashSet<u32> =
+                    outcome.expected_cwes.iter().copied().collect();
+                assert_eq!(
+                    existing_expected, incoming_expected,
+                    "duplicate case {} had inconsistent expected CWEs during deduplication",
+                    existing.case_id
+                );
+
+                let mut detected_set: HashSet<u32> =
+                    existing.detected_cwes.iter().copied().collect();
+                for &cwe in &outcome.detected_cwes {
+                    detected_set.insert(cwe);
+                }
+                existing.detected_cwes = detected_set.into_iter().collect();
+
+                let mut matched_set: HashSet<String> =
+                    existing.matched_finding_ids.drain(..).collect();
+                for id in &outcome.matched_finding_ids {
+                    matched_set.insert(id.clone());
+                }
+                existing.matched_finding_ids = matched_set.into_iter().collect();
+
+                let mut unmatched_set: HashSet<String> =
+                    existing.unmatched_finding_ids.drain(..).collect();
+                for id in &outcome.unmatched_finding_ids {
+                    unmatched_set.insert(id.clone());
+                }
+                existing.unmatched_finding_ids = unmatched_set.into_iter().collect();
+
+                for (&cwe, &hit) in &outcome.cwe_hits {
+                    let entry = existing.cwe_hits.entry(cwe).or_insert(false);
+                    *entry = *entry || hit;
+                }
+            })
+            .or_insert(outcome);
+    }
+
+    by_case.into_values().collect()
+}
+
 /// Compute aggregate scores from a list of case outcomes.
 ///
-/// Deduplicates outcomes by `case_id` so that overlapping parallel shards
-/// do not double-count the same test case. When duplicates exist, the first
-/// occurrence is kept (arbitrary but deterministic for a given input order).
+/// Deduplicates outcomes by case ID before aggregation so that the same
+/// test case appearing in multiple shards/processes is only counted once.
 pub fn aggregate(outcomes: &[CaseOutcome]) -> AggregateScore {
+    // Deduplicate by case_id to handle cross-shard merging
+    let deduped = deduplicate_outcomes(outcomes.to_vec());
+
     let mut score = AggregateScore::default();
     let mut per_cwe: HashMap<u32, CweScore> = HashMap::new();
     let mut per_semantic: HashMap<String, SemanticScore> = HashMap::new();
-    let mut seen_case_ids: HashSet<String> = HashSet::new();
 
-    for outcome in outcomes {
-        if !seen_case_ids.insert(outcome.case_id.clone()) {
-            tracing::debug!(
-                "Dedup: skipping duplicate case_id={} (already aggregated)",
-                outcome.case_id
-            );
-            continue;
-        }
+    for outcome in &deduped {
         if outcome.expected_cwes.is_empty() {
             // Negative test case.
             if outcome.detected_cwes.is_empty() {
@@ -845,10 +898,10 @@ mod tests {
 
     #[test]
     fn test_aggregate_dedup_by_case_id() {
-        // Simulate overlapping shards: same case_id appears twice
+        // Simulate overlapping shards: the same case appears twice and must merge.
         let outcomes = vec![
             CaseOutcome {
-                case_id: "case1".to_string(),
+                case_id: "case-1".to_string(),
                 suite: "test".to_string(),
                 expected_cwes: vec![121],
                 detected_cwes: vec![119],
@@ -857,16 +910,16 @@ mod tests {
                 cwe_hits: [(121, true)].into_iter().collect(),
             },
             CaseOutcome {
-                case_id: "case1".to_string(), // duplicate
+                case_id: "case-1".to_string(), // duplicate case_id from another shard
                 suite: "test".to_string(),
                 expected_cwes: vec![121],
-                detected_cwes: vec![119],
-                matched_finding_ids: vec!["f1".to_string()],
+                detected_cwes: vec![122],
+                matched_finding_ids: vec!["f2".to_string()],
                 unmatched_finding_ids: vec![],
                 cwe_hits: [(121, true)].into_iter().collect(),
             },
             CaseOutcome {
-                case_id: "case2".to_string(),
+                case_id: "case-2".to_string(),
                 suite: "test".to_string(),
                 expected_cwes: vec![134],
                 detected_cwes: vec![],
@@ -882,6 +935,64 @@ mod tests {
         assert_eq!(score.false_negatives, 1);
         assert_eq!(score.precision, 1.0);
         assert_eq!(score.recall, 0.5);
+    }
+
+    #[test]
+    fn test_deduplicate_merges_findings() {
+        let outcomes = vec![
+            CaseOutcome {
+                case_id: "case-1".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![121],
+                detected_cwes: vec![119],
+                matched_finding_ids: vec!["f1".to_string()],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(121, false)].into_iter().collect(),
+            },
+            CaseOutcome {
+                case_id: "case-1".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![121],
+                detected_cwes: vec![122],
+                matched_finding_ids: vec!["f2".to_string()],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(121, true)].into_iter().collect(),
+            },
+        ];
+
+        let deduped = deduplicate_outcomes(outcomes);
+        assert_eq!(deduped.len(), 1);
+        let merged = &deduped[0];
+        assert!(merged.cwe_hits[&121], "CWE hit should be OR-merged");
+        assert!(merged.detected_cwes.len() >= 2);
+        assert_eq!(merged.matched_finding_ids.len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "inconsistent expected CWEs")]
+    fn test_deduplicate_rejects_inconsistent_expected_cwes() {
+        let outcomes = vec![
+            CaseOutcome {
+                case_id: "case-1".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![121],
+                detected_cwes: vec![119],
+                matched_finding_ids: vec!["f1".to_string()],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(121, true)].into_iter().collect(),
+            },
+            CaseOutcome {
+                case_id: "case-1".to_string(),
+                suite: "test".to_string(),
+                expected_cwes: vec![134],
+                detected_cwes: vec![134],
+                matched_finding_ids: vec!["f2".to_string()],
+                unmatched_finding_ids: vec![],
+                cwe_hits: [(134, true)].into_iter().collect(),
+            },
+        ];
+
+        let _ = deduplicate_outcomes(outcomes);
     }
 
     #[test]

--- a/scripts/parallel-gym.sh
+++ b/scripts/parallel-gym.sh
@@ -41,7 +41,11 @@ validate_suite_case_count "$TOTAL" "total_cases" || exit 1
 validate_suite_case_count "$NPROCS" "num_procs" || exit 1
 EXTRA_ARGS=("$@")
 
-CASES_PER_PROC=$(( (TOTAL + NPROCS - 1) / NPROCS ))  # ceiling division
+# Compute strictly non-overlapping, gap-free shard ranges.
+# Uses floor division with remainder distributed to the first N shards.
+BASE_PER_PROC=$(( TOTAL / NPROCS ))
+REMAINDER=$(( TOTAL % NPROCS ))
+
 SKWAQ="${SKWAQ:-./target/release/skwaq}"
 OUTDIR=$(mktemp -d /tmp/gym-parallel-${SUITE}-XXXXXX)
 
@@ -49,7 +53,7 @@ echo "=== Parallel Gym Run ==="
 echo "Suite:      $SUITE"
 echo "Total:      $TOTAL cases"
 echo "Processes:  $NPROCS"
-echo "Per proc:   $CASES_PER_PROC cases (last shard may be smaller)"
+echo "Base/proc:  $BASE_PER_PROC cases (+1 for first $REMAINDER procs)"
 echo "Binary:     $SKWAQ"
 echo "Output:     $OUTDIR"
 echo "Extra args: ${EXTRA_ARGS[*]}"
@@ -61,30 +65,53 @@ if [ ! -f "$SKWAQ" ]; then
     cargo build --release
 fi
 
-# Launch N processes with non-overlapping shard ranges.
-# Each shard gets exactly [SKIP, SKIP+COUNT) where COUNT is capped so the
-# last shard never extends beyond TOTAL, preventing double-counting.
-PIDS=()
-ASSIGNED=0
+# Compute and validate all shard ranges before launching
+declare -a SHARD_SKIPS
+declare -a SHARD_COUNTS
+OFFSET=0
 for i in $(seq 0 $((NPROCS - 1))); do
-    SKIP=$ASSIGNED
-    REMAINING=$((TOTAL - ASSIGNED))
-
-    # Cap this shard's size so it never exceeds the remaining cases
-    if [ "$REMAINING" -le 0 ]; then
-        echo "  Process $i: skipped (no remaining cases)"
-        continue
+    # First REMAINDER shards get (BASE_PER_PROC + 1) cases, rest get BASE_PER_PROC
+    if [ "$i" -lt "$REMAINDER" ]; then
+        COUNT=$((BASE_PER_PROC + 1))
+    else
+        COUNT=$BASE_PER_PROC
     fi
-    COUNT=$CASES_PER_PROC
-    if [ "$COUNT" -gt "$REMAINING" ]; then
-        COUNT=$REMAINING
-    fi
-    ASSIGNED=$((ASSIGNED + COUNT))
+    SHARD_SKIPS[$i]=$OFFSET
+    SHARD_COUNTS[$i]=$COUNT
+    OFFSET=$((OFFSET + COUNT))
+done
 
+# Assert: total assigned must equal TOTAL (gap-free)
+if [ "$OFFSET" -ne "$TOTAL" ]; then
+    echo "ERROR: Shard ranges do not sum to total! Assigned=$OFFSET Expected=$TOTAL" >&2
+    exit 1
+fi
+
+# Assert: ranges are non-overlapping (each starts where the previous ended)
+PREV_END=0
+for i in $(seq 0 $((NPROCS - 1))); do
+    if [ "${SHARD_SKIPS[$i]}" -ne "$PREV_END" ]; then
+        echo "ERROR: Shard $i starts at ${SHARD_SKIPS[$i]} but previous ended at $PREV_END (overlap or gap!)" >&2
+        exit 1
+    fi
+    PREV_END=$((SHARD_SKIPS[$i] + SHARD_COUNTS[$i]))
+done
+
+# Launch N processes
+PIDS=()
+for i in $(seq 0 $((NPROCS - 1))); do
+    SKIP=${SHARD_SKIPS[$i]}
+    COUNT=${SHARD_COUNTS[$i]}
     LOG="$OUTDIR/proc-${i}.log"
     JSON="$OUTDIR/proc-${i}.json"
 
-    echo "  Process $i: skip=$SKIP count=$COUNT -> $LOG"
+    echo "  Process $i: skip=$SKIP max=$COUNT -> $LOG"
+
+    # Skip empty shards (can happen if NPROCS > TOTAL)
+    if [ "$COUNT" -eq 0 ]; then
+        echo "  Process $i: 0 cases, skipping"
+        continue
+    fi
 
     "$SKWAQ" gym run "$SUITE" \
         --skip "$SKIP" \
@@ -97,7 +124,7 @@ for i in $(seq 0 $((NPROCS - 1))); do
 done
 
 echo ""
-echo "Waiting for $NPROCS processes..."
+echo "Waiting for ${#PIDS[@]} processes..."
 
 # Wait and collect exit codes
 FAILURES=0
@@ -116,8 +143,10 @@ echo "=== Results ==="
 # Show individual results
 for i in $(seq 0 $((NPROCS - 1))); do
     LOG="$OUTDIR/proc-${i}.log"
-    echo "--- Process $i ---"
-    grep -E "F1|Precision|Recall|TP:|FP:|FN:" "$LOG" 2>/dev/null || echo "  (no results)"
+    if [ -f "$LOG" ]; then
+        echo "--- Process $i ---"
+        grep -E "F1|Precision|Recall|TP:|FP:|FN:" "$LOG" 2>/dev/null || echo "  (no results)"
+    fi
 done
 
 # Merge JSON results if jq is available


### PR DESCRIPTION
## Summary
- deduplicate benchmark case outcomes once across shards/processes while rejecting inconsistent duplicate metadata
- keep `parallel-gym.sh` shards non-overlapping so aggregate counts stay per-case
- surface the branch in `gym-smoke` so CI exercises the benchmark path directly

## Testing
- `cargo fmt --all`
- `cargo test -q -p skwaq-gym scoring::tests`
- `cargo clippy -q -p skwaq-gym --tests -- -D warnings`
- `cargo test -q -p skwaq-gym`
- `bash -n scripts/parallel-gym.sh`









