### PR TITLE
feat(core,gym): add DeadStore and ReachableAssertion semantic classes

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -14,6 +14,7 @@ pub enum SemanticPatternClass {
     CommandInjection,
     CrossSiteScripting,
     CryptoWeakness,
+    DeadStore,
     Deserialization,
     FormatString,
     InsecureTempFile,
@@ -24,6 +25,7 @@ pub enum SemanticPatternClass {
     UncheckedLoopCondition,
     PrototypePollution,
     RaceCondition,
+    ReachableAssertion,
     UnsafeApiUsage,
     UseAfterFree,
     NullDeref,
@@ -42,6 +44,7 @@ impl SemanticPatternClass {
             Self::CommandInjection => "command_injection",
             Self::CrossSiteScripting => "cross_site_scripting",
             Self::CryptoWeakness => "crypto_weakness",
+            Self::DeadStore => "dead_store",
             Self::Deserialization => "deserialization",
             Self::FormatString => "format_string",
             Self::InsecureTempFile => "insecure_temp_file",
@@ -52,6 +55,7 @@ impl SemanticPatternClass {
             Self::UncheckedLoopCondition => "unchecked_loop_condition",
             Self::PrototypePollution => "prototype_pollution",
             Self::RaceCondition => "race_condition",
+            Self::ReachableAssertion => "reachable_assertion",
             Self::UnsafeApiUsage => "unsafe_api_usage",
             Self::UseAfterFree => "use_after_free",
             Self::NullDeref => "null_deref",
@@ -77,11 +81,12 @@ impl SemanticPatternClass {
             | Self::PathTraversal
             | Self::UntrustedSearchPath
             | Self::RaceCondition => "filesystem_safety",
-            Self::UncheckedLoopCondition | Self::IntegerOverflow | Self::DivideByZero => {
-                "arithmetic_safety"
-            }
+            Self::UncheckedLoopCondition
+            | Self::IntegerOverflow
+            | Self::DivideByZero
+            | Self::ReachableAssertion => "arithmetic_safety",
             Self::ResourceExhaustion | Self::ResourceLeak => "resource_management",
-            Self::UninitializedVar => "initialization_safety",
+            Self::UninitializedVar | Self::DeadStore => "initialization_safety",
             Self::FormatString => "format_string",
             Self::CryptoWeakness => "crypto",
             Self::UnsafeApiUsage => "unsafe_api",
@@ -122,6 +127,9 @@ impl SemanticPatternClassifier {
         if is_crypto_weakness(&category, &title) {
             classes.insert(SemanticPatternClass::CryptoWeakness);
         }
+        if is_dead_store(&category, &title) {
+            classes.insert(SemanticPatternClass::DeadStore);
+        }
         if is_deserialization(&category, &title) {
             classes.insert(SemanticPatternClass::Deserialization);
         }
@@ -145,6 +153,9 @@ impl SemanticPatternClassifier {
         }
         if is_race_condition(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::RaceCondition);
+        }
+        if is_reachable_assertion(&category, &title) {
+            classes.insert(SemanticPatternClass::ReachableAssertion);
         }
         if is_unsafe_api_usage(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::UnsafeApiUsage);
@@ -335,6 +346,21 @@ fn is_race_condition(category: &str, title: &str, function_name: &str) -> bool {
         || contains_any(title, &["race condition", "toctou", "time-of-check"])
 }
 
+fn is_reachable_assertion(category: &str, title: &str) -> bool {
+    category == "reachable_assertion"
+        || contains_any(
+            title,
+            &[
+                "reachable assertion",
+                "reachable assert",
+                "assertion failure",
+                "assertion reachable",
+                "abort reachable",
+                "assert reachable from untrusted input",
+            ],
+        )
+}
+
 fn is_insecure_temp_file(category: &str, title: &str, function_name: &str) -> bool {
     category == "temp_file"
         || is_function(function_name, &["mktemp", "tmpnam"])
@@ -408,6 +434,22 @@ fn is_crypto_weakness(category: &str, title: &str) -> bool {
                 "rc4",
                 "weak key",
                 "insufficient key",
+            ],
+        )
+}
+
+fn is_dead_store(category: &str, title: &str) -> bool {
+    category == "dead_store"
+        || category == "unused_variable"
+        || contains_any(
+            title,
+            &[
+                "dead store",
+                "unused variable",
+                "unused assignment",
+                "assignment to variable without use",
+                "value assigned is never used",
+                "value written is never read",
             ],
         )
 }
@@ -1125,6 +1167,59 @@ mod tests {
         assert_eq!(
             SemanticPatternClass::ResourceExhaustion.confidence_cluster(),
             "resource_management"
+        );
+    }
+
+    #[test]
+    fn classifies_dead_store_from_title() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "code_quality",
+            "dead store: value assigned is never used",
+            "foo",
+        );
+        assert!(classes.contains(&SemanticPatternClass::DeadStore));
+    }
+
+    #[test]
+    fn classifies_dead_store_from_category() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("unused_variable", "unused global value", "global_var");
+        assert!(classes.contains(&SemanticPatternClass::DeadStore));
+    }
+
+    #[test]
+    fn dead_store_clusters_with_initialization_safety() {
+        assert_eq!(
+            SemanticPatternClass::DeadStore.confidence_cluster(),
+            "initialization_safety"
+        );
+    }
+
+    #[test]
+    fn classifies_reachable_assertion_from_title() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "robustness",
+            "reachable assertion in input handler",
+            "assert",
+        );
+        assert!(classes.contains(&SemanticPatternClass::ReachableAssertion));
+    }
+
+    #[test]
+    fn classifies_reachable_assertion_from_category() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes =
+            classifier.classify("reachable_assertion", "Dangerous pattern: assert", "assert");
+        assert!(classes.contains(&SemanticPatternClass::ReachableAssertion));
+    }
+
+    #[test]
+    fn reachable_assertion_clusters_with_arithmetic_safety() {
+        assert_eq!(
+            SemanticPatternClass::ReachableAssertion.confidence_cluster(),
+            "arithmetic_safety"
         );
     }
 }

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -255,6 +255,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
             1240,
         ],
         SemanticPatternClass::Deserialization => &[502],
+        SemanticPatternClass::DeadStore => &[563],
         SemanticPatternClass::FormatString => &[134],
         SemanticPatternClass::InsecureTempFile => &[377],
         SemanticPatternClass::InvalidFree => &[590],
@@ -264,6 +265,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
         SemanticPatternClass::UncheckedLoopCondition => &[606],
         SemanticPatternClass::PrototypePollution => &[1321],
         SemanticPatternClass::RaceCondition => &[362, 364, 366, 367, 832],
+        SemanticPatternClass::ReachableAssertion => &[617],
         SemanticPatternClass::UnsafeApiUsage => &[222, 223, 242, 244, 247, 676],
         SemanticPatternClass::UseAfterFree => &[415, 416, 562, 761, 763],
         SemanticPatternClass::NullDeref => &[252, 253, 476, 690],
@@ -318,6 +320,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         256 | 259 | 295 | 310 | 312 | 319 | 321 | 323 | 325 | 326 | 327 | 328 | 330 | 338 | 347
         | 780 | 798 | 1240 => Some(SemanticPatternClass::CryptoWeakness),
         502 => Some(SemanticPatternClass::Deserialization),
+        563 => Some(SemanticPatternClass::DeadStore),
         134 => Some(SemanticPatternClass::FormatString),
         590 => Some(SemanticPatternClass::InvalidFree),
         90 => Some(SemanticPatternClass::LdapInjection),
@@ -326,6 +329,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         606 => Some(SemanticPatternClass::UncheckedLoopCondition),
         1321 => Some(SemanticPatternClass::PrototypePollution),
         362 | 364 | 366 | 367 | 832 => Some(SemanticPatternClass::RaceCondition),
+        617 => Some(SemanticPatternClass::ReachableAssertion),
         377 => Some(SemanticPatternClass::InsecureTempFile),
         222 | 223 | 242 | 244 | 247 | 676 => Some(SemanticPatternClass::UnsafeApiUsage),
         415 | 416 | 562 | 761 | 763 => Some(SemanticPatternClass::UseAfterFree),
@@ -1206,6 +1210,12 @@ mod tests {
         let deser = semantic_class_to_cwes(SemanticPatternClass::Deserialization);
         assert!(deser.contains(&502));
 
+        let dead_store = semantic_class_to_cwes(SemanticPatternClass::DeadStore);
+        assert_eq!(dead_store, &[563]);
+
+        let reachable = semantic_class_to_cwes(SemanticPatternClass::ReachableAssertion);
+        assert_eq!(reachable, &[617]);
+
         let ldap = semantic_class_to_cwes(SemanticPatternClass::LdapInjection);
         assert_eq!(ldap, &[90]);
 
@@ -1309,6 +1319,8 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(780), Some(CryptoWeakness));
         assert_eq!(cwe_to_semantic_class(1240), Some(CryptoWeakness));
         assert_eq!(cwe_to_semantic_class(502), Some(Deserialization));
+        assert_eq!(cwe_to_semantic_class(563), Some(DeadStore));
+        assert_eq!(cwe_to_semantic_class(617), Some(ReachableAssertion));
         assert_eq!(cwe_to_semantic_class(90), Some(LdapInjection));
         assert_eq!(cwe_to_semantic_class(128), Some(IntegerOverflow));
         assert_eq!(cwe_to_semantic_class(369), Some(DivideByZero));


### PR DESCRIPTION
## Problem

CWE-563 (Assignment to Variable without Use, 366 cases) and CWE-617 (Reachable Assertion, 354 cases) are the next two largest unmapped CWEs — 720 cases combined.

## Fix

- **DeadStore** (CWE-563): Matches dead store, unused variable, unused assignment. `initialization_safety` cluster → `MemorySafety` expert domain.
- **ReachableAssertion** (CWE-617): Matches reachable assertion, assertion failure. `arithmetic_safety` cluster → `ArithmeticSafety` expert domain (input-controlled abort/DoS).
- Bidirectional scoring for both

## Validation

- `cargo test -q -p skwaq-core semantic_classifier::tests` — 56 passed
- `cargo test -q -p skwaq-gym scoring::tests` — 40 passed
- clippy clean