### PR TITLE
feat(gym): semantic-gap-aware failure analysis

### DIFF
--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -395,12 +395,49 @@ async fn run_failure_analyst_agent(
         }
         let kb_context = build_false_negative_knowledge_context(knowledge_db, fn_case)?;
 
-        // Build context with the missed case details
+        // Build context with the missed case details.
+        // Include which semantic classes WERE detected so the analyst
+        // can focus on the gap rather than re-analyzing what was found.
+        let detected_classes: Vec<String> = fn_case
+            .detected_cwes
+            .iter()
+            .filter_map(|&cwe| {
+                crate::scoring::cwe_to_semantic_class_public(cwe).map(|c| c.as_str().to_string())
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        let expected_classes: Vec<String> = fn_case
+            .expected_cwes
+            .iter()
+            .filter_map(|&cwe| {
+                crate::scoring::cwe_to_semantic_class_public(cwe).map(|c| c.as_str().to_string())
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        let gap_context = if detected_classes.is_empty() {
+            format!(
+                "Expected semantic classes: {:?}\n\
+                 Detected semantic classes: NONE (complete detection gap)\n",
+                expected_classes
+            )
+        } else {
+            format!(
+                "Expected semantic classes: {:?}\n\
+                 Detected semantic classes: {:?}\n\
+                 Semantic gap: expected but not detected classes should be \
+                 the primary investigation focus.\n",
+                expected_classes, detected_classes
+            )
+        };
+
         let context = format!(
             "Analyze this FALSE NEGATIVE from the {} benchmark.\n\n\
              Case: {}\n\
              Expected CWEs: {:?}\n\
              Detected CWEs: {:?}\n\
+             {}\n\
              File: {}\n\n\
              Source code:\n```\n{}\n```\n\n\
              Knowledge base guidance:\n{}\n\n\
@@ -428,6 +465,7 @@ async fn run_failure_analyst_agent(
             fn_case.case_id,
             fn_case.expected_cwes,
             fn_case.detected_cwes,
+            gap_context,
             fn_case.source_path.display(),
             &fn_case.source_content[..source_excerpt_len],
             kb_context,

--- a/crates/gym/src/scoring.rs
+++ b/crates/gym/src/scoring.rs
@@ -341,6 +341,11 @@ fn dedup_cwes(cwes: impl IntoIterator<Item = u32>) -> Vec<u32> {
         .collect()
 }
 
+/// Public accessor for CWE-to-semantic-class mapping.
+pub fn cwe_to_semantic_class_public(cwe: u32) -> Option<SemanticPatternClass> {
+    cwe_to_semantic_class(cwe)
+}
+
 fn cwe_to_semantic_class(cwe: u32) -> Option<SemanticPatternClass> {
     match cwe {
         118 | 119 | 120 | 121 | 122 | 123 | 124 | 125 | 126 | 127 | 129 | 131 | 135 | 170 | 176


### PR DESCRIPTION
## Agentic Pattern: Semantic Gap Awareness

Enhances the failure analyst's context with semantic class gap information when analyzing false negatives.

**Before**: Analyst sees expected CWEs and detected CWEs as raw numbers.
**After**: Analyst sees expected vs detected *semantic classes* and the explicit gap.

Example context injected:
```
Expected semantic classes: ["buffer_overflow"]
Detected semantic classes: NONE (complete detection gap)
```

This helps the analyst focus investigation on the right vulnerability class instead of re-analyzing classes already found.

### Validation
- 21 improve tests pass
- clippy clean

Relates to #28