### PR TITLE
feat(core,gym): add untrusted search path support

### DIFF
--- a/crates/core/src/analysis/patterns_source.rs
+++ b/crates/core/src/analysis/patterns_source.rs
@@ -849,15 +849,15 @@ fn c_cpp_patterns() -> &'static [SourcePattern] {
         // Process control (CWE-114) — from self-improvement iteration 5
         SourcePattern {
             regex: r"(?i)\bLoadLibrary[AW]?(Ex[AW]?)?\s*\(",
-            category: DangerCategory::Injection,
+            category: DangerCategory::PathTraversal,
             severity: Severity::High,
-            reason: "LoadLibrary with untrusted input allows DLL injection (CWE-114); validate library path",
+            reason: "LoadLibrary with untrusted input allows uncontrolled search path loading (CWE-427); validate library path",
         },
         SourcePattern {
             regex: r"\bdlopen\s*\(",
-            category: DangerCategory::Injection,
+            category: DangerCategory::PathTraversal,
             severity: Severity::High,
-            reason: "dlopen loads shared libraries dynamically; validate library path to prevent code injection",
+            reason: "dlopen with untrusted path allows uncontrolled search path loading (CWE-427); validate library path",
         },
         // Windows-specific patterns (from self-improvement iteration 4)
         SourcePattern {

--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -18,6 +18,7 @@ pub enum SemanticPatternClass {
     FormatString,
     InsecureTempFile,
     PathTraversal,
+    UntrustedSearchPath,
     PrototypePollution,
     RaceCondition,
     UnsafeApiUsage,
@@ -41,6 +42,7 @@ impl SemanticPatternClass {
             Self::FormatString => "format_string",
             Self::InsecureTempFile => "insecure_temp_file",
             Self::PathTraversal => "path_traversal",
+            Self::UntrustedSearchPath => "untrusted_search_path",
             Self::PrototypePollution => "prototype_pollution",
             Self::RaceCondition => "race_condition",
             Self::UnsafeApiUsage => "unsafe_api_usage",
@@ -61,9 +63,10 @@ impl SemanticPatternClass {
             Self::NullDeref => "memory_allocation",
             Self::CommandInjection | Self::Deserialization => "code_execution",
             Self::CrossSiteScripting | Self::PrototypePollution => "web_data_flow",
-            Self::InsecureTempFile | Self::PathTraversal | Self::RaceCondition => {
-                "filesystem_safety"
-            }
+            Self::InsecureTempFile
+            | Self::PathTraversal
+            | Self::UntrustedSearchPath
+            | Self::RaceCondition => "filesystem_safety",
             Self::IntegerOverflow | Self::DivideByZero => "arithmetic_safety",
             Self::ResourceLeak => "resource_management",
             Self::UninitializedVar => "initialization_safety",
@@ -113,8 +116,11 @@ impl SemanticPatternClassifier {
         if is_format_string(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::FormatString);
         }
-        if is_path_traversal(&category, &title) {
+        if is_path_traversal(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::PathTraversal);
+        }
+        if is_untrusted_search_path(&category, &title, &function_name) {
+            classes.insert(SemanticPatternClass::UntrustedSearchPath);
         }
         if is_prototype_pollution(&category, &title) {
             classes.insert(SemanticPatternClass::PrototypePollution);
@@ -253,12 +259,29 @@ fn is_format_string(category: &str, title: &str, function_name: &str) -> bool {
         || contains_any(title, FORMAT_TERMS)
 }
 
-fn is_path_traversal(category: &str, title: &str) -> bool {
-    category == "path_traversal"
-        || contains_any(
-            title,
-            &["path traversal", "directory traversal", "zip slip"],
-        )
+fn is_path_traversal(category: &str, title: &str, function_name: &str) -> bool {
+    !is_untrusted_search_path(category, title, function_name)
+        && (category == "path_traversal"
+            || contains_any(
+                title,
+                &["path traversal", "directory traversal", "zip slip"],
+            ))
+}
+
+fn is_untrusted_search_path(category: &str, title: &str, function_name: &str) -> bool {
+    const SEARCH_PATH_APIS: &[&str] = &["dlopen", "loadlibrary", "loadlibraryex"];
+    const SEARCH_PATH_TERMS: &[&str] = &[
+        "untrusted search path",
+        "uncontrolled search path",
+        "library path",
+        "shared library",
+        "dll search path",
+        "loadlibrary",
+        "dlopen",
+    ];
+
+    is_function(function_name, SEARCH_PATH_APIS)
+        || (category == "path_traversal" && contains_any(title, SEARCH_PATH_TERMS))
 }
 
 fn is_use_after_free(category: &str, title: &str) -> bool {
@@ -512,6 +535,10 @@ mod tests {
             SemanticPatternClass::UseAfterFree.confidence_cluster(),
             "memory_lifecycle"
         );
+        assert_eq!(
+            SemanticPatternClass::UntrustedSearchPath.confidence_cluster(),
+            "filesystem_safety"
+        );
     }
 
     #[test]
@@ -535,6 +562,42 @@ mod tests {
 
         assert!(classes.contains(&SemanticPatternClass::InsecureTempFile));
         assert!(!classes.contains(&SemanticPatternClass::RaceCondition));
+    }
+
+    #[test]
+    fn classifies_untrusted_search_path_without_generic_path_overlap() {
+        let classes = SemanticPatternClassifier::new().classify(
+            "path_traversal",
+            "Pattern: dlopen with untrusted path allows uncontrolled search path loading",
+            "dlopen",
+        );
+
+        assert!(classes.contains(&SemanticPatternClass::UntrustedSearchPath));
+        assert!(!classes.contains(&SemanticPatternClass::PathTraversal));
+    }
+
+    #[test]
+    fn keeps_generic_path_traversal_distinct_from_search_path() {
+        let classes = SemanticPatternClassifier::new().classify(
+            "path_traversal",
+            "LLM: directory traversal in archive extraction",
+            "extract_archive",
+        );
+
+        assert!(classes.contains(&SemanticPatternClass::PathTraversal));
+        assert!(!classes.contains(&SemanticPatternClass::UntrustedSearchPath));
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_library_path_titles_as_search_path() {
+        let classes = SemanticPatternClassifier::new().classify(
+            "memory",
+            "LLM: buffer overflow in library path parser",
+            "strcpy",
+        );
+
+        assert!(classes.contains(&SemanticPatternClass::BufferOverflow));
+        assert!(!classes.contains(&SemanticPatternClass::UntrustedSearchPath));
     }
 
     #[test]

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -258,6 +258,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
         SemanticPatternClass::FormatString => &[134],
         SemanticPatternClass::InsecureTempFile => &[377],
         SemanticPatternClass::PathTraversal => &[22, 23, 36, 426],
+        SemanticPatternClass::UntrustedSearchPath => &[114, 427],
         SemanticPatternClass::PrototypePollution => &[1321],
         SemanticPatternClass::RaceCondition => &[362, 364, 366, 367, 832],
         SemanticPatternClass::UnsafeApiUsage => &[222, 223, 242, 244, 247, 676],
@@ -315,6 +316,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         502 => Some(SemanticPatternClass::Deserialization),
         134 => Some(SemanticPatternClass::FormatString),
         22 | 23 | 36 | 426 => Some(SemanticPatternClass::PathTraversal),
+        114 | 427 => Some(SemanticPatternClass::UntrustedSearchPath),
         1321 => Some(SemanticPatternClass::PrototypePollution),
         362 | 364 | 366 | 367 | 832 => Some(SemanticPatternClass::RaceCondition),
         377 => Some(SemanticPatternClass::InsecureTempFile),
@@ -862,7 +864,10 @@ mod tests {
             cwe_to_semantic_class(426),
             Some(SemanticPatternClass::PathTraversal)
         );
-        assert_eq!(cwe_to_semantic_class(427), None);
+        assert_eq!(
+            cwe_to_semantic_class(427),
+            Some(SemanticPatternClass::UntrustedSearchPath)
+        );
 
         // Temporal memory safety
         assert_eq!(
@@ -1102,6 +1107,21 @@ mod tests {
     }
 
     #[test]
+    fn test_inferred_finding_cwes_for_untrusted_search_path_preserves_legacy_114() {
+        let finding = make_semantic_finding(
+            "path_traversal",
+            "dlopen",
+            "Pattern: dlopen with untrusted path allows uncontrolled search path loading",
+        );
+
+        let inferred = inferred_finding_cwes(&finding);
+        assert!(inferred.contains(&114));
+        assert!(inferred.contains(&427));
+        assert!(!inferred.contains(&22));
+        assert!(!inferred.contains(&426));
+    }
+
+    #[test]
     fn test_aggregate_tracks_per_semantic_scores() {
         let outcomes = vec![
             CaseOutcome {
@@ -1181,6 +1201,11 @@ mod tests {
         let path = semantic_class_to_cwes(SemanticPatternClass::PathTraversal);
         assert!(!path.contains(&59));
         assert!(!path.contains(&61));
+        assert!(!path.contains(&427));
+
+        let search_path = semantic_class_to_cwes(SemanticPatternClass::UntrustedSearchPath);
+        assert!(search_path.contains(&114));
+        assert!(search_path.contains(&427));
 
         let race = semantic_class_to_cwes(SemanticPatternClass::RaceCondition);
         assert!(race.contains(&364));
@@ -1276,8 +1301,9 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(242), Some(UnsafeApiUsage));
         assert_eq!(cwe_to_semantic_class(457), Some(UninitializedVar));
         assert_eq!(cwe_to_semantic_class(908), Some(UninitializedVar));
+        assert_eq!(cwe_to_semantic_class(114), Some(UntrustedSearchPath));
         assert_eq!(cwe_to_semantic_class(426), Some(PathTraversal));
-        assert_eq!(cwe_to_semantic_class(427), None);
+        assert_eq!(cwe_to_semantic_class(427), Some(UntrustedSearchPath));
     }
 
     #[test]
@@ -1289,6 +1315,7 @@ mod tests {
         assert_eq!(cwe_family(404), 401);
         assert_eq!(cwe_family(675), 401);
         assert_eq!(cwe_family(426), 22);
+        assert_eq!(cwe_family(427), 427);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a dedicated semantic lane for untrusted search path findings
- preserve legacy CWE-114 coverage while adding CWE-427 scoring support
- keep search-path findings distinct from generic path traversal and add regression coverage

## Validation
- cargo test -q -p skwaq-core semantic_classifier::tests
- cargo test -q -p skwaq-gym scoring::tests
- cargo clippy -q -p skwaq-core -p skwaq-gym --tests -- -D warnings
- cargo test -q -p skwaq-core
- cargo test -q -p skwaq-gym
- ./tests/qa/bin/gym-semantic-report.sh