### PR TITLE
feat(core,gym): add unchecked loop condition support

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -19,6 +19,7 @@ pub enum SemanticPatternClass {
     InsecureTempFile,
     PathTraversal,
     UntrustedSearchPath,
+    UncheckedLoopCondition,
     PrototypePollution,
     RaceCondition,
     UnsafeApiUsage,
@@ -43,6 +44,7 @@ impl SemanticPatternClass {
             Self::InsecureTempFile => "insecure_temp_file",
             Self::PathTraversal => "path_traversal",
             Self::UntrustedSearchPath => "untrusted_search_path",
+            Self::UncheckedLoopCondition => "unchecked_loop_condition",
             Self::PrototypePollution => "prototype_pollution",
             Self::RaceCondition => "race_condition",
             Self::UnsafeApiUsage => "unsafe_api_usage",
@@ -67,7 +69,9 @@ impl SemanticPatternClass {
             | Self::PathTraversal
             | Self::UntrustedSearchPath
             | Self::RaceCondition => "filesystem_safety",
-            Self::IntegerOverflow | Self::DivideByZero => "arithmetic_safety",
+            Self::UncheckedLoopCondition | Self::IntegerOverflow | Self::DivideByZero => {
+                "arithmetic_safety"
+            }
             Self::ResourceLeak => "resource_management",
             Self::UninitializedVar => "initialization_safety",
             Self::FormatString => "format_string",
@@ -121,6 +125,9 @@ impl SemanticPatternClassifier {
         }
         if is_untrusted_search_path(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::UntrustedSearchPath);
+        }
+        if is_unchecked_loop_condition(&category, &title) {
+            classes.insert(SemanticPatternClass::UncheckedLoopCondition);
         }
         if is_prototype_pollution(&category, &title) {
             classes.insert(SemanticPatternClass::PrototypePollution);
@@ -287,6 +294,22 @@ fn is_untrusted_search_path(category: &str, title: &str, function_name: &str) ->
 fn is_use_after_free(category: &str, title: &str) -> bool {
     category == "use_after_free"
         || contains_any(title, &["use-after-free", "use after free", "uaf"])
+}
+
+fn is_unchecked_loop_condition(category: &str, title: &str) -> bool {
+    const LOOP_CONDITION_TERMS: &[&str] = &[
+        "unchecked loop condition",
+        "untrusted loop condition",
+        "unchecked loop bound",
+        "unchecked loop bounds",
+        "untrusted loop bound",
+        "untrusted loop bounds",
+        "loop condition from untrusted input",
+        "untrusted iteration count",
+        "unbounded iteration count",
+    ];
+
+    category == "unchecked_loop_condition" || contains_any(title, LOOP_CONDITION_TERMS)
 }
 
 fn is_race_condition(category: &str, title: &str, function_name: &str) -> bool {
@@ -539,6 +562,10 @@ mod tests {
             SemanticPatternClass::UntrustedSearchPath.confidence_cluster(),
             "filesystem_safety"
         );
+        assert_eq!(
+            SemanticPatternClass::UncheckedLoopCondition.confidence_cluster(),
+            "arithmetic_safety"
+        );
     }
 
     #[test]
@@ -577,6 +604,17 @@ mod tests {
     }
 
     #[test]
+    fn classifies_unchecked_loop_condition_from_title() {
+        let classes = SemanticPatternClassifier::new().classify(
+            "memory",
+            "LLM: unchecked loop condition from untrusted input controls iteration count",
+            "print_line",
+        );
+
+        assert!(classes.contains(&SemanticPatternClass::UncheckedLoopCondition));
+    }
+
+    #[test]
     fn keeps_generic_path_traversal_distinct_from_search_path() {
         let classes = SemanticPatternClassifier::new().classify(
             "path_traversal",
@@ -586,6 +624,17 @@ mod tests {
 
         assert!(classes.contains(&SemanticPatternClass::PathTraversal));
         assert!(!classes.contains(&SemanticPatternClass::UntrustedSearchPath));
+    }
+
+    #[test]
+    fn does_not_classify_generic_loop_mentions_as_unchecked_loop_condition() {
+        let classes = SemanticPatternClassifier::new().classify(
+            "memory",
+            "LLM: manual byte-by-byte loop without proof of overflow",
+            "copy_bytes",
+        );
+
+        assert!(!classes.contains(&SemanticPatternClass::UncheckedLoopCondition));
     }
 
     #[test]

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -702,9 +702,11 @@ impl ExpertDomain {
             }
             Self::ArithmeticSafety => {
                 "You are a numeric-safety expert reviewing vulnerability findings. \
-                 You specialize in integer overflows, underflows, and divide-by-zero conditions. \
-                 Evaluate whether arithmetic operations on attacker-influenced values can actually \
-                 overflow or produce division by zero in the given context."
+                 You specialize in integer overflows, underflows, divide-by-zero conditions, \
+                 and unchecked loop bounds from untrusted input. \
+                 Evaluate whether arithmetic operations or loop iteration counts on \
+                 attacker-influenced values can actually overflow, divide by zero, or \
+                 drive unsafe looping in the given context."
             }
             Self::Crypto => {
                 "You are a cryptography expert reviewing vulnerability findings. \
@@ -748,10 +750,12 @@ impl ExpertDomain {
             }
             Self::ArithmeticSafety => {
                 "All findings below relate to ARITHMETIC SAFETY vulnerabilities.\n\
-                 Focus on: integer width, signedness, overflow wrapping behavior, and \
-                 divisor validation.\n\
-                 CONFIRM findings where attacker-influenced arithmetic can wrap or divide by zero.\n\
-                 REJECT findings where range checks, saturating arithmetic, or type constraints prevent overflow.\n\n"
+                 Focus on: integer width, signedness, overflow wrapping behavior, \
+                 divisor validation, and loop bound validation.\n\
+                 CONFIRM findings where attacker-influenced arithmetic can wrap, divide by zero, \
+                 or control loop iteration counts without effective bounds checks.\n\
+                 REJECT findings where range checks, saturating arithmetic, type constraints, \
+                 or explicit iteration limits prevent overflow or unsafe looping.\n\n"
             }
             Self::Crypto => {
                 "All findings below relate to CRYPTOGRAPHIC vulnerabilities.\n\

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -259,6 +259,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
         SemanticPatternClass::InsecureTempFile => &[377],
         SemanticPatternClass::PathTraversal => &[22, 23, 36, 426],
         SemanticPatternClass::UntrustedSearchPath => &[114, 427],
+        SemanticPatternClass::UncheckedLoopCondition => &[606],
         SemanticPatternClass::PrototypePollution => &[1321],
         SemanticPatternClass::RaceCondition => &[362, 364, 366, 367, 832],
         SemanticPatternClass::UnsafeApiUsage => &[222, 223, 242, 244, 247, 676],
@@ -317,6 +318,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         134 => Some(SemanticPatternClass::FormatString),
         22 | 23 | 36 | 426 => Some(SemanticPatternClass::PathTraversal),
         114 | 427 => Some(SemanticPatternClass::UntrustedSearchPath),
+        606 => Some(SemanticPatternClass::UncheckedLoopCondition),
         1321 => Some(SemanticPatternClass::PrototypePollution),
         362 | 364 | 366 | 367 | 832 => Some(SemanticPatternClass::RaceCondition),
         377 => Some(SemanticPatternClass::InsecureTempFile),
@@ -1122,6 +1124,20 @@ mod tests {
     }
 
     #[test]
+    fn test_inferred_finding_cwes_for_unchecked_loop_condition() {
+        let finding = make_semantic_finding(
+            "memory",
+            "print_line",
+            "LLM: unchecked loop condition from untrusted input controls iteration count",
+        );
+
+        let inferred = inferred_finding_cwes(&finding);
+        assert!(inferred.contains(&606));
+        assert!(!inferred.contains(&190));
+        assert!(!inferred.contains(&119));
+    }
+
+    #[test]
     fn test_aggregate_tracks_per_semantic_scores() {
         let outcomes = vec![
             CaseOutcome {
@@ -1206,6 +1222,9 @@ mod tests {
         let search_path = semantic_class_to_cwes(SemanticPatternClass::UntrustedSearchPath);
         assert!(search_path.contains(&114));
         assert!(search_path.contains(&427));
+
+        let loop_condition = semantic_class_to_cwes(SemanticPatternClass::UncheckedLoopCondition);
+        assert_eq!(loop_condition, &[606]);
 
         let race = semantic_class_to_cwes(SemanticPatternClass::RaceCondition);
         assert!(race.contains(&364));
@@ -1304,6 +1323,7 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(114), Some(UntrustedSearchPath));
         assert_eq!(cwe_to_semantic_class(426), Some(PathTraversal));
         assert_eq!(cwe_to_semantic_class(427), Some(UntrustedSearchPath));
+        assert_eq!(cwe_to_semantic_class(606), Some(UncheckedLoopCondition));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a dedicated semantic/scoring lane for CWE-606 unchecked loop condition findings
- keep the matcher narrow with false-positive coverage for generic loop mentions
- align the arithmetic expert prompt with the new unchecked-loop routing

## Validation
- cargo test -q -p skwaq-core semantic_classifier::tests
- cargo test -q -p skwaq-gym scoring::tests
- cargo test -q -p skwaq-gym agentic::tests
- cargo clippy -q -p skwaq-core -p skwaq-gym --tests -- -D warnings
- cargo test -q -p skwaq-core
- cargo test -q -p skwaq-gym
- ./tests/qa/bin/gym-semantic-report.sh