### PR TITLE
feat(core,gym): add InvalidFree semantic class for CWE-590

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -17,6 +17,7 @@ pub enum SemanticPatternClass {
     Deserialization,
     FormatString,
     InsecureTempFile,
+    InvalidFree,
     PathTraversal,
     UntrustedSearchPath,
     UncheckedLoopCondition,
@@ -42,6 +43,7 @@ impl SemanticPatternClass {
             Self::Deserialization => "deserialization",
             Self::FormatString => "format_string",
             Self::InsecureTempFile => "insecure_temp_file",
+            Self::InvalidFree => "invalid_free",
             Self::PathTraversal => "path_traversal",
             Self::UntrustedSearchPath => "untrusted_search_path",
             Self::UncheckedLoopCondition => "unchecked_loop_condition",
@@ -61,7 +63,7 @@ impl SemanticPatternClass {
     pub fn confidence_cluster(&self) -> &'static str {
         match self {
             Self::BufferOverflow => "memory_bounds",
-            Self::UseAfterFree => "memory_lifecycle",
+            Self::UseAfterFree | Self::InvalidFree => "memory_lifecycle",
             Self::NullDeref => "memory_allocation",
             Self::CommandInjection | Self::Deserialization => "code_execution",
             Self::CrossSiteScripting | Self::PrototypePollution => "web_data_flow",
@@ -143,6 +145,9 @@ impl SemanticPatternClassifier {
         }
         if is_insecure_temp_file(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::InsecureTempFile);
+        }
+        if is_invalid_free(&category, &title) {
+            classes.insert(SemanticPatternClass::InvalidFree);
         }
         if is_null_deref(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::NullDeref);
@@ -324,6 +329,25 @@ fn is_insecure_temp_file(category: &str, title: &str, function_name: &str) -> bo
         || contains_any(
             title,
             &["temporary file", "temp file", "insecure temporary file"],
+        )
+}
+
+fn is_invalid_free(category: &str, title: &str) -> bool {
+    category == "invalid_free"
+        || contains_any(
+            title,
+            &[
+                "free of memory not on the heap",
+                "free memory not on heap",
+                "invalid free",
+                "free non-heap",
+                "free stack memory",
+                "free of pointer not on the heap",
+                "free of non-heap memory",
+                "freeing stack",
+                "freeing non-heap",
+                "free on stack",
+            ],
         )
 }
 
@@ -936,5 +960,39 @@ mod tests {
                 "{api} should classify as FormatString"
             );
         }
+    }
+
+    #[test]
+    fn classifies_invalid_free_from_title() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "memory",
+            "free of memory not on the heap in process_data",
+            "free",
+        );
+        assert!(classes.contains(&SemanticPatternClass::InvalidFree));
+    }
+
+    #[test]
+    fn classifies_invalid_free_from_category() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("invalid_free", "Dangerous pattern: free", "free");
+        assert!(classes.contains(&SemanticPatternClass::InvalidFree));
+    }
+
+    #[test]
+    fn invalid_free_does_not_trigger_on_use_after_free() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("memory", "use-after-free in handler", "handler");
+        assert!(classes.contains(&SemanticPatternClass::UseAfterFree));
+        assert!(!classes.contains(&SemanticPatternClass::InvalidFree));
+    }
+
+    #[test]
+    fn invalid_free_clusters_with_memory_lifecycle() {
+        assert_eq!(
+            SemanticPatternClass::InvalidFree.confidence_cluster(),
+            "memory_lifecycle"
+        );
     }
 }

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -257,6 +257,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
         SemanticPatternClass::Deserialization => &[502],
         SemanticPatternClass::FormatString => &[134],
         SemanticPatternClass::InsecureTempFile => &[377],
+        SemanticPatternClass::InvalidFree => &[590],
         SemanticPatternClass::PathTraversal => &[22, 23, 36, 426],
         SemanticPatternClass::UntrustedSearchPath => &[114, 427],
         SemanticPatternClass::UncheckedLoopCondition => &[606],
@@ -316,6 +317,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         | 780 | 798 | 1240 => Some(SemanticPatternClass::CryptoWeakness),
         502 => Some(SemanticPatternClass::Deserialization),
         134 => Some(SemanticPatternClass::FormatString),
+        590 => Some(SemanticPatternClass::InvalidFree),
         22 | 23 | 36 | 426 => Some(SemanticPatternClass::PathTraversal),
         114 | 427 => Some(SemanticPatternClass::UntrustedSearchPath),
         606 => Some(SemanticPatternClass::UncheckedLoopCondition),
@@ -1257,6 +1259,9 @@ mod tests {
         assert!(memory_lifecycle.contains(&761));
         assert!(memory_lifecycle.contains(&763));
 
+        let invalid_free = semantic_class_to_cwes(SemanticPatternClass::InvalidFree);
+        assert_eq!(invalid_free, &[590]);
+
         let buffer_overflow = semantic_class_to_cwes(SemanticPatternClass::BufferOverflow);
         assert!(buffer_overflow.contains(&118));
         assert!(buffer_overflow.contains(&135));
@@ -1323,6 +1328,7 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(114), Some(UntrustedSearchPath));
         assert_eq!(cwe_to_semantic_class(426), Some(PathTraversal));
         assert_eq!(cwe_to_semantic_class(427), Some(UntrustedSearchPath));
+        assert_eq!(cwe_to_semantic_class(590), Some(InvalidFree));
         assert_eq!(cwe_to_semantic_class(606), Some(UncheckedLoopCondition));
     }
 


### PR DESCRIPTION
## Problem

CWE-590 (Free of Memory Not on Heap) has **900 ground-truth test cases** in juliet.toml — the largest unmapped CWE — with no semantic classifier, scoring lane, or expert routing support.

## Fix

- New `InvalidFree` variant in `SemanticPatternClass`
- Classifier rules matching `free of memory not on the heap`, `invalid free`, `free non-heap`, etc.
- Bidirectional scoring: `InvalidFree → [590]` and `590 → InvalidFree`
- `memory_lifecycle` confidence cluster (same as UseAfterFree — both are deallocation errors)
- With PR #217, this routes to the `MemorySafety` expert domain for domain-specific synthesis

## Validation

- `cargo test -q -p skwaq-core semantic_classifier::tests` — 45 passed
- `cargo test -q -p skwaq-gym scoring::tests` — 40 passed
- `cargo clippy -q -p skwaq-core -p skwaq-gym --tests -- -D warnings` — clean
- `cargo test -q -p skwaq-core` — 330 passed
- `cargo test -q -p skwaq-gym` — 189 passed