### PR TITLE
feat(core,gym): add ResourceExhaustion semantic class for CWE-400

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -29,6 +29,7 @@ pub enum SemanticPatternClass {
     NullDeref,
     IntegerOverflow,
     DivideByZero,
+    ResourceExhaustion,
     ResourceLeak,
     UninitializedVar,
 }
@@ -56,6 +57,7 @@ impl SemanticPatternClass {
             Self::NullDeref => "null_deref",
             Self::IntegerOverflow => "integer_overflow",
             Self::DivideByZero => "divide_by_zero",
+            Self::ResourceExhaustion => "resource_exhaustion",
             Self::ResourceLeak => "resource_leak",
             Self::UninitializedVar => "uninitialized_var",
         }
@@ -78,7 +80,7 @@ impl SemanticPatternClass {
             Self::UncheckedLoopCondition | Self::IntegerOverflow | Self::DivideByZero => {
                 "arithmetic_safety"
             }
-            Self::ResourceLeak => "resource_management",
+            Self::ResourceExhaustion | Self::ResourceLeak => "resource_management",
             Self::UninitializedVar => "initialization_safety",
             Self::FormatString => "format_string",
             Self::CryptoWeakness => "crypto",
@@ -167,6 +169,9 @@ impl SemanticPatternClassifier {
         }
         if is_resource_leak(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::ResourceLeak);
+        }
+        if is_resource_exhaustion(&category, &title) {
+            classes.insert(SemanticPatternClass::ResourceExhaustion);
         }
         if is_uninitialized_var(&category, &title) {
             classes.insert(SemanticPatternClass::UninitializedVar);
@@ -518,6 +523,27 @@ fn is_resource_leak(category: &str, title: &str, function_name: &str) -> bool {
         )
         || (is_function(function_name, RESOURCE_APIS)
             && contains_any(title, &["leak", "unclosed", "not closed"]))
+}
+
+fn is_resource_exhaustion(category: &str, title: &str) -> bool {
+    category == "resource_exhaustion"
+        || contains_any(
+            title,
+            &[
+                "resource exhaustion",
+                "resource consumption",
+                "uncontrolled resource",
+                "denial of service",
+                "excessive allocation",
+                "excessive iteration",
+                "excessive memory",
+                "excessive cpu",
+                "algorithmic complexity",
+                "billion laughs",
+                "zip bomb",
+                "decompression bomb",
+            ],
+        )
 }
 
 fn is_uninitialized_var(category: &str, title: &str) -> bool {
@@ -1060,6 +1086,45 @@ mod tests {
         assert_eq!(
             SemanticPatternClass::LdapInjection.confidence_cluster(),
             "code_execution"
+        );
+    }
+
+    #[test]
+    fn classifies_resource_exhaustion_from_title() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "memory",
+            "resource exhaustion via unbounded allocation",
+            "malloc",
+        );
+        assert!(classes.contains(&SemanticPatternClass::ResourceExhaustion));
+    }
+
+    #[test]
+    fn classifies_resource_exhaustion_from_category() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "resource_exhaustion",
+            "Dangerous pattern: connect loop",
+            "connect",
+        );
+        assert!(classes.contains(&SemanticPatternClass::ResourceExhaustion));
+    }
+
+    #[test]
+    fn resource_exhaustion_does_not_trigger_on_resource_leak() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes =
+            classifier.classify("resource_leak", "file descriptor leak in handler", "open");
+        assert!(classes.contains(&SemanticPatternClass::ResourceLeak));
+        assert!(!classes.contains(&SemanticPatternClass::ResourceExhaustion));
+    }
+
+    #[test]
+    fn resource_exhaustion_clusters_with_resource_management() {
+        assert_eq!(
+            SemanticPatternClass::ResourceExhaustion.confidence_cluster(),
+            "resource_management"
         );
     }
 }

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -271,6 +271,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
             128, 189, 190, 191, 192, 193, 194, 195, 196, 197, 680, 681, 682,
         ],
         SemanticPatternClass::DivideByZero => &[369],
+        SemanticPatternClass::ResourceExhaustion => &[400],
         SemanticPatternClass::ResourceLeak => &[401, 404, 459, 675, 772, 773, 775, 789],
         SemanticPatternClass::UninitializedVar => &[457, 665, 908],
     }
@@ -333,6 +334,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
             Some(SemanticPatternClass::IntegerOverflow)
         }
         369 => Some(SemanticPatternClass::DivideByZero),
+        400 => Some(SemanticPatternClass::ResourceExhaustion),
         401 | 404 | 459 | 675 | 772 | 773 | 775 | 789 => Some(SemanticPatternClass::ResourceLeak),
         457 | 665 | 908 => Some(SemanticPatternClass::UninitializedVar),
         _ => None,
@@ -830,7 +832,10 @@ mod tests {
             cwe_to_semantic_class(773),
             Some(SemanticPatternClass::ResourceLeak)
         );
-        assert_eq!(cwe_to_semantic_class(400), None);
+        assert_eq!(
+            cwe_to_semantic_class(400),
+            Some(SemanticPatternClass::ResourceExhaustion)
+        );
         assert_eq!(cwe_to_semantic_class(666), None);
 
         // Crypto
@@ -1247,6 +1252,9 @@ mod tests {
         assert!(!leak.contains(&761));
         assert!(!leak.contains(&763));
 
+        let exhaustion = semantic_class_to_cwes(SemanticPatternClass::ResourceExhaustion);
+        assert_eq!(exhaustion, &[400]);
+
         let unsafe_api = semantic_class_to_cwes(SemanticPatternClass::UnsafeApiUsage);
         assert!(unsafe_api.contains(&222));
         assert!(unsafe_api.contains(&223));
@@ -1315,7 +1323,7 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(832), Some(RaceCondition));
         assert_eq!(cwe_to_semantic_class(401), Some(ResourceLeak));
         assert_eq!(cwe_to_semantic_class(675), Some(ResourceLeak));
-        assert_eq!(cwe_to_semantic_class(400), None);
+        assert_eq!(cwe_to_semantic_class(400), Some(ResourceExhaustion));
         assert_eq!(cwe_to_semantic_class(666), None);
         assert_eq!(cwe_to_semantic_class(189), Some(IntegerOverflow));
         assert_eq!(cwe_to_semantic_class(682), Some(IntegerOverflow));


### PR DESCRIPTION
## Problem

CWE-400 (Uncontrolled Resource Consumption) has **840 ground-truth test cases** in juliet.toml — the largest remaining unmapped CWE — with no semantic support.

## Fix

- New `ResourceExhaustion` variant in `SemanticPatternClass`
- Classifier rules matching resource exhaustion, denial of service, excessive allocation, zip bomb, billion laughs, etc.
- Bidirectional scoring: `ResourceExhaustion → [400]` and `400 → ResourceExhaustion`
- `resource_management` confidence cluster (routes to `ResourceManagement` expert domain via #217)

## Validation

- `cargo test -q -p skwaq-core semantic_classifier::tests` — 54 passed
- `cargo test -q -p skwaq-gym scoring::tests` — 40 passed
- `cargo test -q -p skwaq-core` — 339 passed
- `cargo test -q -p skwaq-gym` — 198 passed
- clippy clean