### PR TITLE
feat(core,gym): add 4 semantic classes covering remaining high-volume CWEs

### DIFF
--- a/crates/core/src/analysis/semantic_classifier.rs
+++ b/crates/core/src/analysis/semantic_classifier.rs
@@ -16,12 +16,16 @@ pub enum SemanticPatternClass {
     CryptoWeakness,
     DeadStore,
     Deserialization,
+    EmbeddedMaliciousCode,
     FormatString,
     ImproperAccessControl,
+    ImproperErrorHandling,
+    InformationExposure,
     InsecureTempFile,
     InvalidFree,
     LdapInjection,
     PathTraversal,
+    SuspiciousCodeConstruct,
     TypeConfusion,
     UntrustedSearchPath,
     UncheckedLoopCondition,
@@ -49,12 +53,16 @@ impl SemanticPatternClass {
             Self::CryptoWeakness => "crypto_weakness",
             Self::DeadStore => "dead_store",
             Self::Deserialization => "deserialization",
+            Self::EmbeddedMaliciousCode => "embedded_malicious_code",
             Self::FormatString => "format_string",
             Self::ImproperAccessControl => "improper_access_control",
+            Self::ImproperErrorHandling => "improper_error_handling",
+            Self::InformationExposure => "information_exposure",
             Self::InsecureTempFile => "insecure_temp_file",
             Self::InvalidFree => "invalid_free",
             Self::LdapInjection => "ldap_injection",
             Self::PathTraversal => "path_traversal",
+            Self::SuspiciousCodeConstruct => "suspicious_code_construct",
             Self::TypeConfusion => "type_confusion",
             Self::UntrustedSearchPath => "untrusted_search_path",
             Self::UncheckedLoopCondition => "unchecked_loop_condition",
@@ -79,9 +87,10 @@ impl SemanticPatternClass {
             Self::BufferOverflow => "memory_bounds",
             Self::UseAfterFree | Self::InvalidFree | Self::TypeConfusion => "memory_lifecycle",
             Self::NullDeref => "memory_allocation",
-            Self::CommandInjection | Self::Deserialization | Self::LdapInjection => {
-                "code_execution"
-            }
+            Self::CommandInjection
+            | Self::Deserialization
+            | Self::LdapInjection
+            | Self::EmbeddedMaliciousCode => "code_execution",
             Self::CrossSiteScripting | Self::PrototypePollution => "web_data_flow",
             Self::InsecureTempFile
             | Self::PathTraversal
@@ -91,10 +100,14 @@ impl SemanticPatternClass {
             | Self::IntegerOverflow
             | Self::DivideByZero
             | Self::ReachableAssertion => "arithmetic_safety",
-            Self::ResourceExhaustion | Self::ResourceLeak => "resource_management",
-            Self::UninitializedVar | Self::DeadStore => "initialization_safety",
+            Self::ResourceExhaustion | Self::ResourceLeak | Self::ImproperErrorHandling => {
+                "resource_management"
+            }
+            Self::UninitializedVar | Self::DeadStore | Self::SuspiciousCodeConstruct => {
+                "initialization_safety"
+            }
             Self::FormatString => "format_string",
-            Self::CryptoWeakness => "crypto",
+            Self::CryptoWeakness | Self::InformationExposure => "crypto",
             Self::UnsafeApiUsage | Self::ImproperAccessControl | Self::UndefinedBehavior => {
                 "unsafe_api"
             }
@@ -141,11 +154,20 @@ impl SemanticPatternClassifier {
         if is_deserialization(&category, &title) {
             classes.insert(SemanticPatternClass::Deserialization);
         }
+        if is_embedded_malicious_code(&category, &title) {
+            classes.insert(SemanticPatternClass::EmbeddedMaliciousCode);
+        }
         if is_format_string(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::FormatString);
         }
         if is_improper_access_control(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::ImproperAccessControl);
+        }
+        if is_improper_error_handling(&category, &title) {
+            classes.insert(SemanticPatternClass::ImproperErrorHandling);
+        }
+        if is_information_exposure(&category, &title) {
+            classes.insert(SemanticPatternClass::InformationExposure);
         }
         if is_path_traversal(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::PathTraversal);
@@ -164,6 +186,9 @@ impl SemanticPatternClassifier {
         }
         if is_type_confusion(&category, &title) {
             classes.insert(SemanticPatternClass::TypeConfusion);
+        }
+        if is_suspicious_code_construct(&category, &title) {
+            classes.insert(SemanticPatternClass::SuspiciousCodeConstruct);
         }
         if is_race_condition(&category, &title, &function_name) {
             classes.insert(SemanticPatternClass::RaceCondition);
@@ -675,6 +700,76 @@ fn is_uninitialized_var(category: &str, title: &str) -> bool {
                 "not initialized",
                 "use of uninitialized",
                 "indeterminate value",
+            ],
+        )
+}
+
+fn is_embedded_malicious_code(category: &str, title: &str) -> bool {
+    category == "malicious_code"
+        || category == "trojan"
+        || category == "backdoor"
+        || contains_any(
+            title,
+            &[
+                "trojan",
+                "backdoor",
+                "malicious code",
+                "embedded malicious",
+                "logic bomb",
+                "hidden functionality",
+                "covert channel",
+            ],
+        )
+}
+
+fn is_improper_error_handling(category: &str, title: &str) -> bool {
+    category == "error_handling"
+        || contains_any(
+            title,
+            &[
+                "empty catch",
+                "unchecked error",
+                "improper error handling",
+                "missing error check",
+                "error condition",
+                "improper locking",
+                "improper check for unusual",
+            ],
+        )
+}
+
+fn is_information_exposure(category: &str, title: &str) -> bool {
+    category == "information_exposure"
+        || category == "sensitive_data"
+        || contains_any(
+            title,
+            &[
+                "information exposure",
+                "sensitive data in log",
+                "sensitive data in debug",
+                "debug information",
+                "environment variable exposure",
+                "sensitive information in environment",
+                "password in log",
+                "credential in log",
+            ],
+        )
+}
+
+fn is_suspicious_code_construct(category: &str, title: &str) -> bool {
+    category == "suspicious_comment"
+        || category == "dead_code"
+        || contains_any(
+            title,
+            &[
+                "suspicious comment",
+                "dead code",
+                "unreachable code",
+                "always true",
+                "always false",
+                "expression is always",
+                "code never executed",
+                "obsolete code",
             ],
         )
 }
@@ -1379,6 +1474,54 @@ mod tests {
         assert_eq!(
             SemanticPatternClass::UndefinedBehavior.confidence_cluster(),
             "unsafe_api"
+        );
+    }
+
+    #[test]
+    fn classifies_embedded_malicious_code() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("security", "trojan horse in network handler", "send");
+        assert!(classes.contains(&SemanticPatternClass::EmbeddedMaliciousCode));
+    }
+
+    #[test]
+    fn classifies_improper_error_handling() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("error_handling", "empty catch block", "catch");
+        assert!(classes.contains(&SemanticPatternClass::ImproperErrorHandling));
+    }
+
+    #[test]
+    fn classifies_information_exposure() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("security", "sensitive data in log output", "log");
+        assert!(classes.contains(&SemanticPatternClass::InformationExposure));
+    }
+
+    #[test]
+    fn classifies_suspicious_code_construct() {
+        let classifier = SemanticPatternClassifier::new();
+        let classes = classifier.classify("code_quality", "expression is always true", "check");
+        assert!(classes.contains(&SemanticPatternClass::SuspiciousCodeConstruct));
+    }
+
+    #[test]
+    fn new_classes_cluster_correctly() {
+        assert_eq!(
+            SemanticPatternClass::EmbeddedMaliciousCode.confidence_cluster(),
+            "code_execution"
+        );
+        assert_eq!(
+            SemanticPatternClass::ImproperErrorHandling.confidence_cluster(),
+            "resource_management"
+        );
+        assert_eq!(
+            SemanticPatternClass::InformationExposure.confidence_cluster(),
+            "crypto"
+        );
+        assert_eq!(
+            SemanticPatternClass::SuspiciousCodeConstruct.confidence_cluster(),
+            "initialization_safety"
         );
     }
 }

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -256,12 +256,16 @@ pub fn semantic_class_to_cwes(class: SemanticPatternClass) -> &'static [u32] {
         ],
         SemanticPatternClass::Deserialization => &[502],
         SemanticPatternClass::DeadStore => &[563],
+        SemanticPatternClass::EmbeddedMaliciousCode => &[506, 511, 510],
         SemanticPatternClass::FormatString => &[134],
         SemanticPatternClass::ImproperAccessControl => &[272, 284],
+        SemanticPatternClass::ImproperErrorHandling => &[666, 390, 391],
+        SemanticPatternClass::InformationExposure => &[226, 534, 535, 526],
         SemanticPatternClass::InsecureTempFile => &[377],
         SemanticPatternClass::InvalidFree => &[590],
         SemanticPatternClass::LdapInjection => &[90],
         SemanticPatternClass::PathTraversal => &[22, 23, 36, 426],
+        SemanticPatternClass::SuspiciousCodeConstruct => &[546, 561, 570, 571],
         SemanticPatternClass::UntrustedSearchPath => &[114, 427],
         SemanticPatternClass::UncheckedLoopCondition => &[606],
         SemanticPatternClass::PrototypePollution => &[1321],
@@ -324,11 +328,15 @@ fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
         | 780 | 798 | 1240 => Some(SemanticPatternClass::CryptoWeakness),
         502 => Some(SemanticPatternClass::Deserialization),
         563 => Some(SemanticPatternClass::DeadStore),
+        506 | 511 | 510 => Some(SemanticPatternClass::EmbeddedMaliciousCode),
         134 => Some(SemanticPatternClass::FormatString),
         272 | 284 => Some(SemanticPatternClass::ImproperAccessControl),
+        666 | 390 | 391 => Some(SemanticPatternClass::ImproperErrorHandling),
+        226 | 534 | 535 | 526 => Some(SemanticPatternClass::InformationExposure),
         590 => Some(SemanticPatternClass::InvalidFree),
         90 => Some(SemanticPatternClass::LdapInjection),
         22 | 23 | 36 | 426 => Some(SemanticPatternClass::PathTraversal),
+        546 | 561 | 570 | 571 => Some(SemanticPatternClass::SuspiciousCodeConstruct),
         114 | 427 => Some(SemanticPatternClass::UntrustedSearchPath),
         606 => Some(SemanticPatternClass::UncheckedLoopCondition),
         1321 => Some(SemanticPatternClass::PrototypePollution),
@@ -846,7 +854,10 @@ mod tests {
             cwe_to_semantic_class(400),
             Some(SemanticPatternClass::ResourceExhaustion)
         );
-        assert_eq!(cwe_to_semantic_class(666), None);
+        assert_eq!(
+            cwe_to_semantic_class(666),
+            Some(SemanticPatternClass::ImproperErrorHandling)
+        );
 
         // Crypto
         assert_eq!(
@@ -1333,6 +1344,14 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(591), Some(TypeConfusion));
         assert_eq!(cwe_to_semantic_class(563), Some(DeadStore));
         assert_eq!(cwe_to_semantic_class(617), Some(ReachableAssertion));
+        assert_eq!(cwe_to_semantic_class(506), Some(EmbeddedMaliciousCode));
+        assert_eq!(cwe_to_semantic_class(511), Some(EmbeddedMaliciousCode));
+        assert_eq!(cwe_to_semantic_class(666), Some(ImproperErrorHandling));
+        assert_eq!(cwe_to_semantic_class(390), Some(ImproperErrorHandling));
+        assert_eq!(cwe_to_semantic_class(226), Some(InformationExposure));
+        assert_eq!(cwe_to_semantic_class(534), Some(InformationExposure));
+        assert_eq!(cwe_to_semantic_class(546), Some(SuspiciousCodeConstruct));
+        assert_eq!(cwe_to_semantic_class(570), Some(SuspiciousCodeConstruct));
         assert_eq!(cwe_to_semantic_class(90), Some(LdapInjection));
         assert_eq!(cwe_to_semantic_class(128), Some(IntegerOverflow));
         assert_eq!(cwe_to_semantic_class(369), Some(DivideByZero));
@@ -1348,7 +1367,7 @@ mod tests {
         assert_eq!(cwe_to_semantic_class(401), Some(ResourceLeak));
         assert_eq!(cwe_to_semantic_class(675), Some(ResourceLeak));
         assert_eq!(cwe_to_semantic_class(400), Some(ResourceExhaustion));
-        assert_eq!(cwe_to_semantic_class(666), None);
+        assert_eq!(cwe_to_semantic_class(666), Some(ImproperErrorHandling));
         assert_eq!(cwe_to_semantic_class(189), Some(IntegerOverflow));
         assert_eq!(cwe_to_semantic_class(682), Some(IntegerOverflow));
         assert_eq!(cwe_to_semantic_class(761), Some(UseAfterFree));


### PR DESCRIPTION
## Batch CWE expansion (802 new cases)

4 new semantic classes in one PR, covering the remaining high-volume unmapped CWEs:

| Class | CWEs | Cases | Cluster |
|-------|------|-------|---------|
| EmbeddedMaliciousCode | 506, 511, 510 | 300 | code_execution |
| ImproperErrorHandling | 666, 390, 391 | 216 | resource_management |
| InformationExposure | 226, 534, 535, 526 | 162 | crypto |
| SuspiciousCodeConstruct | 546, 561, 570, 571 | 124 | initialization_safety |

This brings total semantic coverage to **31 classes** mapping **84/109 Juliet CWEs** (~98.5% of case-CWE assignments).

## Validation
- 74 classifier tests, 40 scoring tests — all pass
- clippy clean

Relates to #28