### PR TITLE
feat(core,gym): add LdapInjection semantic class for CWE-90

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -18,6 +18,7 @@ pub enum SemanticPatternClass {
     FormatString,
     InsecureTempFile,
     InvalidFree,
+    LdapInjection,
     PathTraversal,
     UntrustedSearchPath,
     UncheckedLoopCondition,
@@ -44,6 +45,7 @@ impl SemanticPatternClass {
             Self::FormatString => "format_string",
             Self::InsecureTempFile => "insecure_temp_file",
             Self::InvalidFree => "invalid_free",
+            Self::LdapInjection => "ldap_injection",
             Self::PathTraversal => "path_traversal",
             Self::UntrustedSearchPath => "untrusted_search_path",
             Self::UncheckedLoopCondition => "unchecked_loop_condition",
@@ -65,7 +67,9 @@ impl SemanticPatternClass {
             Self::BufferOverflow => "memory_bounds",
             Self::UseAfterFree | Self::InvalidFree => "memory_lifecycle",
             Self::NullDeref => "memory_allocation",
-            Self::CommandInjection | Self::Deserialization => "code_execution",
+            Self::CommandInjection | Self::Deserialization | Self::LdapInjection => {
+                "code_execution"
+            }
             Self::CrossSiteScripting | Self::PrototypePollution => "web_data_flow",
             Self::InsecureTempFile
             | Self::PathTraversal
@@ -148,6 +152,9 @@ impl SemanticPatternClassifier {
         }
         if is_invalid_free(&category, &title) {
             classes.insert(SemanticPatternClass::InvalidFree);
+        }
+        if is_ldap_injection(&category, &title, &function_name) {
+            classes.insert(SemanticPatternClass::LdapInjection);
         }
         if is_null_deref(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::NullDeref);
@@ -349,6 +356,21 @@ fn is_invalid_free(category: &str, title: &str) -> bool {
                 "free on stack",
             ],
         )
+}
+
+fn is_ldap_injection(category: &str, title: &str, function_name: &str) -> bool {
+    const LDAP_APIS: &[&str] = &["ldap_search", "ldap_search_s", "ldap_search_ext_s"];
+    const LDAP_TERMS: &[&str] = &[
+        "ldap injection",
+        "ldap query injection",
+        "ldap filter injection",
+        "unsanitized ldap",
+        "ldap search injection",
+    ];
+
+    category == "ldap_injection"
+        || is_function(function_name, LDAP_APIS)
+        || contains_any(title, LDAP_TERMS)
 }
 
 fn is_cross_site_scripting(category: &str, title: &str) -> bool {
@@ -993,6 +1015,51 @@ mod tests {
         assert_eq!(
             SemanticPatternClass::InvalidFree.confidence_cluster(),
             "memory_lifecycle"
+        );
+    }
+
+    #[test]
+    fn classifies_ldap_injection_from_title() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "injection",
+            "ldap injection in search_users",
+            "search_users",
+        );
+        assert!(classes.contains(&SemanticPatternClass::LdapInjection));
+    }
+
+    #[test]
+    fn classifies_ldap_injection_from_api() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "injection",
+            "Dangerous pattern: ldap_search_s",
+            "ldap_search_s",
+        );
+        assert!(classes.contains(&SemanticPatternClass::LdapInjection));
+    }
+
+    #[test]
+    fn classifies_ldap_injection_from_category() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("ldap_injection", "unsanitized user input", "query");
+        assert!(classes.contains(&SemanticPatternClass::LdapInjection));
+    }
+
+    #[test]
+    fn ldap_injection_does_not_trigger_on_command_injection() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("injection", "command injection in run", "system");
+        assert!(classes.contains(&SemanticPatternClass::CommandInjection));
+        assert!(!classes.contains(&SemanticPatternClass::LdapInjection));
+    }
+
+    #[test]
+    fn ldap_injection_clusters_with_code_execution() {
+        assert_eq!(
+            SemanticPatternClass::LdapInjection.confidence_cluster(),
+            "code_execution"
         );
     }
 }

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -258,6 +258,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
         SemanticPatternClass::FormatString => &[134],
         SemanticPatternClass::InsecureTempFile => &[377],
         SemanticPatternClass::InvalidFree => &[590],
+        SemanticPatternClass::LdapInjection => &[90],
         SemanticPatternClass::PathTraversal => &[22, 23, 36, 426],
         SemanticPatternClass::UntrustedSearchPath => &[114, 427],
         SemanticPatternClass::UncheckedLoopCondition => &[606],
@@ -318,6 +319,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         502 => Some(SemanticPatternClass::Deserialization),
         134 => Some(SemanticPatternClass::FormatString),
         590 => Some(SemanticPatternClass::InvalidFree),
+        90 => Some(SemanticPatternClass::LdapInjection),
         22 | 23 | 36 | 426 => Some(SemanticPatternClass::PathTraversal),
         114 | 427 => Some(SemanticPatternClass::UntrustedSearchPath),
         606 => Some(SemanticPatternClass::UncheckedLoopCondition),
@@ -1199,6 +1201,9 @@ mod tests {
         let deser = semantic_class_to_cwes(SemanticPatternClass::Deserialization);
         assert!(deser.contains(&502));
 
+        let ldap = semantic_class_to_cwes(SemanticPatternClass::LdapInjection);
+        assert_eq!(ldap, &[90]);
+
         let int_overflow = semantic_class_to_cwes(SemanticPatternClass::IntegerOverflow);
         assert!(int_overflow.contains(&128));
         assert!(int_overflow.contains(&189));
@@ -1296,6 +1301,7 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(780), Some(CryptoWeakness));
         assert_eq!(cwe_to_semantic_class(1240), Some(CryptoWeakness));
         assert_eq!(cwe_to_semantic_class(502), Some(Deserialization));
+        assert_eq!(cwe_to_semantic_class(90), Some(LdapInjection));
         assert_eq!(cwe_to_semantic_class(128), Some(IntegerOverflow));
         assert_eq!(cwe_to_semantic_class(369), Some(DivideByZero));
         assert_eq!(cwe_to_semantic_class(476), Some(NullDeref));


### PR DESCRIPTION
## Problem

CWE-90 (LDAP Injection) has **560 ground-truth test cases** in juliet.toml with no semantic classifier, scoring lane, or expert routing support.

## Fix

- New `LdapInjection` variant in `SemanticPatternClass`
- Classifier rules matching LDAP injection titles, `ldap_injection` category, and LDAP API names (`ldap_search`, `ldap_search_s`, `ldap_search_ext_s`)
- Bidirectional scoring: `LdapInjection → [90]` and `90 → LdapInjection`
- `code_execution` confidence cluster (injection attacks share the same expert domain as command injection and deserialization)
- With PR #217 (merged), this routes to the `CodeExecution` expert domain for domain-specific synthesis

## Validation

- `cargo test -q -p skwaq-core semantic_classifier::tests` — 46 passed
- `cargo test -q -p skwaq-gym scoring::tests` — 40 passed
- `cargo clippy -q -p skwaq-core -p skwaq-gym --tests -- -D warnings` — clean
- `cargo test -q -p skwaq-core` — 331 passed
- `cargo test -q -p skwaq-gym` — 189 passed