### PR TITLE
feat(gym): persist per-case outcome diffs

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -118,6 +118,13 @@ pub enum GymSub {
         max_cases: usize,
     },
 
+    /// Compare per-case outcomes between the latest two finished runs for a suite
+    CaseDiff {
+        /// Suite to diff (defaults to the suite from the most recent finished run)
+        #[arg(long)]
+        suite: Option<String>,
+    },
+
     /// Generate dashboard: mermaid charts + scores table from run history
     Dashboard,
 
@@ -242,6 +249,80 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
         }
         GymSub::History { limit } => {
             gym.history(*limit)?;
+        }
+        GymSub::CaseDiff { suite } => {
+            let suite = if let Some(suite) = suite {
+                suite.clone()
+            } else {
+                gym.history_db
+                    .recent_finished_runs(1)?
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("No finished runs yet. Run `skwaq gym run` first.")
+                    })?
+                    .suite
+            };
+            let runs = gym.history_db.recent_finished_runs_for_suite(&suite, 2)?;
+            if runs.len() < 2 {
+                anyhow::bail!(
+                    "Need at least 2 finished runs for suite `{}` to diff. Run `skwaq gym run {}` twice.",
+                    suite,
+                    suite
+                );
+            }
+
+            let deltas = gym
+                .history_db
+                .compare_case_outcomes(&runs[1].id, &runs[0].id)?;
+            if deltas.is_empty() {
+                println!("No per-case changes between the last two runs.");
+                println!(
+                    "(Hint: per-case outcomes are recorded during `gym run`; identical runs simply produce no deltas.)"
+                );
+            } else {
+                println!(
+                    "\nPer-case diff for suite `{}`: {} -> {}",
+                    suite,
+                    &runs[1].skwaq_commit[..6.min(runs[1].skwaq_commit.len())],
+                    &runs[0].skwaq_commit[..6.min(runs[0].skwaq_commit.len())]
+                );
+                println!("{}", "-".repeat(60));
+                for delta in &deltas {
+                    match delta {
+                        skwaq_gym::history::CaseDelta::Improved { case_id, cwe } => {
+                            println!("  [+] IMPROVED  {} (CWE-{}): FN -> TP", case_id, cwe);
+                        }
+                        skwaq_gym::history::CaseDelta::Regressed { case_id, cwe } => {
+                            println!("  [-] REGRESSED {} (CWE-{}): TP -> FN", case_id, cwe);
+                        }
+                        skwaq_gym::history::CaseDelta::NewFalsePositive { case_id, cwe } => {
+                            println!("  [!] NEW FP    {} (CWE-{})", case_id, cwe);
+                        }
+                        skwaq_gym::history::CaseDelta::FixedFalsePositive { case_id, cwe } => {
+                            println!("  [*] FIXED FP  {} (CWE-{})", case_id, cwe);
+                        }
+                    }
+                }
+
+                let improved = deltas
+                    .iter()
+                    .filter(|delta| matches!(delta, skwaq_gym::history::CaseDelta::Improved { .. }))
+                    .count();
+                let regressed = deltas
+                    .iter()
+                    .filter(|delta| {
+                        matches!(delta, skwaq_gym::history::CaseDelta::Regressed { .. })
+                    })
+                    .count();
+                println!();
+                println!(
+                    "  Summary: {} improved, {} regressed, {} total changes",
+                    improved,
+                    regressed,
+                    deltas.len()
+                );
+            }
         }
         GymSub::Eval {
             suites,

--- a/crates/gym/src/history.rs
+++ b/crates/gym/src/history.rs
@@ -81,6 +81,55 @@ pub struct CaseResult {
     pub classification: String,
 }
 
+/// Per-case outcome classification persisted for per-CWE diffs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CaseOutcomeKind {
+    TruePositive,
+    FalsePositive,
+    FalseNegative,
+}
+
+impl std::fmt::Display for CaseOutcomeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CaseOutcomeKind::TruePositive => write!(f, "TP"),
+            CaseOutcomeKind::FalsePositive => write!(f, "FP"),
+            CaseOutcomeKind::FalseNegative => write!(f, "FN"),
+        }
+    }
+}
+
+impl std::str::FromStr for CaseOutcomeKind {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TP" => Ok(CaseOutcomeKind::TruePositive),
+            "FP" => Ok(CaseOutcomeKind::FalsePositive),
+            "FN" => Ok(CaseOutcomeKind::FalseNegative),
+            _ => anyhow::bail!("Unknown outcome kind: {}", s),
+        }
+    }
+}
+
+/// A single per-case outcome stored in the case_outcomes table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaseOutcome {
+    pub run_id: String,
+    pub case_id: String,
+    pub outcome: CaseOutcomeKind,
+    pub cwe: u32,
+}
+
+/// Describes how a specific case changed between two runs.
+#[derive(Debug, Clone)]
+pub enum CaseDelta {
+    Improved { case_id: String, cwe: u32 },
+    Regressed { case_id: String, cwe: u32 },
+    NewFalsePositive { case_id: String, cwe: u32 },
+    FixedFalsePositive { case_id: String, cwe: u32 },
+}
+
 /// A regression where a case went from detected (TP) to missed (FN).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CaseRegression {
@@ -180,9 +229,18 @@ impl HistoryDb {
                 PRIMARY KEY (run_id, suite, case_id)
             );
 
+            CREATE TABLE IF NOT EXISTS case_outcomes (
+                run_id TEXT NOT NULL REFERENCES runs(id),
+                case_id TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                cwe INTEGER NOT NULL,
+                PRIMARY KEY (run_id, case_id, cwe)
+            );
+
             CREATE INDEX IF NOT EXISTS idx_cwe_results_cwe ON cwe_results(cwe_id);
             CREATE INDEX IF NOT EXISTS idx_semantic_results_class ON semantic_results(class_name);
             CREATE INDEX IF NOT EXISTS idx_case_results_suite ON case_results(suite);
+            CREATE INDEX IF NOT EXISTS idx_case_outcomes_run ON case_outcomes(run_id);
             CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at);
             ",
         )?;
@@ -239,6 +297,10 @@ impl HistoryDb {
 
     /// Remove a run that failed before producing a usable result.
     pub fn abandon_run(&self, run_id: &str) -> anyhow::Result<()> {
+        self.conn.execute(
+            "DELETE FROM case_outcomes WHERE run_id = ?1",
+            rusqlite::params![run_id],
+        )?;
         self.conn.execute(
             "DELETE FROM case_results WHERE run_id = ?1",
             rusqlite::params![run_id],
@@ -311,6 +373,21 @@ impl HistoryDb {
                 serde_json::to_string(&result.matched_finding_ids)?,
                 serde_json::to_string(&result.unmatched_finding_ids)?,
                 result.classification
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a per-case outcome (TP/FP/FN) for a specific CWE.
+    pub fn insert_case_outcome(&self, outcome: &CaseOutcome) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO case_outcomes (run_id, case_id, outcome, cwe)
+             VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![
+                outcome.run_id,
+                outcome.case_id,
+                outcome.outcome.to_string(),
+                outcome.cwe
             ],
         )?;
         Ok(())
@@ -496,6 +573,112 @@ impl HistoryDb {
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Load all case outcomes for a run.
+    pub fn case_outcomes_for_run(&self, run_id: &str) -> anyhow::Result<Vec<CaseOutcome>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT run_id, case_id, outcome, cwe
+             FROM case_outcomes WHERE run_id = ?1 ORDER BY case_id, cwe",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![run_id], |row| {
+            let run_id: String = row.get(0)?;
+            let case_id: String = row.get(1)?;
+            let outcome_str: String = row.get(2)?;
+            let cwe: u32 = row.get(3)?;
+            let outcome = outcome_str.parse().unwrap_or_else(|err| {
+                tracing::warn!(
+                    "Invalid case outcome '{}' for run {} case {} CWE-{}: {}. Defaulting to FN.",
+                    outcome_str,
+                    run_id,
+                    case_id,
+                    cwe,
+                    err
+                );
+                CaseOutcomeKind::FalseNegative
+            });
+            Ok(CaseOutcome {
+                run_id,
+                case_id,
+                outcome,
+                cwe,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Compare two runs and return per-case deltas (improvements and regressions).
+    pub fn compare_case_outcomes(
+        &self,
+        baseline_run_id: &str,
+        new_run_id: &str,
+    ) -> anyhow::Result<Vec<CaseDelta>> {
+        let baseline = self.case_outcomes_for_run(baseline_run_id)?;
+        let new = self.case_outcomes_for_run(new_run_id)?;
+
+        let baseline_map: std::collections::HashMap<(String, u32), CaseOutcomeKind> = baseline
+            .into_iter()
+            .map(|outcome| ((outcome.case_id, outcome.cwe), outcome.outcome))
+            .collect();
+        let new_map: std::collections::HashMap<(String, u32), CaseOutcomeKind> = new
+            .into_iter()
+            .map(|outcome| ((outcome.case_id, outcome.cwe), outcome.outcome))
+            .collect();
+
+        let mut deltas = Vec::new();
+        let mut all_keys: std::collections::HashSet<(String, u32)> =
+            baseline_map.keys().cloned().collect();
+        all_keys.extend(new_map.keys().cloned());
+
+        for key in all_keys {
+            let old = baseline_map.get(&key);
+            let new_outcome = new_map.get(&key);
+            match (old, new_outcome) {
+                (Some(CaseOutcomeKind::FalseNegative), Some(CaseOutcomeKind::TruePositive)) => {
+                    deltas.push(CaseDelta::Improved {
+                        case_id: key.0,
+                        cwe: key.1,
+                    });
+                }
+                (Some(CaseOutcomeKind::TruePositive), Some(CaseOutcomeKind::FalseNegative)) => {
+                    deltas.push(CaseDelta::Regressed {
+                        case_id: key.0,
+                        cwe: key.1,
+                    });
+                }
+                (None, Some(CaseOutcomeKind::FalsePositive)) => {
+                    deltas.push(CaseDelta::NewFalsePositive {
+                        case_id: key.0,
+                        cwe: key.1,
+                    });
+                }
+                (Some(CaseOutcomeKind::FalsePositive), None) => {
+                    deltas.push(CaseDelta::FixedFalsePositive {
+                        case_id: key.0,
+                        cwe: key.1,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        deltas.sort_by(|a, b| {
+            let a_key = match a {
+                CaseDelta::Improved { case_id, cwe }
+                | CaseDelta::Regressed { case_id, cwe }
+                | CaseDelta::NewFalsePositive { case_id, cwe }
+                | CaseDelta::FixedFalsePositive { case_id, cwe } => (case_id.clone(), *cwe),
+            };
+            let b_key = match b {
+                CaseDelta::Improved { case_id, cwe }
+                | CaseDelta::Regressed { case_id, cwe }
+                | CaseDelta::NewFalsePositive { case_id, cwe }
+                | CaseDelta::FixedFalsePositive { case_id, cwe } => (case_id.clone(), *cwe),
+            };
+            a_key.cmp(&b_key)
+        });
+
+        Ok(deltas)
     }
 
     /// Find per-case regressions between two runs.
@@ -786,6 +969,119 @@ mod tests {
         assert_eq!(results[0].expected_cwes, vec![121, 134]);
         assert_eq!(results[0].detected_cwes, vec![119]);
         assert_eq!(results[0].classification, "TP");
+    }
+
+    #[test]
+    fn test_case_outcomes_roundtrip() {
+        let db = HistoryDb::in_memory().unwrap();
+        let run_id = db
+            .start_run("fixtures", "abc123", &RunMetadata::default())
+            .unwrap();
+
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run_id.clone(),
+            case_id: "case1".to_string(),
+            outcome: CaseOutcomeKind::TruePositive,
+            cwe: 121,
+        })
+        .unwrap();
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run_id.clone(),
+            case_id: "case2".to_string(),
+            outcome: CaseOutcomeKind::FalseNegative,
+            cwe: 78,
+        })
+        .unwrap();
+
+        let outcomes = db.case_outcomes_for_run(&run_id).unwrap();
+        assert_eq!(outcomes.len(), 2);
+        assert_eq!(outcomes[0].outcome, CaseOutcomeKind::TruePositive);
+        assert_eq!(outcomes[1].outcome, CaseOutcomeKind::FalseNegative);
+    }
+
+    #[test]
+    fn test_case_outcomes_invalid_kind_defaults_false_negative() {
+        let db = HistoryDb::in_memory().unwrap();
+        let run_id = db
+            .start_run("fixtures", "abc123", &RunMetadata::default())
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO case_outcomes (run_id, case_id, outcome, cwe) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![run_id, "case1", "BAD", 121],
+            )
+            .unwrap();
+
+        let outcomes = db.case_outcomes_for_run(&run_id).unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].outcome, CaseOutcomeKind::FalseNegative);
+    }
+
+    #[test]
+    fn test_compare_case_outcomes() {
+        let db = HistoryDb::in_memory().unwrap();
+        let meta = RunMetadata::default();
+        let run1 = db.start_run("fixtures", "aaa111", &meta).unwrap();
+        let run2 = db.start_run("fixtures", "bbb222", &meta).unwrap();
+
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run1.clone(),
+            case_id: "case1".to_string(),
+            outcome: CaseOutcomeKind::FalseNegative,
+            cwe: 121,
+        })
+        .unwrap();
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run1.clone(),
+            case_id: "case2".to_string(),
+            outcome: CaseOutcomeKind::TruePositive,
+            cwe: 78,
+        })
+        .unwrap();
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run1.clone(),
+            case_id: "case3".to_string(),
+            outcome: CaseOutcomeKind::FalsePositive,
+            cwe: 89,
+        })
+        .unwrap();
+
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run2.clone(),
+            case_id: "case1".to_string(),
+            outcome: CaseOutcomeKind::TruePositive,
+            cwe: 121,
+        })
+        .unwrap();
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run2.clone(),
+            case_id: "case2".to_string(),
+            outcome: CaseOutcomeKind::FalseNegative,
+            cwe: 78,
+        })
+        .unwrap();
+        db.insert_case_outcome(&CaseOutcome {
+            run_id: run2.clone(),
+            case_id: "case4".to_string(),
+            outcome: CaseOutcomeKind::FalsePositive,
+            cwe: 134,
+        })
+        .unwrap();
+
+        let deltas = db.compare_case_outcomes(&run1, &run2).unwrap();
+        assert_eq!(deltas.len(), 4);
+        assert!(deltas.iter().any(
+            |delta| matches!(delta, CaseDelta::Improved { case_id, .. } if case_id == "case1")
+        ));
+        assert!(deltas.iter().any(
+            |delta| matches!(delta, CaseDelta::Regressed { case_id, .. } if case_id == "case2")
+        ));
+        assert!(deltas
+            .iter()
+            .any(|delta| matches!(delta, CaseDelta::FixedFalsePositive { case_id, .. } if case_id == "case3")));
+        assert!(deltas
+            .iter()
+            .any(|delta| matches!(delta, CaseDelta::NewFalsePositive { case_id, .. } if case_id == "case4")));
     }
 
     #[test]

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -431,20 +431,8 @@ impl Gym {
 
             // Store per-case results for regression tracking.
             for outcome in &outcomes {
-                let classification = if outcome.expected_cwes.is_empty() {
-                    if outcome.detected_cwes.is_empty() {
-                        "TN"
-                    } else {
-                        "FP"
-                    }
-                } else if outcome.cwe_hits.values().all(|&hit| hit) {
-                    "TP"
-                } else if outcome.cwe_hits.values().any(|&hit| hit) {
-                    "PARTIAL"
-                } else {
-                    "FN"
-                };
-                let _ = self.history_db.insert_case_result(&history::CaseResult {
+                let classification = classify_case_result(outcome);
+                if let Err(err) = self.history_db.insert_case_result(&history::CaseResult {
                     run_id: run_id.clone(),
                     suite: suite_name.clone(),
                     case_id: outcome.case_id.clone(),
@@ -453,7 +441,27 @@ impl Gym {
                     matched_finding_ids: outcome.matched_finding_ids.clone(),
                     unmatched_finding_ids: outcome.unmatched_finding_ids.clone(),
                     classification: classification.to_string(),
-                });
+                }) {
+                    if let Err(cleanup_err) = self.history_db.abandon_run(&run_id) {
+                        return Err(err.context(format!(
+                            "failed to store per-case results and failed to clean up unfinished run {}: {}",
+                            run_id, cleanup_err
+                        )));
+                    }
+                    return Err(err);
+                }
+
+                for case_outcome in case_outcomes_for_history(&run_id, outcome) {
+                    if let Err(err) = self.history_db.insert_case_outcome(&case_outcome) {
+                        if let Err(cleanup_err) = self.history_db.abandon_run(&run_id) {
+                            return Err(err.context(format!(
+                                "failed to store per-case outcomes and failed to clean up unfinished run {}: {}",
+                                run_id, cleanup_err
+                            )));
+                        }
+                        return Err(err);
+                    }
+                }
             }
 
             for cwe_score in score.per_cwe.values() {
@@ -671,6 +679,59 @@ fn build_run_metadata(repo: &std::path::Path, config: &BenchmarkConfig) -> histo
     }
 }
 
+fn classify_case_result(outcome: &scoring::CaseOutcome) -> &'static str {
+    if outcome.expected_cwes.is_empty() {
+        if outcome.detected_cwes.is_empty() {
+            "TN"
+        } else {
+            "FP"
+        }
+    } else if outcome.cwe_hits.values().all(|&hit| hit) {
+        "TP"
+    } else if outcome.cwe_hits.values().any(|&hit| hit) {
+        "PARTIAL"
+    } else {
+        "FN"
+    }
+}
+
+fn case_outcomes_for_history(
+    run_id: &str,
+    outcome: &scoring::CaseOutcome,
+) -> Vec<history::CaseOutcome> {
+    if outcome.expected_cwes.is_empty() {
+        return outcome
+            .detected_cwes
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .map(|cwe| history::CaseOutcome {
+                run_id: run_id.to_string(),
+                case_id: outcome.case_id.clone(),
+                outcome: history::CaseOutcomeKind::FalsePositive,
+                cwe,
+            })
+            .collect();
+    }
+
+    outcome
+        .expected_cwes
+        .iter()
+        .copied()
+        .map(|cwe| history::CaseOutcome {
+            run_id: run_id.to_string(),
+            case_id: outcome.case_id.clone(),
+            outcome: if outcome.cwe_hits.get(&cwe).copied().unwrap_or(false) {
+                history::CaseOutcomeKind::TruePositive
+            } else {
+                history::CaseOutcomeKind::FalseNegative
+            },
+            cwe,
+        })
+        .collect()
+}
+
 fn reconstruct_score(
     run: &history::BenchmarkRun,
     cwe_results: &[history::CweResult],
@@ -721,8 +782,9 @@ fn reconstruct_score(
 
 #[cfg(test)]
 mod tests {
-    use super::{reconstruct_score, Gym};
+    use super::{case_outcomes_for_history, classify_case_result, reconstruct_score, Gym};
     use crate::history;
+    use crate::scoring;
 
     fn write_manifest(path: &std::path::Path, suite: &str) {
         std::fs::write(
@@ -839,5 +901,56 @@ language = "c"
             score.per_semantic["buffer_overflow"].class_name,
             "buffer_overflow"
         );
+    }
+
+    #[test]
+    fn test_classify_case_result_handles_partial_hits() {
+        let outcome = scoring::CaseOutcome {
+            case_id: "case-1".to_string(),
+            suite: "fixtures".to_string(),
+            expected_cwes: vec![121, 134],
+            detected_cwes: vec![119],
+            matched_finding_ids: vec!["f1".to_string()],
+            unmatched_finding_ids: vec![],
+            cwe_hits: [(121, true), (134, false)].into_iter().collect(),
+        };
+
+        assert_eq!(classify_case_result(&outcome), "PARTIAL");
+    }
+
+    #[test]
+    fn test_case_outcomes_for_history_records_positive_and_negative_rows() {
+        let positive = scoring::CaseOutcome {
+            case_id: "case-1".to_string(),
+            suite: "fixtures".to_string(),
+            expected_cwes: vec![121, 134],
+            detected_cwes: vec![119],
+            matched_finding_ids: vec!["f1".to_string()],
+            unmatched_finding_ids: vec![],
+            cwe_hits: [(121, true), (134, false)].into_iter().collect(),
+        };
+        let positive_rows = case_outcomes_for_history("run-1", &positive);
+        assert_eq!(positive_rows.len(), 2);
+        assert!(positive_rows.iter().any(|row| {
+            row.cwe == 121 && row.outcome == history::CaseOutcomeKind::TruePositive
+        }));
+        assert!(positive_rows.iter().any(|row| {
+            row.cwe == 134 && row.outcome == history::CaseOutcomeKind::FalseNegative
+        }));
+
+        let negative = scoring::CaseOutcome {
+            case_id: "case-2".to_string(),
+            suite: "fixtures".to_string(),
+            expected_cwes: vec![],
+            detected_cwes: vec![78, 78, 89],
+            matched_finding_ids: vec![],
+            unmatched_finding_ids: vec!["f2".to_string()],
+            cwe_hits: std::collections::HashMap::new(),
+        };
+        let negative_rows = case_outcomes_for_history("run-1", &negative);
+        assert_eq!(negative_rows.len(), 2);
+        assert!(negative_rows
+            .iter()
+            .all(|row| { row.outcome == history::CaseOutcomeKind::FalsePositive }));
     }
 }


### PR DESCRIPTION
## Summary
- persist per-CWE case outcomes during `gym run` alongside the existing per-case summary rows
- add a suite-aware `skwaq gym case-diff [--suite <name>]` command over the latest finished runs
- warn on invalid persisted outcome strings instead of silently dropping them

## Testing
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/skwaq-case-diff-target cargo test -q -p skwaq-gym`
- `CARGO_TARGET_DIR=/tmp/skwaq-case-diff-target cargo test -q -p skwaq`
- `CARGO_TARGET_DIR=/tmp/skwaq-case-diff-target cargo clippy -q -p skwaq-gym -p skwaq --all-targets -- -D warnings`






