### PR TITLE
feat(gym): add sanitizer crash output to CyberGym hints

### DIFF
--- a/crates/gym/src/adapters/cybergym.rs
+++ b/crates/gym/src/adapters/cybergym.rs
@@ -181,6 +181,13 @@ fn load_case_hints(data_dir: &Path, case_id: &str) -> AnalysisHints {
             }
         }
 
+        let error_path = case_data_dir.join("error.txt");
+        if error_path.exists() {
+            if let Ok(error) = std::fs::read_to_string(&error_path) {
+                hints.error_output = Some(error);
+            }
+        }
+
         let diff_path = case_data_dir.join("patch.diff");
         if diff_path.exists() {
             if let Ok(diff) = std::fs::read_to_string(&diff_path) {

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -192,6 +192,9 @@ pub struct AnalysisHints {
     /// Patch diff (e.g. from CyberGym patch.diff).
     /// Injected as "known fix" context for offense/defense analysts.
     pub patch_diff: Option<String>,
+    /// Sanitizer/crash output (e.g. from CyberGym error.txt).
+    /// Shows the exact crash location and error type from ASan/MSan/UBSan.
+    pub error_output: Option<String>,
 }
 
 /// Run full agentic analysis on a source file.
@@ -338,15 +341,27 @@ pub async fn run_agentic_source_analysis_with_hints(
 
     // If we have context hints, store them as investigation metadata
     // so LLM agents can reference them during analysis.
-    if hints.vuln_description.is_some() || hints.patch_diff.is_some() {
+    if hints.vuln_description.is_some()
+        || hints.patch_diff.is_some()
+        || hints.error_output.is_some()
+    {
         let mut hint_text = String::new();
         if let Some(desc) = &hints.vuln_description {
             hint_text.push_str("PRIOR INTELLIGENCE (vulnerability description):\n");
-            // Cap at 2000 chars to avoid overwhelming context
             let capped = if desc.len() > 2000 {
                 &desc[..2000]
             } else {
                 desc
+            };
+            hint_text.push_str(capped);
+            hint_text.push_str("\n\n");
+        }
+        if let Some(error) = &hints.error_output {
+            hint_text.push_str("CRASH EVIDENCE (sanitizer output — shows exact crash location):\n");
+            let capped = if error.len() > 3000 {
+                &error[..3000]
+            } else {
+                error
             };
             hint_text.push_str(capped);
             hint_text.push_str("\n\n");


### PR DESCRIPTION
## Sanitizer Crash Evidence for LLM Agents

Extends `AnalysisHints` with `error_output` — sanitizer crash data (ASan/MSan/UBSan) from CyberGym's `error.txt` files. Gives LLM agents the exact crash location and stack trace.

**Hint injection order**: description → crash evidence → patch diff (mirrors human investigation flow).

### Validation
- 201 gym tests pass, clippy clean

Relates to #28, #220