### PR TITLE
feat(core,gym): add UndefinedBehavior semantic class for CWE-758/398

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -28,6 +28,7 @@ pub enum SemanticPatternClass {
     PrototypePollution,
     RaceCondition,
     ReachableAssertion,
+    UndefinedBehavior,
     UnsafeApiUsage,
     UseAfterFree,
     NullDeref,
@@ -60,6 +61,7 @@ impl SemanticPatternClass {
             Self::PrototypePollution => "prototype_pollution",
             Self::RaceCondition => "race_condition",
             Self::ReachableAssertion => "reachable_assertion",
+            Self::UndefinedBehavior => "undefined_behavior",
             Self::UnsafeApiUsage => "unsafe_api_usage",
             Self::UseAfterFree => "use_after_free",
             Self::NullDeref => "null_deref",
@@ -93,7 +95,9 @@ impl SemanticPatternClass {
             Self::UninitializedVar | Self::DeadStore => "initialization_safety",
             Self::FormatString => "format_string",
             Self::CryptoWeakness => "crypto",
-            Self::UnsafeApiUsage | Self::ImproperAccessControl => "unsafe_api",
+            Self::UnsafeApiUsage | Self::ImproperAccessControl | Self::UndefinedBehavior => {
+                "unsafe_api"
+            }
         }
     }
 }
@@ -166,6 +170,9 @@ impl SemanticPatternClassifier {
         }
         if is_reachable_assertion(&category, &title) {
             classes.insert(SemanticPatternClass::ReachableAssertion);
+        }
+        if is_undefined_behavior(&category, &title) {
+            classes.insert(SemanticPatternClass::UndefinedBehavior);
         }
         if is_unsafe_api_usage(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::UnsafeApiUsage);
@@ -410,6 +417,23 @@ fn is_reachable_assertion(category: &str, title: &str) -> bool {
                 "assertion reachable",
                 "abort reachable",
                 "assert reachable from untrusted input",
+            ],
+        )
+}
+
+fn is_undefined_behavior(category: &str, title: &str) -> bool {
+    category == "undefined_behavior"
+        || category == "poor_code_quality"
+        || contains_any(
+            title,
+            &[
+                "undefined behavior",
+                "unspecified behavior",
+                "implementation-defined",
+                "implementation defined",
+                "poor code quality",
+                "code quality indicator",
+                "reliance on undefined",
             ],
         )
 }
@@ -1325,6 +1349,36 @@ mod tests {
         assert_eq!(
             SemanticPatternClass::TypeConfusion.confidence_cluster(),
             "memory_lifecycle"
+        );
+    }
+
+    #[test]
+    fn classifies_undefined_behavior_from_title() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "code_quality",
+            "reliance on undefined behavior in pointer arithmetic",
+            "ptr_add",
+        );
+        assert!(classes.contains(&SemanticPatternClass::UndefinedBehavior));
+    }
+
+    #[test]
+    fn classifies_undefined_behavior_from_category() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify(
+            "poor_code_quality",
+            "suspicious arithmetic operation",
+            "add",
+        );
+        assert!(classes.contains(&SemanticPatternClass::UndefinedBehavior));
+    }
+
+    #[test]
+    fn undefined_behavior_clusters_with_unsafe_api() {
+        assert_eq!(
+            SemanticPatternClass::UndefinedBehavior.confidence_cluster(),
+            "unsafe_api"
         );
     }
 }

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -268,6 +268,7 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
         SemanticPatternClass::RaceCondition => &[362, 364, 366, 367, 832],
         SemanticPatternClass::ReachableAssertion => &[617],
         SemanticPatternClass::TypeConfusion => &[843, 591],
+        SemanticPatternClass::UndefinedBehavior => &[758, 398],
         SemanticPatternClass::UnsafeApiUsage => &[222, 223, 242, 244, 247, 676],
         SemanticPatternClass::UseAfterFree => &[415, 416, 562, 761, 763],
         SemanticPatternClass::NullDeref => &[252, 253, 476, 690],
@@ -333,6 +334,7 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         1321 => Some(SemanticPatternClass::PrototypePollution),
         362 | 364 | 366 | 367 | 832 => Some(SemanticPatternClass::RaceCondition),
         617 => Some(SemanticPatternClass::ReachableAssertion),
+        758 | 398 => Some(SemanticPatternClass::UndefinedBehavior),
         843 | 591 => Some(SemanticPatternClass::TypeConfusion),
         377 => Some(SemanticPatternClass::InsecureTempFile),
         222 | 223 | 242 | 244 | 247 | 676 => Some(SemanticPatternClass::UnsafeApiUsage),
@@ -1326,6 +1328,8 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(272), Some(ImproperAccessControl));
         assert_eq!(cwe_to_semantic_class(284), Some(ImproperAccessControl));
         assert_eq!(cwe_to_semantic_class(843), Some(TypeConfusion));
+        assert_eq!(cwe_to_semantic_class(758), Some(UndefinedBehavior));
+        assert_eq!(cwe_to_semantic_class(398), Some(UndefinedBehavior));
         assert_eq!(cwe_to_semantic_class(591), Some(TypeConfusion));
         assert_eq!(cwe_to_semantic_class(563), Some(DeadStore));
         assert_eq!(cwe_to_semantic_class(617), Some(ReachableAssertion));


### PR DESCRIPTION
CWE-758 (Undefined Behavior, 365 cases) + CWE-398 (Poor Code Quality, 181 cases) = **546 new cases**.

- New `UndefinedBehavior` semantic class
- `unsafe_api` cluster → `MemorySafety` expert domain
- 69 classifier tests pass, 40 scoring tests pass, clippy clean