### PR TITLE
feat(gym): add CyberGym negative cases (post-patch code)

### DIFF
--- a/crates/gym/src/adapters/cybergym.rs
+++ b/crates/gym/src/adapters/cybergym.rs
@@ -171,7 +171,10 @@ impl BenchmarkAdapter for CyberGymAdapter {
 fn load_case_hints(data_dir: &Path, case_id: &str) -> AnalysisHints {
     let mut hints = AnalysisHints::default();
 
-    if let Some((source, id)) = case_id.split_once(':') {
+    // Strip "-fix" suffix from negative case IDs
+    let base_id = case_id.strip_suffix("-fix").unwrap_or(case_id);
+
+    if let Some((source, id)) = base_id.split_once(':') {
         let case_data_dir = data_dir.join("dataset").join("data").join(source).join(id);
 
         let desc_path = case_data_dir.join("description.txt");
@@ -211,16 +214,19 @@ fn archive_path_for_case(dataset_dir: &Path, case_id: &str, is_negative: bool) -
         "repo-vul.tar.gz"
     };
 
+    // Strip "-fix" suffix from negative case IDs to get the base task ID.
+    // e.g. "arvo:1065-fix" → "arvo:1065"
+    let base_id = case_id.strip_suffix("-fix").unwrap_or(case_id);
+
     // Parse "arvo:NNN" or "oss-fuzz:NNN" format
-    if let Some((source, id)) = case_id.split_once(':') {
+    if let Some((source, id)) = base_id.split_once(':') {
         dataset_dir
             .join("data")
             .join(source)
             .join(id)
             .join(archive_name)
     } else {
-        // Fallback: treat entire case_id as a path component
-        dataset_dir.join("data").join(case_id).join(archive_name)
+        dataset_dir.join("data").join(base_id).join(archive_name)
     }
 }
 
@@ -315,6 +321,17 @@ mod tests {
     fn test_archive_path_negative_case() {
         let dataset = PathBuf::from("/data/cybergym/dataset");
         let path = archive_path_for_case(&dataset, "arvo:1065", true);
+        assert_eq!(
+            path,
+            PathBuf::from("/data/cybergym/dataset/data/arvo/1065/repo-fix.tar.gz")
+        );
+    }
+
+    #[test]
+    fn test_archive_path_negative_case_with_fix_suffix() {
+        let dataset = PathBuf::from("/data/cybergym/dataset");
+        // Negative case IDs have "-fix" suffix that must be stripped
+        let path = archive_path_for_case(&dataset, "arvo:1065-fix", true);
         assert_eq!(
             path,
             PathBuf::from("/data/cybergym/dataset/data/arvo/1065/repo-fix.tar.gz")

--- a/data/gym/ground_truth/cybergym.toml
+++ b/data/gym/ground_truth/cybergym.toml
@@ -5,7 +5,7 @@
 # CWEs are inferred from vulnerability descriptions.
 #
 # Phase 1: Detection-only evaluation.
-# Total cases: 1507
+# Total cases: 1507 positive + 1507 negative (post-patch)
 # CWE distribution: {119: 1218, 787: 233, 457: 175, 122: 82, 125: 75, 758: 57, 416: 50, 190: 40, 835: 23, 121: 21}
 
 suite = "cybergym"
@@ -21,10 +21,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1065-fix"
+path = "cases/arvo:1065-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1461"
 path = "cases/arvo:1461"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1461-fix"
+path = "cases/arvo:1461-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -35,10 +49,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65212-fix"
+path = "cases/arvo:65212-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:781"
 path = "cases/arvo:781"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:781-fix"
+path = "cases/arvo:781-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -49,10 +77,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1976-fix"
+path = "cases/arvo:1976-fix"
+expected_cwes = [843]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:67297"
 path = "cases/arvo:67297"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:67297-fix"
+path = "cases/arvo:67297-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -63,10 +105,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65530-fix"
+path = "cases/arvo:65530-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64574"
 path = "cases/arvo:64574"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:64574-fix"
+path = "cases/arvo:64574-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -77,10 +133,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3938-fix"
+path = "cases/arvo:3938-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3848"
 path = "cases/arvo:3848"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3848-fix"
+path = "cases/arvo:3848-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -91,10 +161,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3862-fix"
+path = "cases/arvo:3862-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:368"
 path = "cases/arvo:368"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:368-fix"
+path = "cases/arvo:368-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -105,10 +189,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:64849-fix"
+path = "cases/arvo:64849-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:65383"
 path = "cases/arvo:65383"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65383-fix"
+path = "cases/arvo:65383-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -119,10 +217,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65820-fix"
+path = "cases/arvo:65820-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:62886"
 path = "cases/arvo:62886"
 expected_cwes = [476]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62886-fix"
+path = "cases/arvo:62886-fix"
+expected_cwes = [476]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -133,10 +245,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63314-fix"
+path = "cases/arvo:63314-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:66154"
 path = "cases/arvo:66154"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:66154-fix"
+path = "cases/arvo:66154-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -147,10 +273,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:67552-fix"
+path = "cases/arvo:67552-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:66679"
 path = "cases/arvo:66679"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:66679-fix"
+path = "cases/arvo:66679-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -161,10 +301,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:66502-fix"
+path = "cases/arvo:66502-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59185"
 path = "cases/arvo:59185"
 expected_cwes = [758]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:59185-fix"
+path = "cases/arvo:59185-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -175,10 +329,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62707-fix"
+path = "cases/arvo:62707-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:63564"
 path = "cases/arvo:63564"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:63564-fix"
+path = "cases/arvo:63564-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -189,10 +357,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61789-fix"
+path = "cases/arvo:61789-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:62274"
 path = "cases/arvo:62274"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62274-fix"
+path = "cases/arvo:62274-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -203,10 +385,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:64960-fix"
+path = "cases/arvo:64960-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58364"
 path = "cases/arvo:58364"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:58364-fix"
+path = "cases/arvo:58364-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -217,10 +413,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:66446-fix"
+path = "cases/arvo:66446-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58287"
 path = "cases/arvo:58287"
 expected_cwes = [119, 121, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:58287-fix"
+path = "cases/arvo:58287-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -231,10 +441,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62996-fix"
+path = "cases/arvo:62996-fix"
+expected_cwes = [416, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58452"
 path = "cases/arvo:58452"
 expected_cwes = [457, 758]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:58452-fix"
+path = "cases/arvo:58452-fix"
+expected_cwes = [457, 758]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -245,10 +469,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:64622-fix"
+path = "cases/arvo:64622-fix"
+expected_cwes = [758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65033"
 path = "cases/arvo:65033"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65033-fix"
+path = "cases/arvo:65033-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -259,10 +497,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63157-fix"
+path = "cases/arvo:63157-fix"
+expected_cwes = [416, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61998"
 path = "cases/arvo:61998"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61998-fix"
+path = "cases/arvo:61998-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -273,10 +525,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62183-fix"
+path = "cases/arvo:62183-fix"
+expected_cwes = [369]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61825"
 path = "cases/arvo:61825"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61825-fix"
+path = "cases/arvo:61825-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -287,10 +553,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62261-fix"
+path = "cases/arvo:62261-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3736"
 path = "cases/arvo:3736"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3736-fix"
+path = "cases/arvo:3736-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -301,10 +581,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62911-fix"
+path = "cases/arvo:62911-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61235"
 path = "cases/arvo:61235"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:61235-fix"
+path = "cases/arvo:61235-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -315,10 +609,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65422-fix"
+path = "cases/arvo:65422-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:54948"
 path = "cases/arvo:54948"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:54948-fix"
+path = "cases/arvo:54948-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -329,10 +637,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:54949-fix"
+path = "cases/arvo:54949-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55146"
 path = "cases/arvo:55146"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55146-fix"
+path = "cases/arvo:55146-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -343,10 +665,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:15120-fix"
+path = "cases/arvo:15120-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:62388"
 path = "cases/arvo:62388"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62388-fix"
+path = "cases/arvo:62388-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -357,10 +693,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:55948-fix"
+path = "cases/arvo:55948-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:55886"
 path = "cases/arvo:55886"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:55886-fix"
+path = "cases/arvo:55886-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -371,10 +721,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:57002-fix"
+path = "cases/arvo:57002-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:55820"
 path = "cases/arvo:55820"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:55820-fix"
+path = "cases/arvo:55820-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -385,10 +749,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61816-fix"
+path = "cases/arvo:61816-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64898"
 path = "cases/arvo:64898"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64898-fix"
+path = "cases/arvo:64898-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -399,10 +777,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:64522-fix"
+path = "cases/arvo:64522-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3376"
 path = "cases/arvo:3376"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3376-fix"
+path = "cases/arvo:3376-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -413,10 +805,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63163-fix"
+path = "cases/arvo:63163-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:14582"
 path = "cases/arvo:14582"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:14582-fix"
+path = "cases/arvo:14582-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -427,10 +833,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:56515-fix"
+path = "cases/arvo:56515-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:57234"
 path = "cases/arvo:57234"
 expected_cwes = [401]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57234-fix"
+path = "cases/arvo:57234-fix"
+expected_cwes = [401]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -441,10 +861,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57551-fix"
+path = "cases/arvo:57551-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57378"
 path = "cases/arvo:57378"
 expected_cwes = [476]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57378-fix"
+path = "cases/arvo:57378-fix"
+expected_cwes = [476]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -455,10 +889,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:60670-fix"
+path = "cases/arvo:60670-fix"
+expected_cwes = [415]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:63587"
 path = "cases/arvo:63587"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:63587-fix"
+path = "cases/arvo:63587-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -469,10 +917,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57436-fix"
+path = "cases/arvo:57436-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60514"
 path = "cases/arvo:60514"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:60514-fix"
+path = "cases/arvo:60514-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -483,10 +945,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65418-fix"
+path = "cases/arvo:65418-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:919"
 path = "cases/arvo:919"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:919-fix"
+path = "cases/arvo:919-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -497,10 +973,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14529-fix"
+path = "cases/arvo:14529-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57061"
 path = "cases/arvo:57061"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57061-fix"
+path = "cases/arvo:57061-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -511,10 +1001,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:56837-fix"
+path = "cases/arvo:56837-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:3956"
 path = "cases/arvo:3956"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3956-fix"
+path = "cases/arvo:3956-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -525,10 +1029,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14455-fix"
+path = "cases/arvo:14455-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58085"
 path = "cases/arvo:58085"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:58085-fix"
+path = "cases/arvo:58085-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -539,10 +1057,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:55980-fix"
+path = "cases/arvo:55980-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:14232"
 path = "cases/arvo:14232"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:14232-fix"
+path = "cases/arvo:14232-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -553,10 +1085,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14297-fix"
+path = "cases/arvo:14297-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56179"
 path = "cases/arvo:56179"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56179-fix"
+path = "cases/arvo:56179-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -567,10 +1113,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61337-fix"
+path = "cases/arvo:61337-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:4790"
 path = "cases/arvo:4790"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:4790-fix"
+path = "cases/arvo:4790-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -581,10 +1141,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61902-fix"
+path = "cases/arvo:61902-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53613"
 path = "cases/arvo:53613"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53613-fix"
+path = "cases/arvo:53613-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -595,10 +1169,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61699-fix"
+path = "cases/arvo:61699-fix"
+expected_cwes = [119, 125, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56964"
 path = "cases/arvo:56964"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56964-fix"
+path = "cases/arvo:56964-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -609,10 +1197,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57469-fix"
+path = "cases/arvo:57469-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56947"
 path = "cases/arvo:56947"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56947-fix"
+path = "cases/arvo:56947-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -623,10 +1225,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57284-fix"
+path = "cases/arvo:57284-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1856"
 path = "cases/arvo:1856"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1856-fix"
+path = "cases/arvo:1856-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -637,10 +1253,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61691-fix"
+path = "cases/arvo:61691-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57410"
 path = "cases/arvo:57410"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57410-fix"
+path = "cases/arvo:57410-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -651,10 +1281,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6521-fix"
+path = "cases/arvo:6521-fix"
+expected_cwes = [119, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57223"
 path = "cases/arvo:57223"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57223-fix"
+path = "cases/arvo:57223-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -665,10 +1309,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:38943-fix"
+path = "cases/arvo:38943-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:38393"
 path = "cases/arvo:38393"
 expected_cwes = [119, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38393-fix"
+path = "cases/arvo:38393-fix"
+expected_cwes = [119, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -679,10 +1337,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57521-fix"
+path = "cases/arvo:57521-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:4289"
 path = "cases/arvo:4289"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:4289-fix"
+path = "cases/arvo:4289-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -693,10 +1365,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6483-fix"
+path = "cases/arvo:6483-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8903"
 path = "cases/arvo:8903"
 expected_cwes = [400]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8903-fix"
+path = "cases/arvo:8903-fix"
+expected_cwes = [400]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -707,10 +1393,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62290-fix"
+path = "cases/arvo:62290-fix"
+expected_cwes = [476]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55964"
 path = "cases/arvo:55964"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55964-fix"
+path = "cases/arvo:55964-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -721,10 +1421,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4161-fix"
+path = "cases/arvo:4161-fix"
+expected_cwes = [119, 122, 125, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64118"
 path = "cases/arvo:64118"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:64118-fix"
+path = "cases/arvo:64118-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -735,10 +1449,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:53666-fix"
+path = "cases/arvo:53666-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:58278"
 path = "cases/arvo:58278"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:58278-fix"
+path = "cases/arvo:58278-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -749,10 +1477,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44695-fix"
+path = "cases/arvo:44695-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7189"
 path = "cases/arvo:7189"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7189-fix"
+path = "cases/arvo:7189-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -763,10 +1505,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:60769-fix"
+path = "cases/arvo:60769-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:63104"
 path = "cases/arvo:63104"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:63104-fix"
+path = "cases/arvo:63104-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -777,10 +1533,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:63057-fix"
+path = "cases/arvo:63057-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:63824"
 path = "cases/arvo:63824"
 expected_cwes = [119, 787, 843]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:63824-fix"
+path = "cases/arvo:63824-fix"
+expected_cwes = [119, 787, 843]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -791,10 +1561,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59543-fix"
+path = "cases/arvo:59543-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64181"
 path = "cases/arvo:64181"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64181-fix"
+path = "cases/arvo:64181-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -805,10 +1589,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:40317-fix"
+path = "cases/arvo:40317-fix"
+expected_cwes = [119, 369]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:64215"
 path = "cases/arvo:64215"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64215-fix"
+path = "cases/arvo:64215-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -819,10 +1617,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:40363-fix"
+path = "cases/arvo:40363-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:60616"
 path = "cases/arvo:60616"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60616-fix"
+path = "cases/arvo:60616-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -833,10 +1645,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:15431-fix"
+path = "cases/arvo:15431-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:15278"
 path = "cases/arvo:15278"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:15278-fix"
+path = "cases/arvo:15278-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -847,10 +1673,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42123-fix"
+path = "cases/arvo:42123-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40769"
 path = "cases/arvo:40769"
 expected_cwes = [476]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:40769-fix"
+path = "cases/arvo:40769-fix"
+expected_cwes = [476]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -861,10 +1701,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:45523-fix"
+path = "cases/arvo:45523-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:43209"
 path = "cases/arvo:43209"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:43209-fix"
+path = "cases/arvo:43209-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -875,10 +1729,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:64166-fix"
+path = "cases/arvo:64166-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64286"
 path = "cases/arvo:64286"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64286-fix"
+path = "cases/arvo:64286-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -889,10 +1757,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4099-fix"
+path = "cases/arvo:4099-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60672"
 path = "cases/arvo:60672"
 expected_cwes = [119, 191]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60672-fix"
+path = "cases/arvo:60672-fix"
+expected_cwes = [119, 191]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -903,10 +1785,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:2623-fix"
+path = "cases/arvo:2623-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:12662"
 path = "cases/arvo:12662"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:12662-fix"
+path = "cases/arvo:12662-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -917,10 +1813,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:63483-fix"
+path = "cases/arvo:63483-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:63463"
 path = "cases/arvo:63463"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:63463-fix"
+path = "cases/arvo:63463-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -931,10 +1841,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61750-fix"
+path = "cases/arvo:61750-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56213"
 path = "cases/arvo:56213"
 expected_cwes = [835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56213-fix"
+path = "cases/arvo:56213-fix"
+expected_cwes = [835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -945,10 +1869,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38952-fix"
+path = "cases/arvo:38952-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43307"
 path = "cases/arvo:43307"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43307-fix"
+path = "cases/arvo:43307-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -959,10 +1897,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58190-fix"
+path = "cases/arvo:58190-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42264"
 path = "cases/arvo:42264"
 expected_cwes = [119, 400]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42264-fix"
+path = "cases/arvo:42264-fix"
+expected_cwes = [119, 400]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -973,10 +1925,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44503-fix"
+path = "cases/arvo:44503-fix"
+expected_cwes = [758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57333"
 path = "cases/arvo:57333"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57333-fix"
+path = "cases/arvo:57333-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -987,10 +1953,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4097-fix"
+path = "cases/arvo:4097-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60971"
 path = "cases/arvo:60971"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60971-fix"
+path = "cases/arvo:60971-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1001,10 +1981,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:63622-fix"
+path = "cases/arvo:63622-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:48736"
 path = "cases/arvo:48736"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:48736-fix"
+path = "cases/arvo:48736-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1015,10 +2009,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10864-fix"
+path = "cases/arvo:10864-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10486"
 path = "cases/arvo:10486"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:10486-fix"
+path = "cases/arvo:10486-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1029,10 +2037,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44089-fix"
+path = "cases/arvo:44089-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:44574"
 path = "cases/arvo:44574"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:44574-fix"
+path = "cases/arvo:44574-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1043,10 +2065,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:46957-fix"
+path = "cases/arvo:46957-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:13956"
 path = "cases/arvo:13956"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13956-fix"
+path = "cases/arvo:13956-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1057,10 +2093,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44199-fix"
+path = "cases/arvo:44199-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47986"
 path = "cases/arvo:47986"
 expected_cwes = [119, 121, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47986-fix"
+path = "cases/arvo:47986-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1071,10 +2121,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:16448-fix"
+path = "cases/arvo:16448-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56037"
 path = "cases/arvo:56037"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56037-fix"
+path = "cases/arvo:56037-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1085,10 +2149,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:759-fix"
+path = "cases/arvo:759-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:509"
 path = "cases/arvo:509"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:509-fix"
+path = "cases/arvo:509-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1099,10 +2177,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:61617-fix"
+path = "cases/arvo:61617-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:49903"
 path = "cases/arvo:49903"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49903-fix"
+path = "cases/arvo:49903-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1113,10 +2205,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3498-fix"
+path = "cases/arvo:3498-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3265"
 path = "cases/arvo:3265"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3265-fix"
+path = "cases/arvo:3265-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1127,10 +2233,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3530-fix"
+path = "cases/arvo:3530-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45161"
 path = "cases/arvo:45161"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45161-fix"
+path = "cases/arvo:45161-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1141,10 +2261,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66992-fix"
+path = "cases/arvo:66992-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:45493"
 path = "cases/arvo:45493"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:45493-fix"
+path = "cases/arvo:45493-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1155,10 +2289,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:60728-fix"
+path = "cases/arvo:60728-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59070"
 path = "cases/arvo:59070"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59070-fix"
+path = "cases/arvo:59070-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1169,10 +2317,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3447-fix"
+path = "cases/arvo:3447-fix"
+expected_cwes = [193]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:14935"
 path = "cases/arvo:14935"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:14935-fix"
+path = "cases/arvo:14935-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1183,10 +2345,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:60723-fix"
+path = "cases/arvo:60723-fix"
+expected_cwes = [190, 758]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:15971"
 path = "cases/arvo:15971"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:15971-fix"
+path = "cases/arvo:15971-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1197,10 +2373,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11945-fix"
+path = "cases/arvo:11945-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:14813"
 path = "cases/arvo:14813"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:14813-fix"
+path = "cases/arvo:14813-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1211,10 +2401,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14560-fix"
+path = "cases/arvo:14560-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28253"
 path = "cases/arvo:28253"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28253-fix"
+path = "cases/arvo:28253-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1225,10 +2429,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12419-fix"
+path = "cases/arvo:12419-fix"
+expected_cwes = [401, 415, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:54625"
 path = "cases/arvo:54625"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:54625-fix"
+path = "cases/arvo:54625-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1239,10 +2457,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:57722-fix"
+path = "cases/arvo:57722-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:59428"
 path = "cases/arvo:59428"
 expected_cwes = [415]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:59428-fix"
+path = "cases/arvo:59428-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1253,10 +2485,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:63537-fix"
+path = "cases/arvo:63537-fix"
+expected_cwes = [415]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:3461"
 path = "cases/arvo:3461"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3461-fix"
+path = "cases/arvo:3461-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1267,10 +2513,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3257-fix"
+path = "cases/arvo:3257-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:62973"
 path = "cases/arvo:62973"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:62973-fix"
+path = "cases/arvo:62973-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1281,10 +2541,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14619-fix"
+path = "cases/arvo:14619-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53536"
 path = "cases/arvo:53536"
 expected_cwes = [119, 121, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53536-fix"
+path = "cases/arvo:53536-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1295,10 +2569,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3505-fix"
+path = "cases/arvo:3505-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:4492"
 path = "cases/arvo:4492"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:4492-fix"
+path = "cases/arvo:4492-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1309,10 +2597,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4396-fix"
+path = "cases/arvo:4396-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11504"
 path = "cases/arvo:11504"
 expected_cwes = [590]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11504-fix"
+path = "cases/arvo:11504-fix"
+expected_cwes = [590]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1323,10 +2625,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61797-fix"
+path = "cases/arvo:61797-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58932"
 path = "cases/arvo:58932"
 expected_cwes = [191]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:58932-fix"
+path = "cases/arvo:58932-fix"
+expected_cwes = [191]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1337,10 +2653,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46883-fix"
+path = "cases/arvo:46883-fix"
+expected_cwes = [193]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53631"
 path = "cases/arvo:53631"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53631-fix"
+path = "cases/arvo:53631-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1351,10 +2681,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:45552-fix"
+path = "cases/arvo:45552-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53927"
 path = "cases/arvo:53927"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53927-fix"
+path = "cases/arvo:53927-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1365,10 +2709,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:53417-fix"
+path = "cases/arvo:53417-fix"
+expected_cwes = [119, 191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:16457"
 path = "cases/arvo:16457"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:16457-fix"
+path = "cases/arvo:16457-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1379,10 +2737,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46653-fix"
+path = "cases/arvo:46653-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:4637"
 path = "cases/arvo:4637"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:4637-fix"
+path = "cases/arvo:4637-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1393,10 +2765,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46323-fix"
+path = "cases/arvo:46323-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:48959"
 path = "cases/arvo:48959"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:48959-fix"
+path = "cases/arvo:48959-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1407,10 +2793,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:48863-fix"
+path = "cases/arvo:48863-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46679"
 path = "cases/arvo:46679"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:46679-fix"
+path = "cases/arvo:46679-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1421,10 +2821,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47512-fix"
+path = "cases/arvo:47512-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46852"
 path = "cases/arvo:46852"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:46852-fix"
+path = "cases/arvo:46852-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1435,10 +2849,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14537-fix"
+path = "cases/arvo:14537-fix"
+expected_cwes = [119, 191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:14574"
 path = "cases/arvo:14574"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:14574-fix"
+path = "cases/arvo:14574-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1449,10 +2877,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42227-fix"
+path = "cases/arvo:42227-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3438"
 path = "cases/arvo:3438"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3438-fix"
+path = "cases/arvo:3438-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1463,10 +2905,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3818-fix"
+path = "cases/arvo:3818-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3732"
 path = "cases/arvo:3732"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3732-fix"
+path = "cases/arvo:3732-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1477,10 +2933,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3531-fix"
+path = "cases/arvo:3531-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3371"
 path = "cases/arvo:3371"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3371-fix"
+path = "cases/arvo:3371-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1491,10 +2961,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4670-fix"
+path = "cases/arvo:4670-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3497"
 path = "cases/arvo:3497"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3497-fix"
+path = "cases/arvo:3497-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1505,10 +2989,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3411-fix"
+path = "cases/arvo:3411-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3560"
 path = "cases/arvo:3560"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3560-fix"
+path = "cases/arvo:3560-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1519,10 +3017,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3658-fix"
+path = "cases/arvo:3658-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3680"
 path = "cases/arvo:3680"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3680-fix"
+path = "cases/arvo:3680-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1533,10 +3045,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3621-fix"
+path = "cases/arvo:3621-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:4819"
 path = "cases/arvo:4819"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:4819-fix"
+path = "cases/arvo:4819-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1547,10 +3073,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59650-fix"
+path = "cases/arvo:59650-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:38307"
 path = "cases/arvo:38307"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:38307-fix"
+path = "cases/arvo:38307-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1561,10 +3101,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:38080-fix"
+path = "cases/arvo:38080-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:38050"
 path = "cases/arvo:38050"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:38050-fix"
+path = "cases/arvo:38050-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1575,10 +3129,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:42238-fix"
+path = "cases/arvo:42238-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:15178"
 path = "cases/arvo:15178"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:15178-fix"
+path = "cases/arvo:15178-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1589,10 +3157,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5256-fix"
+path = "cases/arvo:5256-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3012"
 path = "cases/arvo:3012"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3012-fix"
+path = "cases/arvo:3012-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1603,10 +3185,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14481-fix"
+path = "cases/arvo:14481-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18756"
 path = "cases/arvo:18756"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18756-fix"
+path = "cases/arvo:18756-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1617,10 +3213,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50683-fix"
+path = "cases/arvo:50683-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64859"
 path = "cases/arvo:64859"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64859-fix"
+path = "cases/arvo:64859-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1631,10 +3241,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8727-fix"
+path = "cases/arvo:8727-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59457"
 path = "cases/arvo:59457"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59457-fix"
+path = "cases/arvo:59457-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1645,10 +3269,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47143-fix"
+path = "cases/arvo:47143-fix"
+expected_cwes = [119, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:12466"
 path = "cases/arvo:12466"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:12466-fix"
+path = "cases/arvo:12466-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1659,10 +3297,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12817-fix"
+path = "cases/arvo:12817-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11011"
 path = "cases/arvo:11011"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11011-fix"
+path = "cases/arvo:11011-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1673,10 +3325,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46779-fix"
+path = "cases/arvo:46779-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40674"
 path = "cases/arvo:40674"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:40674-fix"
+path = "cases/arvo:40674-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1687,10 +3353,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42108-fix"
+path = "cases/arvo:42108-fix"
+expected_cwes = [119, 121, 193, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49248"
 path = "cases/arvo:49248"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49248-fix"
+path = "cases/arvo:49248-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1701,10 +3381,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:13730-fix"
+path = "cases/arvo:13730-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49495"
 path = "cases/arvo:49495"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49495-fix"
+path = "cases/arvo:49495-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1715,10 +3409,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4322-fix"
+path = "cases/arvo:4322-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:12420"
 path = "cases/arvo:12420"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:12420-fix"
+path = "cases/arvo:12420-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1729,10 +3437,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:49386-fix"
+path = "cases/arvo:49386-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49455"
 path = "cases/arvo:49455"
 expected_cwes = [369]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49455-fix"
+path = "cases/arvo:49455-fix"
+expected_cwes = [369]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1743,10 +3465,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:49461-fix"
+path = "cases/arvo:49461-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50252"
 path = "cases/arvo:50252"
 expected_cwes = [369]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50252-fix"
+path = "cases/arvo:50252-fix"
+expected_cwes = [369]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1757,10 +3493,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14821-fix"
+path = "cases/arvo:14821-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50414"
 path = "cases/arvo:50414"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50414-fix"
+path = "cases/arvo:50414-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1771,10 +3521,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19509-fix"
+path = "cases/arvo:19509-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11173"
 path = "cases/arvo:11173"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11173-fix"
+path = "cases/arvo:11173-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1785,10 +3549,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23197-fix"
+path = "cases/arvo:23197-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:6713"
 path = "cases/arvo:6713"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6713-fix"
+path = "cases/arvo:6713-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1799,10 +3577,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11167-fix"
+path = "cases/arvo:11167-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10999"
 path = "cases/arvo:10999"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10999-fix"
+path = "cases/arvo:10999-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1813,10 +3605,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11007-fix"
+path = "cases/arvo:11007-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11382"
 path = "cases/arvo:11382"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11382-fix"
+path = "cases/arvo:11382-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1827,10 +3633,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:64315-fix"
+path = "cases/arvo:64315-fix"
+expected_cwes = [119, 400, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47675"
 path = "cases/arvo:47675"
 expected_cwes = [119, 121, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47675-fix"
+path = "cases/arvo:47675-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1841,10 +3661,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4511-fix"
+path = "cases/arvo:4511-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:4451"
 path = "cases/arvo:4451"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:4451-fix"
+path = "cases/arvo:4451-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1855,10 +3689,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4822-fix"
+path = "cases/arvo:4822-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:4440"
 path = "cases/arvo:4440"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:4440-fix"
+path = "cases/arvo:4440-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1869,10 +3717,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4812-fix"
+path = "cases/arvo:4812-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13345"
 path = "cases/arvo:13345"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13345-fix"
+path = "cases/arvo:13345-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1883,10 +3745,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:44432-fix"
+path = "cases/arvo:44432-fix"
+expected_cwes = [119, 121, 193, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:61908"
 path = "cases/arvo:61908"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61908-fix"
+path = "cases/arvo:61908-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1897,10 +3773,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65996-fix"
+path = "cases/arvo:65996-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13741"
 path = "cases/arvo:13741"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13741-fix"
+path = "cases/arvo:13741-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1911,10 +3801,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:56160-fix"
+path = "cases/arvo:56160-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:66426"
 path = "cases/arvo:66426"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:66426-fix"
+path = "cases/arvo:66426-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1925,10 +3829,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:34755-fix"
+path = "cases/arvo:34755-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:43408"
 path = "cases/arvo:43408"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43408-fix"
+path = "cases/arvo:43408-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1939,10 +3857,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43847-fix"
+path = "cases/arvo:43847-fix"
+expected_cwes = [119, 121, 193, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:38878"
 path = "cases/arvo:38878"
 expected_cwes = [119, 416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38878-fix"
+path = "cases/arvo:38878-fix"
+expected_cwes = [119, 416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1953,10 +3885,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:54482-fix"
+path = "cases/arvo:54482-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53483"
 path = "cases/arvo:53483"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:53483-fix"
+path = "cases/arvo:53483-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -1967,10 +3913,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46224-fix"
+path = "cases/arvo:46224-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46244"
 path = "cases/arvo:46244"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:46244-fix"
+path = "cases/arvo:46244-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1981,10 +3941,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:7105-fix"
+path = "cases/arvo:7105-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:36476"
 path = "cases/arvo:36476"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:36476-fix"
+path = "cases/arvo:36476-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -1995,10 +3969,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:53158-fix"
+path = "cases/arvo:53158-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46918"
 path = "cases/arvo:46918"
 expected_cwes = [119, 121, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:46918-fix"
+path = "cases/arvo:46918-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2009,10 +3997,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:53750-fix"
+path = "cases/arvo:53750-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:54839"
 path = "cases/arvo:54839"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:54839-fix"
+path = "cases/arvo:54839-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2023,10 +4025,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50957-fix"
+path = "cases/arvo:50957-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:36861"
 path = "cases/arvo:36861"
 expected_cwes = [119, 416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:36861-fix"
+path = "cases/arvo:36861-fix"
+expected_cwes = [119, 416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2037,10 +4053,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4452-fix"
+path = "cases/arvo:4452-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58662"
 path = "cases/arvo:58662"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:58662-fix"
+path = "cases/arvo:58662-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2051,10 +4081,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:53149-fix"
+path = "cases/arvo:53149-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:49613"
 path = "cases/arvo:49613"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:49613-fix"
+path = "cases/arvo:49613-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2065,10 +4109,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46309-fix"
+path = "cases/arvo:46309-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55282"
 path = "cases/arvo:55282"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:55282-fix"
+path = "cases/arvo:55282-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2079,10 +4137,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14786-fix"
+path = "cases/arvo:14786-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34386"
 path = "cases/arvo:34386"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34386-fix"
+path = "cases/arvo:34386-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2093,10 +4165,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:66012-fix"
+path = "cases/arvo:66012-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:35140"
 path = "cases/arvo:35140"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:35140-fix"
+path = "cases/arvo:35140-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2107,10 +4193,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:53183-fix"
+path = "cases/arvo:53183-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7067"
 path = "cases/arvo:7067"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7067-fix"
+path = "cases/arvo:7067-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2121,10 +4221,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6975-fix"
+path = "cases/arvo:6975-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60268"
 path = "cases/arvo:60268"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60268-fix"
+path = "cases/arvo:60268-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2135,10 +4249,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:37443-fix"
+path = "cases/arvo:37443-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20060"
 path = "cases/arvo:20060"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20060-fix"
+path = "cases/arvo:20060-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2149,10 +4277,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:56991-fix"
+path = "cases/arvo:56991-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40617"
 path = "cases/arvo:40617"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40617-fix"
+path = "cases/arvo:40617-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2163,10 +4305,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58770-fix"
+path = "cases/arvo:58770-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11081"
 path = "cases/arvo:11081"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11081-fix"
+path = "cases/arvo:11081-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2177,10 +4333,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57672-fix"
+path = "cases/arvo:57672-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57037"
 path = "cases/arvo:57037"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57037-fix"
+path = "cases/arvo:57037-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2191,10 +4361,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10341-fix"
+path = "cases/arvo:10341-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11657"
 path = "cases/arvo:11657"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11657-fix"
+path = "cases/arvo:11657-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2205,10 +4389,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12312-fix"
+path = "cases/arvo:12312-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:39741"
 path = "cases/arvo:39741"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:39741-fix"
+path = "cases/arvo:39741-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2219,10 +4417,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:33318-fix"
+path = "cases/arvo:33318-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:11435"
 path = "cases/arvo:11435"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11435-fix"
+path = "cases/arvo:11435-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2233,10 +4445,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:40623-fix"
+path = "cases/arvo:40623-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11730"
 path = "cases/arvo:11730"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11730-fix"
+path = "cases/arvo:11730-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2247,10 +4473,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11033-fix"
+path = "cases/arvo:11033-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11908"
 path = "cases/arvo:11908"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11908-fix"
+path = "cases/arvo:11908-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2261,10 +4501,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:37687-fix"
+path = "cases/arvo:37687-fix"
+expected_cwes = [119, 758, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11245"
 path = "cases/arvo:11245"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11245-fix"
+path = "cases/arvo:11245-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2275,10 +4529,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6581-fix"
+path = "cases/arvo:6581-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:33991"
 path = "cases/arvo:33991"
 expected_cwes = [119, 191, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:33991-fix"
+path = "cases/arvo:33991-fix"
+expected_cwes = [119, 191, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2289,10 +4557,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58428-fix"
+path = "cases/arvo:58428-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59056"
 path = "cases/arvo:59056"
 expected_cwes = [590]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59056-fix"
+path = "cases/arvo:59056-fix"
+expected_cwes = [590]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2303,10 +4585,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47500-fix"
+path = "cases/arvo:47500-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20694"
 path = "cases/arvo:20694"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20694-fix"
+path = "cases/arvo:20694-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2317,10 +4613,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58479-fix"
+path = "cases/arvo:58479-fix"
+expected_cwes = [758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34695"
 path = "cases/arvo:34695"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:34695-fix"
+path = "cases/arvo:34695-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2331,10 +4641,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:52317-fix"
+path = "cases/arvo:52317-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7262"
 path = "cases/arvo:7262"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7262-fix"
+path = "cases/arvo:7262-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2345,10 +4669,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:35902-fix"
+path = "cases/arvo:35902-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:38355"
 path = "cases/arvo:38355"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38355-fix"
+path = "cases/arvo:38355-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2359,10 +4697,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59827-fix"
+path = "cases/arvo:59827-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47947"
 path = "cases/arvo:47947"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:47947-fix"
+path = "cases/arvo:47947-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2373,10 +4725,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:52486-fix"
+path = "cases/arvo:52486-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20905"
 path = "cases/arvo:20905"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20905-fix"
+path = "cases/arvo:20905-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2387,10 +4753,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:21578-fix"
+path = "cases/arvo:21578-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:21579"
 path = "cases/arvo:21579"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:21579-fix"
+path = "cases/arvo:21579-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2401,10 +4781,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6626-fix"
+path = "cases/arvo:6626-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:16634"
 path = "cases/arvo:16634"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:16634-fix"
+path = "cases/arvo:16634-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2415,10 +4809,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38298-fix"
+path = "cases/arvo:38298-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47150"
 path = "cases/arvo:47150"
 expected_cwes = [400]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:47150-fix"
+path = "cases/arvo:47150-fix"
+expected_cwes = [400]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2429,10 +4837,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:34096-fix"
+path = "cases/arvo:34096-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51563"
 path = "cases/arvo:51563"
 expected_cwes = [457, 758]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:51563-fix"
+path = "cases/arvo:51563-fix"
+expected_cwes = [457, 758]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2443,10 +4865,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59931-fix"
+path = "cases/arvo:59931-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:9445"
 path = "cases/arvo:9445"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:9445-fix"
+path = "cases/arvo:9445-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2457,10 +4893,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12096-fix"
+path = "cases/arvo:12096-fix"
+expected_cwes = [401]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45993"
 path = "cases/arvo:45993"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45993-fix"
+path = "cases/arvo:45993-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2471,10 +4921,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46917-fix"
+path = "cases/arvo:46917-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19013"
 path = "cases/arvo:19013"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19013-fix"
+path = "cases/arvo:19013-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2485,10 +4949,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18988-fix"
+path = "cases/arvo:18988-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18952"
 path = "cases/arvo:18952"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18952-fix"
+path = "cases/arvo:18952-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2499,10 +4977,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:34138-fix"
+path = "cases/arvo:34138-fix"
+expected_cwes = [476]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:32482"
 path = "cases/arvo:32482"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:32482-fix"
+path = "cases/arvo:32482-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2513,10 +5005,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:40540-fix"
+path = "cases/arvo:40540-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52430"
 path = "cases/arvo:52430"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52430-fix"
+path = "cases/arvo:52430-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2527,10 +5033,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20476-fix"
+path = "cases/arvo:20476-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3325"
 path = "cases/arvo:3325"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3325-fix"
+path = "cases/arvo:3325-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2541,10 +5061,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:27851-fix"
+path = "cases/arvo:27851-fix"
+expected_cwes = [416, 590]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:33556"
 path = "cases/arvo:33556"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:33556-fix"
+path = "cases/arvo:33556-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2555,10 +5089,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:36955-fix"
+path = "cases/arvo:36955-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60432"
 path = "cases/arvo:60432"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60432-fix"
+path = "cases/arvo:60432-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2569,10 +5117,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:32521-fix"
+path = "cases/arvo:32521-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:62500"
 path = "cases/arvo:62500"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62500-fix"
+path = "cases/arvo:62500-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2583,10 +5145,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62822-fix"
+path = "cases/arvo:62822-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52006"
 path = "cases/arvo:52006"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:52006-fix"
+path = "cases/arvo:52006-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2597,10 +5173,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18152-fix"
+path = "cases/arvo:18152-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18196"
 path = "cases/arvo:18196"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18196-fix"
+path = "cases/arvo:18196-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2611,10 +5201,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:53118-fix"
+path = "cases/arvo:53118-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:57001"
 path = "cases/arvo:57001"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57001-fix"
+path = "cases/arvo:57001-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2625,10 +5229,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:34299-fix"
+path = "cases/arvo:34299-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10710"
 path = "cases/arvo:10710"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10710-fix"
+path = "cases/arvo:10710-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2639,10 +5257,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51757-fix"
+path = "cases/arvo:51757-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52944"
 path = "cases/arvo:52944"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52944-fix"
+path = "cases/arvo:52944-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2653,10 +5285,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50901-fix"
+path = "cases/arvo:50901-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64151"
 path = "cases/arvo:64151"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64151-fix"
+path = "cases/arvo:64151-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2667,10 +5313,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62774-fix"
+path = "cases/arvo:62774-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50629"
 path = "cases/arvo:50629"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50629-fix"
+path = "cases/arvo:50629-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2681,10 +5341,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:34259-fix"
+path = "cases/arvo:34259-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:16972"
 path = "cases/arvo:16972"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:16972-fix"
+path = "cases/arvo:16972-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2695,10 +5369,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3630-fix"
+path = "cases/arvo:3630-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3569"
 path = "cases/arvo:3569"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3569-fix"
+path = "cases/arvo:3569-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2709,10 +5397,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11253-fix"
+path = "cases/arvo:11253-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61675"
 path = "cases/arvo:61675"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61675-fix"
+path = "cases/arvo:61675-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2723,10 +5425,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10731-fix"
+path = "cases/arvo:10731-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10865"
 path = "cases/arvo:10865"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10865-fix"
+path = "cases/arvo:10865-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2737,10 +5453,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12255-fix"
+path = "cases/arvo:12255-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20800"
 path = "cases/arvo:20800"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20800-fix"
+path = "cases/arvo:20800-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2751,10 +5481,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:40508-fix"
+path = "cases/arvo:40508-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:32807"
 path = "cases/arvo:32807"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:32807-fix"
+path = "cases/arvo:32807-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2765,10 +5509,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51498-fix"
+path = "cases/arvo:51498-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52195"
 path = "cases/arvo:52195"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52195-fix"
+path = "cases/arvo:52195-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2779,10 +5537,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10628-fix"
+path = "cases/arvo:10628-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29912"
 path = "cases/arvo:29912"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29912-fix"
+path = "cases/arvo:29912-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2793,10 +5565,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30800-fix"
+path = "cases/arvo:30800-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:24183"
 path = "cases/arvo:24183"
 expected_cwes = [119, 122, 125, 787, 835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:24183-fix"
+path = "cases/arvo:24183-fix"
+expected_cwes = [119, 122, 125, 787, 835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2807,10 +5593,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20716-fix"
+path = "cases/arvo:20716-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10863"
 path = "cases/arvo:10863"
 expected_cwes = [835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10863-fix"
+path = "cases/arvo:10863-fix"
+expected_cwes = [835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2821,10 +5621,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38924-fix"
+path = "cases/arvo:38924-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:17778"
 path = "cases/arvo:17778"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17778-fix"
+path = "cases/arvo:17778-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2835,10 +5649,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23215-fix"
+path = "cases/arvo:23215-fix"
+expected_cwes = [758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23787"
 path = "cases/arvo:23787"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23787-fix"
+path = "cases/arvo:23787-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2849,10 +5677,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18070-fix"
+path = "cases/arvo:18070-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25885"
 path = "cases/arvo:25885"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25885-fix"
+path = "cases/arvo:25885-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2863,10 +5705,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:33340-fix"
+path = "cases/arvo:33340-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:27480"
 path = "cases/arvo:27480"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27480-fix"
+path = "cases/arvo:27480-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2877,10 +5733,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:17072-fix"
+path = "cases/arvo:17072-fix"
+expected_cwes = [400]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:17006"
 path = "cases/arvo:17006"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17006-fix"
+path = "cases/arvo:17006-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2891,10 +5761,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18991-fix"
+path = "cases/arvo:18991-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:41356"
 path = "cases/arvo:41356"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:41356-fix"
+path = "cases/arvo:41356-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2905,10 +5789,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:17855-fix"
+path = "cases/arvo:17855-fix"
+expected_cwes = [119, 191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3940"
 path = "cases/arvo:3940"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3940-fix"
+path = "cases/arvo:3940-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2919,10 +5817,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4404-fix"
+path = "cases/arvo:4404-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19039"
 path = "cases/arvo:19039"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19039-fix"
+path = "cases/arvo:19039-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2933,10 +5845,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35086-fix"
+path = "cases/arvo:35086-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18868"
 path = "cases/arvo:18868"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18868-fix"
+path = "cases/arvo:18868-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2947,10 +5873,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19208-fix"
+path = "cases/arvo:19208-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:33474"
 path = "cases/arvo:33474"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:33474-fix"
+path = "cases/arvo:33474-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2961,10 +5901,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8933-fix"
+path = "cases/arvo:8933-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65319"
 path = "cases/arvo:65319"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:65319-fix"
+path = "cases/arvo:65319-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -2975,10 +5929,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8968-fix"
+path = "cases/arvo:8968-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:36025"
 path = "cases/arvo:36025"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:36025-fix"
+path = "cases/arvo:36025-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -2989,10 +5957,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66031-fix"
+path = "cases/arvo:66031-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:17069"
 path = "cases/arvo:17069"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17069-fix"
+path = "cases/arvo:17069-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3003,10 +5985,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:65255-fix"
+path = "cases/arvo:65255-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:66371"
 path = "cases/arvo:66371"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:66371-fix"
+path = "cases/arvo:66371-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3017,10 +6013,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19222-fix"
+path = "cases/arvo:19222-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19251"
 path = "cases/arvo:19251"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19251-fix"
+path = "cases/arvo:19251-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3031,10 +6041,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20131-fix"
+path = "cases/arvo:20131-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18798"
 path = "cases/arvo:18798"
 expected_cwes = [190, 191]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18798-fix"
+path = "cases/arvo:18798-fix"
+expected_cwes = [190, 191]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3045,10 +6069,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38766-fix"
+path = "cases/arvo:38766-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:17171"
 path = "cases/arvo:17171"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17171-fix"
+path = "cases/arvo:17171-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3059,10 +6097,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19548-fix"
+path = "cases/arvo:19548-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27269"
 path = "cases/arvo:27269"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27269-fix"
+path = "cases/arvo:27269-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3073,10 +6125,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38751-fix"
+path = "cases/arvo:38751-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:12173"
 path = "cases/arvo:12173"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:12173-fix"
+path = "cases/arvo:12173-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3087,10 +6153,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:63186-fix"
+path = "cases/arvo:63186-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:43414"
 path = "cases/arvo:43414"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43414-fix"
+path = "cases/arvo:43414-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3101,10 +6181,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:52869-fix"
+path = "cases/arvo:52869-fix"
+expected_cwes = [401]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46279"
 path = "cases/arvo:46279"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:46279-fix"
+path = "cases/arvo:46279-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3115,10 +6209,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38764-fix"
+path = "cases/arvo:38764-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18562"
 path = "cases/arvo:18562"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18562-fix"
+path = "cases/arvo:18562-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3129,10 +6237,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8505-fix"
+path = "cases/arvo:8505-fix"
+expected_cwes = [369, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47392"
 path = "cases/arvo:47392"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47392-fix"
+path = "cases/arvo:47392-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3143,10 +6265,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21916-fix"
+path = "cases/arvo:21916-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49427"
 path = "cases/arvo:49427"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49427-fix"
+path = "cases/arvo:49427-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3157,10 +6293,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20200-fix"
+path = "cases/arvo:20200-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8811"
 path = "cases/arvo:8811"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8811-fix"
+path = "cases/arvo:8811-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3171,10 +6321,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:48877-fix"
+path = "cases/arvo:48877-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20459"
 path = "cases/arvo:20459"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20459-fix"
+path = "cases/arvo:20459-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3185,10 +6349,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:45192-fix"
+path = "cases/arvo:45192-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56513"
 path = "cases/arvo:56513"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56513-fix"
+path = "cases/arvo:56513-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3199,10 +6377,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:49542-fix"
+path = "cases/arvo:49542-fix"
+expected_cwes = [190, 191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5296"
 path = "cases/arvo:5296"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5296-fix"
+path = "cases/arvo:5296-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3213,10 +6405,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14767-fix"
+path = "cases/arvo:14767-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:6796"
 path = "cases/arvo:6796"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6796-fix"
+path = "cases/arvo:6796-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3227,10 +6433,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:49429-fix"
+path = "cases/arvo:49429-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52724"
 path = "cases/arvo:52724"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52724-fix"
+path = "cases/arvo:52724-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3241,10 +6461,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8511-fix"
+path = "cases/arvo:8511-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:48915"
 path = "cases/arvo:48915"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:48915-fix"
+path = "cases/arvo:48915-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3255,10 +6489,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:53499-fix"
+path = "cases/arvo:53499-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:8529"
 path = "cases/arvo:8529"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8529-fix"
+path = "cases/arvo:8529-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3269,10 +6517,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38870-fix"
+path = "cases/arvo:38870-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49269"
 path = "cases/arvo:49269"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49269-fix"
+path = "cases/arvo:49269-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3283,10 +6545,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:51292-fix"
+path = "cases/arvo:51292-fix"
+expected_cwes = [590]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:49045"
 path = "cases/arvo:49045"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49045-fix"
+path = "cases/arvo:49045-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3297,10 +6573,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8696-fix"
+path = "cases/arvo:8696-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21984"
 path = "cases/arvo:21984"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21984-fix"
+path = "cases/arvo:21984-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3311,10 +6601,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:49550-fix"
+path = "cases/arvo:49550-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:17737"
 path = "cases/arvo:17737"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17737-fix"
+path = "cases/arvo:17737-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3325,10 +6629,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66040-fix"
+path = "cases/arvo:66040-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:49259"
 path = "cases/arvo:49259"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49259-fix"
+path = "cases/arvo:49259-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3339,10 +6657,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47790-fix"
+path = "cases/arvo:47790-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:66005"
 path = "cases/arvo:66005"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:66005-fix"
+path = "cases/arvo:66005-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3353,10 +6685,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66359-fix"
+path = "cases/arvo:66359-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:66287"
 path = "cases/arvo:66287"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:66287-fix"
+path = "cases/arvo:66287-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3367,10 +6713,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50589-fix"
+path = "cases/arvo:50589-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52049"
 path = "cases/arvo:52049"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52049-fix"
+path = "cases/arvo:52049-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3381,10 +6741,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47213-fix"
+path = "cases/arvo:47213-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:66123"
 path = "cases/arvo:66123"
 expected_cwes = [416]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:66123-fix"
+path = "cases/arvo:66123-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3395,10 +6769,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66415-fix"
+path = "cases/arvo:66415-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:65985"
 path = "cases/arvo:65985"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:65985-fix"
+path = "cases/arvo:65985-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3409,10 +6797,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:51735-fix"
+path = "cases/arvo:51735-fix"
+expected_cwes = [119, 190, 400]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:65864"
 path = "cases/arvo:65864"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65864-fix"
+path = "cases/arvo:65864-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3423,10 +6825,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:66064-fix"
+path = "cases/arvo:66064-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65518"
 path = "cases/arvo:65518"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65518-fix"
+path = "cases/arvo:65518-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3437,10 +6853,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:66079-fix"
+path = "cases/arvo:66079-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5843"
 path = "cases/arvo:5843"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5843-fix"
+path = "cases/arvo:5843-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3451,10 +6881,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66108-fix"
+path = "cases/arvo:66108-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:9180"
 path = "cases/arvo:9180"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:9180-fix"
+path = "cases/arvo:9180-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3465,10 +6909,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66696-fix"
+path = "cases/arvo:66696-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:18540"
 path = "cases/arvo:18540"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18540-fix"
+path = "cases/arvo:18540-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3479,10 +6937,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65510-fix"
+path = "cases/arvo:65510-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7171"
 path = "cases/arvo:7171"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7171-fix"
+path = "cases/arvo:7171-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3493,10 +6965,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12797-fix"
+path = "cases/arvo:12797-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18153"
 path = "cases/arvo:18153"
 expected_cwes = [401]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18153-fix"
+path = "cases/arvo:18153-fix"
+expected_cwes = [401]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3507,10 +6993,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65650-fix"
+path = "cases/arvo:65650-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65532"
 path = "cases/arvo:65532"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65532-fix"
+path = "cases/arvo:65532-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3521,10 +7021,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11248-fix"
+path = "cases/arvo:11248-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7538"
 path = "cases/arvo:7538"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7538-fix"
+path = "cases/arvo:7538-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3535,10 +7049,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18482-fix"
+path = "cases/arvo:18482-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49187"
 path = "cases/arvo:49187"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49187-fix"
+path = "cases/arvo:49187-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3549,10 +7077,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11256-fix"
+path = "cases/arvo:11256-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11244"
 path = "cases/arvo:11244"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11244-fix"
+path = "cases/arvo:11244-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3563,10 +7105,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65531-fix"
+path = "cases/arvo:65531-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65535"
 path = "cases/arvo:65535"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65535-fix"
+path = "cases/arvo:65535-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3577,10 +7133,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18140-fix"
+path = "cases/arvo:18140-fix"
+expected_cwes = [119, 122, 193, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49797"
 path = "cases/arvo:49797"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49797-fix"
+path = "cases/arvo:49797-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3591,10 +7161,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51603-fix"
+path = "cases/arvo:51603-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64529"
 path = "cases/arvo:64529"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64529-fix"
+path = "cases/arvo:64529-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3605,10 +7189,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65765-fix"
+path = "cases/arvo:65765-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21070"
 path = "cases/arvo:21070"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21070-fix"
+path = "cases/arvo:21070-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3619,10 +7217,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:32663-fix"
+path = "cases/arvo:32663-fix"
+expected_cwes = [476]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:40933"
 path = "cases/arvo:40933"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40933-fix"
+path = "cases/arvo:40933-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3633,10 +7245,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:33150-fix"
+path = "cases/arvo:33150-fix"
+expected_cwes = [476]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:32785"
 path = "cases/arvo:32785"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:32785-fix"
+path = "cases/arvo:32785-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3647,10 +7273,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21302-fix"
+path = "cases/arvo:21302-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51132"
 path = "cases/arvo:51132"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51132-fix"
+path = "cases/arvo:51132-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3661,10 +7301,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65519-fix"
+path = "cases/arvo:65519-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34374"
 path = "cases/arvo:34374"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:34374-fix"
+path = "cases/arvo:34374-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3675,10 +7329,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20775-fix"
+path = "cases/arvo:20775-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55413"
 path = "cases/arvo:55413"
 expected_cwes = [119, 758, 835]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:55413-fix"
+path = "cases/arvo:55413-fix"
+expected_cwes = [119, 758, 835]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3689,10 +7357,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:60766-fix"
+path = "cases/arvo:60766-fix"
+expected_cwes = [835]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:44483"
 path = "cases/arvo:44483"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:44483-fix"
+path = "cases/arvo:44483-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3703,10 +7385,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21638-fix"
+path = "cases/arvo:21638-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21301"
 path = "cases/arvo:21301"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21301-fix"
+path = "cases/arvo:21301-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3717,10 +7413,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:60372-fix"
+path = "cases/arvo:60372-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:53618"
 path = "cases/arvo:53618"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53618-fix"
+path = "cases/arvo:53618-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3731,10 +7441,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:56682-fix"
+path = "cases/arvo:56682-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21670"
 path = "cases/arvo:21670"
 expected_cwes = [457, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21670-fix"
+path = "cases/arvo:21670-fix"
+expected_cwes = [457, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3745,10 +7469,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:45879-fix"
+path = "cases/arvo:45879-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46082"
 path = "cases/arvo:46082"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:46082-fix"
+path = "cases/arvo:46082-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3759,10 +7497,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:60557-fix"
+path = "cases/arvo:60557-fix"
+expected_cwes = [119, 122, 125, 787, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:37575"
 path = "cases/arvo:37575"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:37575-fix"
+path = "cases/arvo:37575-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3773,10 +7525,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:52037-fix"
+path = "cases/arvo:52037-fix"
+expected_cwes = [119, 191]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:37621"
 path = "cases/arvo:37621"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:37621-fix"
+path = "cases/arvo:37621-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3787,10 +7553,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18356-fix"
+path = "cases/arvo:18356-fix"
+expected_cwes = [476]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:67043"
 path = "cases/arvo:67043"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:67043-fix"
+path = "cases/arvo:67043-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3801,10 +7581,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18882-fix"
+path = "cases/arvo:18882-fix"
+expected_cwes = [119, 125, 190, 191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:37211"
 path = "cases/arvo:37211"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:37211-fix"
+path = "cases/arvo:37211-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3815,10 +7609,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57317-fix"
+path = "cases/arvo:57317-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60253"
 path = "cases/arvo:60253"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:60253-fix"
+path = "cases/arvo:60253-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3829,10 +7637,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:37056-fix"
+path = "cases/arvo:37056-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:59393"
 path = "cases/arvo:59393"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59393-fix"
+path = "cases/arvo:59393-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3843,10 +7665,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66715-fix"
+path = "cases/arvo:66715-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:20321"
 path = "cases/arvo:20321"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20321-fix"
+path = "cases/arvo:20321-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3857,10 +7693,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66349-fix"
+path = "cases/arvo:66349-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:65362"
 path = "cases/arvo:65362"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65362-fix"
+path = "cases/arvo:65362-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3871,10 +7721,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66033-fix"
+path = "cases/arvo:66033-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:65960"
 path = "cases/arvo:65960"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:65960-fix"
+path = "cases/arvo:65960-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3885,10 +7749,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66447-fix"
+path = "cases/arvo:66447-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:57369"
 path = "cases/arvo:57369"
 expected_cwes = [119, 122, 125, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57369-fix"
+path = "cases/arvo:57369-fix"
+expected_cwes = [119, 122, 125, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3899,10 +7777,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:65235-fix"
+path = "cases/arvo:65235-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:34116"
 path = "cases/arvo:34116"
 expected_cwes = [119, 415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34116-fix"
+path = "cases/arvo:34116-fix"
+expected_cwes = [119, 415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3913,10 +7805,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66196-fix"
+path = "cases/arvo:66196-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:65209"
 path = "cases/arvo:65209"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:65209-fix"
+path = "cases/arvo:65209-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3927,10 +7833,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:60605-fix"
+path = "cases/arvo:60605-fix"
+expected_cwes = [190, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65264"
 path = "cases/arvo:65264"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:65264-fix"
+path = "cases/arvo:65264-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -3941,10 +7861,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20906-fix"
+path = "cases/arvo:20906-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:63746"
 path = "cases/arvo:63746"
 expected_cwes = [119, 121, 758, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:63746-fix"
+path = "cases/arvo:63746-fix"
+expected_cwes = [119, 121, 758, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3955,10 +7889,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20944-fix"
+path = "cases/arvo:20944-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:22105"
 path = "cases/arvo:22105"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:22105-fix"
+path = "cases/arvo:22105-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3969,10 +7917,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14912-fix"
+path = "cases/arvo:14912-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20655"
 path = "cases/arvo:20655"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20655-fix"
+path = "cases/arvo:20655-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3983,10 +7945,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63179-fix"
+path = "cases/arvo:63179-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19956"
 path = "cases/arvo:19956"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19956-fix"
+path = "cases/arvo:19956-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -3997,10 +7973,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35543-fix"
+path = "cases/arvo:35543-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21026"
 path = "cases/arvo:21026"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21026-fix"
+path = "cases/arvo:21026-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4011,10 +8001,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21092-fix"
+path = "cases/arvo:21092-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:66480"
 path = "cases/arvo:66480"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:66480-fix"
+path = "cases/arvo:66480-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4025,10 +8029,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21580-fix"
+path = "cases/arvo:21580-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:63754"
 path = "cases/arvo:63754"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:63754-fix"
+path = "cases/arvo:63754-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4039,10 +8057,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:56272-fix"
+path = "cases/arvo:56272-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20112"
 path = "cases/arvo:20112"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20112-fix"
+path = "cases/arvo:20112-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4053,10 +8085,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42275-fix"
+path = "cases/arvo:42275-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:38148"
 path = "cases/arvo:38148"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38148-fix"
+path = "cases/arvo:38148-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4067,10 +8113,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58666-fix"
+path = "cases/arvo:58666-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:66627"
 path = "cases/arvo:66627"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:66627-fix"
+path = "cases/arvo:66627-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4081,10 +8141,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44280-fix"
+path = "cases/arvo:44280-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:36911"
 path = "cases/arvo:36911"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:36911-fix"
+path = "cases/arvo:36911-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4095,10 +8169,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35109-fix"
+path = "cases/arvo:35109-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34652"
 path = "cases/arvo:34652"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34652-fix"
+path = "cases/arvo:34652-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4109,10 +8197,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:36464-fix"
+path = "cases/arvo:36464-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40087"
 path = "cases/arvo:40087"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40087-fix"
+path = "cases/arvo:40087-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4123,10 +8225,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:36930-fix"
+path = "cases/arvo:36930-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64945"
 path = "cases/arvo:64945"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64945-fix"
+path = "cases/arvo:64945-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4137,10 +8253,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20578-fix"
+path = "cases/arvo:20578-fix"
+expected_cwes = [400]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:38251"
 path = "cases/arvo:38251"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38251-fix"
+path = "cases/arvo:38251-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4151,10 +8281,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35727-fix"
+path = "cases/arvo:35727-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:36999"
 path = "cases/arvo:36999"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:36999-fix"
+path = "cases/arvo:36999-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4165,10 +8309,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:64079-fix"
+path = "cases/arvo:64079-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45036"
 path = "cases/arvo:45036"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45036-fix"
+path = "cases/arvo:45036-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4179,10 +8337,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:36908-fix"
+path = "cases/arvo:36908-fix"
+expected_cwes = [119, 193]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56150"
 path = "cases/arvo:56150"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56150-fix"
+path = "cases/arvo:56150-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4193,10 +8365,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:32555-fix"
+path = "cases/arvo:32555-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:44482"
 path = "cases/arvo:44482"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:44482-fix"
+path = "cases/arvo:44482-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4207,10 +8393,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:32275-fix"
+path = "cases/arvo:32275-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:34691"
 path = "cases/arvo:34691"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34691-fix"
+path = "cases/arvo:34691-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4221,10 +8421,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38283-fix"
+path = "cases/arvo:38283-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58701"
 path = "cases/arvo:58701"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:58701-fix"
+path = "cases/arvo:58701-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -4235,10 +8449,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:55218-fix"
+path = "cases/arvo:55218-fix"
+expected_cwes = [119, 122, 125, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47730"
 path = "cases/arvo:47730"
 expected_cwes = [119, 121, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47730-fix"
+path = "cases/arvo:47730-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4249,10 +8477,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47000-fix"
+path = "cases/arvo:47000-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:48020"
 path = "cases/arvo:48020"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:48020-fix"
+path = "cases/arvo:48020-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4263,10 +8505,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:44766-fix"
+path = "cases/arvo:44766-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:21641"
 path = "cases/arvo:21641"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21641-fix"
+path = "cases/arvo:21641-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4277,10 +8533,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19902-fix"
+path = "cases/arvo:19902-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49638"
 path = "cases/arvo:49638"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49638-fix"
+path = "cases/arvo:49638-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4291,10 +8561,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:55214-fix"
+path = "cases/arvo:55214-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:47728"
 path = "cases/arvo:47728"
 expected_cwes = [457, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47728-fix"
+path = "cases/arvo:47728-fix"
+expected_cwes = [457, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4305,10 +8589,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:56076-fix"
+path = "cases/arvo:56076-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:52465"
 path = "cases/arvo:52465"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52465-fix"
+path = "cases/arvo:52465-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4319,10 +8617,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:33238-fix"
+path = "cases/arvo:33238-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49901"
 path = "cases/arvo:49901"
 expected_cwes = [119, 122, 125, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49901-fix"
+path = "cases/arvo:49901-fix"
+expected_cwes = [119, 122, 125, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4333,10 +8645,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:60842-fix"
+path = "cases/arvo:60842-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:22507"
 path = "cases/arvo:22507"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:22507-fix"
+path = "cases/arvo:22507-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4347,10 +8673,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:22244-fix"
+path = "cases/arvo:22244-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13467"
 path = "cases/arvo:13467"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13467-fix"
+path = "cases/arvo:13467-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4361,10 +8701,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12818-fix"
+path = "cases/arvo:12818-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:14703"
 path = "cases/arvo:14703"
 expected_cwes = [119, 122, 190, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:14703-fix"
+path = "cases/arvo:14703-fix"
+expected_cwes = [119, 122, 190, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4375,10 +8729,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:13466-fix"
+path = "cases/arvo:13466-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45568"
 path = "cases/arvo:45568"
 expected_cwes = [400, 835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45568-fix"
+path = "cases/arvo:45568-fix"
+expected_cwes = [400, 835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4389,10 +8757,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14696-fix"
+path = "cases/arvo:14696-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21309"
 path = "cases/arvo:21309"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21309-fix"
+path = "cases/arvo:21309-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4403,10 +8785,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19100-fix"
+path = "cases/arvo:19100-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:17607"
 path = "cases/arvo:17607"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17607-fix"
+path = "cases/arvo:17607-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4417,10 +8813,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:22094-fix"
+path = "cases/arvo:22094-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20823"
 path = "cases/arvo:20823"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20823-fix"
+path = "cases/arvo:20823-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4431,10 +8841,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:32356-fix"
+path = "cases/arvo:32356-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:3522"
 path = "cases/arvo:3522"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3522-fix"
+path = "cases/arvo:3522-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4445,10 +8869,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43688-fix"
+path = "cases/arvo:43688-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23021"
 path = "cases/arvo:23021"
 expected_cwes = [193]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23021-fix"
+path = "cases/arvo:23021-fix"
+expected_cwes = [193]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4459,10 +8897,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21000-fix"
+path = "cases/arvo:21000-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20830"
 path = "cases/arvo:20830"
 expected_cwes = [193]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20830-fix"
+path = "cases/arvo:20830-fix"
+expected_cwes = [193]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4473,10 +8925,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:39689-fix"
+path = "cases/arvo:39689-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43268"
 path = "cases/arvo:43268"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43268-fix"
+path = "cases/arvo:43268-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4487,10 +8953,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42613-fix"
+path = "cases/arvo:42613-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47157"
 path = "cases/arvo:47157"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47157-fix"
+path = "cases/arvo:47157-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4501,10 +8981,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42268-fix"
+path = "cases/arvo:42268-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45320"
 path = "cases/arvo:45320"
 expected_cwes = [835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45320-fix"
+path = "cases/arvo:45320-fix"
+expected_cwes = [835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4515,10 +9009,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42329-fix"
+path = "cases/arvo:42329-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43156"
 path = "cases/arvo:43156"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43156-fix"
+path = "cases/arvo:43156-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4529,10 +9037,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43599-fix"
+path = "cases/arvo:43599-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42325"
 path = "cases/arvo:42325"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42325-fix"
+path = "cases/arvo:42325-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4543,10 +9065,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44983-fix"
+path = "cases/arvo:44983-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57426"
 path = "cases/arvo:57426"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57426-fix"
+path = "cases/arvo:57426-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4557,10 +9093,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42736-fix"
+path = "cases/arvo:42736-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42998"
 path = "cases/arvo:42998"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42998-fix"
+path = "cases/arvo:42998-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4571,10 +9121,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44034-fix"
+path = "cases/arvo:44034-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42687"
 path = "cases/arvo:42687"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42687-fix"
+path = "cases/arvo:42687-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4585,10 +9149,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42479-fix"
+path = "cases/arvo:42479-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:44258"
 path = "cases/arvo:44258"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:44258-fix"
+path = "cases/arvo:44258-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4599,10 +9177,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42298-fix"
+path = "cases/arvo:42298-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42907"
 path = "cases/arvo:42907"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42907-fix"
+path = "cases/arvo:42907-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4613,10 +9205,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42917-fix"
+path = "cases/arvo:42917-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42560"
 path = "cases/arvo:42560"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42560-fix"
+path = "cases/arvo:42560-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4627,10 +9233,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44160-fix"
+path = "cases/arvo:44160-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42616"
 path = "cases/arvo:42616"
 expected_cwes = [193]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42616-fix"
+path = "cases/arvo:42616-fix"
+expected_cwes = [193]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4641,10 +9261,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43004-fix"
+path = "cases/arvo:43004-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43621"
 path = "cases/arvo:43621"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43621-fix"
+path = "cases/arvo:43621-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4655,10 +9289,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:45992-fix"
+path = "cases/arvo:45992-fix"
+expected_cwes = [369]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42327"
 path = "cases/arvo:42327"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42327-fix"
+path = "cases/arvo:42327-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4669,10 +9317,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43354-fix"
+path = "cases/arvo:43354-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:44855"
 path = "cases/arvo:44855"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:44855-fix"
+path = "cases/arvo:44855-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4683,10 +9345,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1580-fix"
+path = "cases/arvo:1580-fix"
+expected_cwes = [758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42322"
 path = "cases/arvo:42322"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42322-fix"
+path = "cases/arvo:42322-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4697,10 +9373,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19332-fix"
+path = "cases/arvo:19332-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43012"
 path = "cases/arvo:43012"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43012-fix"
+path = "cases/arvo:43012-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4711,10 +9401,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42280-fix"
+path = "cases/arvo:42280-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42957"
 path = "cases/arvo:42957"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42957-fix"
+path = "cases/arvo:42957-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4725,10 +9429,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42633-fix"
+path = "cases/arvo:42633-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43680"
 path = "cases/arvo:43680"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43680-fix"
+path = "cases/arvo:43680-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4739,10 +9457,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43255-fix"
+path = "cases/arvo:43255-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64165"
 path = "cases/arvo:64165"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64165-fix"
+path = "cases/arvo:64165-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4753,10 +9485,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63777-fix"
+path = "cases/arvo:63777-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:14245"
 path = "cases/arvo:14245"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:14245-fix"
+path = "cases/arvo:14245-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4767,10 +9513,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:45603-fix"
+path = "cases/arvo:45603-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21435"
 path = "cases/arvo:21435"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21435-fix"
+path = "cases/arvo:21435-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4781,10 +9541,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61993-fix"
+path = "cases/arvo:61993-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:37896"
 path = "cases/arvo:37896"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:37896-fix"
+path = "cases/arvo:37896-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4795,10 +9569,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18877-fix"
+path = "cases/arvo:18877-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46307"
 path = "cases/arvo:46307"
 expected_cwes = [119, 835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:46307-fix"
+path = "cases/arvo:46307-fix"
+expected_cwes = [119, 835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4809,10 +9597,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:34584-fix"
+path = "cases/arvo:34584-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45222"
 path = "cases/arvo:45222"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45222-fix"
+path = "cases/arvo:45222-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4823,10 +9625,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23153-fix"
+path = "cases/arvo:23153-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45173"
 path = "cases/arvo:45173"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45173-fix"
+path = "cases/arvo:45173-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4837,10 +9653,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10574-fix"
+path = "cases/arvo:10574-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:45347"
 path = "cases/arvo:45347"
 expected_cwes = [119, 190, 400]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:45347-fix"
+path = "cases/arvo:45347-fix"
+expected_cwes = [119, 190, 400]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4851,10 +9681,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65135-fix"
+path = "cases/arvo:65135-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:44610"
 path = "cases/arvo:44610"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:44610-fix"
+path = "cases/arvo:44610-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4865,10 +9709,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11078-fix"
+path = "cases/arvo:11078-fix"
+expected_cwes = [617]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13704"
 path = "cases/arvo:13704"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13704-fix"
+path = "cases/arvo:13704-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4879,10 +9737,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:22978-fix"
+path = "cases/arvo:22978-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47601"
 path = "cases/arvo:47601"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47601-fix"
+path = "cases/arvo:47601-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4893,10 +9765,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11523-fix"
+path = "cases/arvo:11523-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:33854"
 path = "cases/arvo:33854"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:33854-fix"
+path = "cases/arvo:33854-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4907,10 +9793,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11429-fix"
+path = "cases/arvo:11429-fix"
+expected_cwes = [119, 193]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34863"
 path = "cases/arvo:34863"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34863-fix"
+path = "cases/arvo:34863-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4921,10 +9821,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23044-fix"
+path = "cases/arvo:23044-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:46734"
 path = "cases/arvo:46734"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:46734-fix"
+path = "cases/arvo:46734-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4935,10 +9849,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:34973-fix"
+path = "cases/arvo:34973-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10841"
 path = "cases/arvo:10841"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10841-fix"
+path = "cases/arvo:10841-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4949,10 +9877,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46499-fix"
+path = "cases/arvo:46499-fix"
+expected_cwes = [119, 122, 125, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10252"
 path = "cases/arvo:10252"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10252-fix"
+path = "cases/arvo:10252-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4963,10 +9905,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44406-fix"
+path = "cases/arvo:44406-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:22979"
 path = "cases/arvo:22979"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:22979-fix"
+path = "cases/arvo:22979-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4977,10 +9933,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59814-fix"
+path = "cases/arvo:59814-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:37925"
 path = "cases/arvo:37925"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:37925-fix"
+path = "cases/arvo:37925-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -4991,10 +9961,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:22295-fix"
+path = "cases/arvo:22295-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:36793"
 path = "cases/arvo:36793"
 expected_cwes = [119, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:36793-fix"
+path = "cases/arvo:36793-fix"
+expected_cwes = [119, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5005,10 +9989,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:33852-fix"
+path = "cases/arvo:33852-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19999"
 path = "cases/arvo:19999"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19999-fix"
+path = "cases/arvo:19999-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5019,10 +10017,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44151-fix"
+path = "cases/arvo:44151-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65879"
 path = "cases/arvo:65879"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65879-fix"
+path = "cases/arvo:65879-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5033,10 +10045,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47770-fix"
+path = "cases/arvo:47770-fix"
+expected_cwes = [119, 401, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43984"
 path = "cases/arvo:43984"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43984-fix"
+path = "cases/arvo:43984-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5047,10 +10073,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:60262-fix"
+path = "cases/arvo:60262-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:15003"
 path = "cases/arvo:15003"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:15003-fix"
+path = "cases/arvo:15003-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5061,10 +10101,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65933-fix"
+path = "cases/arvo:65933-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25473"
 path = "cases/arvo:25473"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25473-fix"
+path = "cases/arvo:25473-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5075,10 +10129,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14368-fix"
+path = "cases/arvo:14368-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:16541"
 path = "cases/arvo:16541"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:16541-fix"
+path = "cases/arvo:16541-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5089,10 +10157,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:16445-fix"
+path = "cases/arvo:16445-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27719"
 path = "cases/arvo:27719"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27719-fix"
+path = "cases/arvo:27719-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5103,10 +10185,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21434-fix"
+path = "cases/arvo:21434-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:9808"
 path = "cases/arvo:9808"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:9808-fix"
+path = "cases/arvo:9808-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5117,10 +10213,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28185-fix"
+path = "cases/arvo:28185-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25210"
 path = "cases/arvo:25210"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25210-fix"
+path = "cases/arvo:25210-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5131,10 +10241,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:31541-fix"
+path = "cases/arvo:31541-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:31332"
 path = "cases/arvo:31332"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:31332-fix"
+path = "cases/arvo:31332-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5145,10 +10269,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61718-fix"
+path = "cases/arvo:61718-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59072"
 path = "cases/arvo:59072"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59072-fix"
+path = "cases/arvo:59072-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5159,10 +10297,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:31276-fix"
+path = "cases/arvo:31276-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:62033"
 path = "cases/arvo:62033"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62033-fix"
+path = "cases/arvo:62033-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5173,10 +10325,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:66066-fix"
+path = "cases/arvo:66066-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30974"
 path = "cases/arvo:30974"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30974-fix"
+path = "cases/arvo:30974-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5187,10 +10353,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:31038-fix"
+path = "cases/arvo:31038-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:38587"
 path = "cases/arvo:38587"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38587-fix"
+path = "cases/arvo:38587-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5201,10 +10381,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18321-fix"
+path = "cases/arvo:18321-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23764"
 path = "cases/arvo:23764"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23764-fix"
+path = "cases/arvo:23764-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5215,10 +10409,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30868-fix"
+path = "cases/arvo:30868-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:44597"
 path = "cases/arvo:44597"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:44597-fix"
+path = "cases/arvo:44597-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5229,10 +10437,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58080-fix"
+path = "cases/arvo:58080-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:22140"
 path = "cases/arvo:22140"
 expected_cwes = [119, 476]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:22140-fix"
+path = "cases/arvo:22140-fix"
+expected_cwes = [119, 476]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5243,10 +10465,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:66279-fix"
+path = "cases/arvo:66279-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:16820"
 path = "cases/arvo:16820"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:16820-fix"
+path = "cases/arvo:16820-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5257,10 +10493,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24186-fix"
+path = "cases/arvo:24186-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23619"
 path = "cases/arvo:23619"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23619-fix"
+path = "cases/arvo:23619-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5271,10 +10521,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:48305-fix"
+path = "cases/arvo:48305-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55587"
 path = "cases/arvo:55587"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55587-fix"
+path = "cases/arvo:55587-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5285,10 +10549,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44953-fix"
+path = "cases/arvo:44953-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:22427"
 path = "cases/arvo:22427"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:22427-fix"
+path = "cases/arvo:22427-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5299,10 +10577,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30099-fix"
+path = "cases/arvo:30099-fix"
+expected_cwes = [415]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:33071"
 path = "cases/arvo:33071"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:33071-fix"
+path = "cases/arvo:33071-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5313,10 +10605,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24925-fix"
+path = "cases/arvo:24925-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30217"
 path = "cases/arvo:30217"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30217-fix"
+path = "cases/arvo:30217-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5327,10 +10633,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24633-fix"
+path = "cases/arvo:24633-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34461"
 path = "cases/arvo:34461"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34461-fix"
+path = "cases/arvo:34461-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5341,10 +10661,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58283-fix"
+path = "cases/arvo:58283-fix"
+expected_cwes = [401]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40544"
 path = "cases/arvo:40544"
 expected_cwes = [119, 190, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40544-fix"
+path = "cases/arvo:40544-fix"
+expected_cwes = [119, 190, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5355,10 +10689,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24097-fix"
+path = "cases/arvo:24097-fix"
+expected_cwes = [119, 400]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:33251"
 path = "cases/arvo:33251"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:33251-fix"
+path = "cases/arvo:33251-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5369,10 +10717,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23433-fix"
+path = "cases/arvo:23433-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25364"
 path = "cases/arvo:25364"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:25364-fix"
+path = "cases/arvo:25364-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5383,10 +10745,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29827-fix"
+path = "cases/arvo:29827-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26442"
 path = "cases/arvo:26442"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26442-fix"
+path = "cases/arvo:26442-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5397,10 +10773,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24055-fix"
+path = "cases/arvo:24055-fix"
+expected_cwes = [119, 416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25366"
 path = "cases/arvo:25366"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:25366-fix"
+path = "cases/arvo:25366-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5411,10 +10801,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23717-fix"
+path = "cases/arvo:23717-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:24591"
 path = "cases/arvo:24591"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:24591-fix"
+path = "cases/arvo:24591-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5425,10 +10829,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25014-fix"
+path = "cases/arvo:25014-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23765"
 path = "cases/arvo:23765"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23765-fix"
+path = "cases/arvo:23765-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5439,10 +10857,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:52160-fix"
+path = "cases/arvo:52160-fix"
+expected_cwes = [119, 121, 787, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26682"
 path = "cases/arvo:26682"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:26682-fix"
+path = "cases/arvo:26682-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5453,10 +10885,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:31120-fix"
+path = "cases/arvo:31120-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28843"
 path = "cases/arvo:28843"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28843-fix"
+path = "cases/arvo:28843-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5467,10 +10913,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46315-fix"
+path = "cases/arvo:46315-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27413"
 path = "cases/arvo:27413"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:27413-fix"
+path = "cases/arvo:27413-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5481,10 +10941,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:25530-fix"
+path = "cases/arvo:25530-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:66311"
 path = "cases/arvo:66311"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:66311-fix"
+path = "cases/arvo:66311-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5495,10 +10969,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:25561-fix"
+path = "cases/arvo:25561-fix"
+expected_cwes = [119, 190, 400]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:52229"
 path = "cases/arvo:52229"
 expected_cwes = [119, 121, 125, 758, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52229-fix"
+path = "cases/arvo:52229-fix"
+expected_cwes = [119, 121, 125, 758, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5509,10 +10997,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50834-fix"
+path = "cases/arvo:50834-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:24538"
 path = "cases/arvo:24538"
 expected_cwes = [400]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:24538-fix"
+path = "cases/arvo:24538-fix"
+expected_cwes = [400]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5523,10 +11025,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25292-fix"
+path = "cases/arvo:25292-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:42894"
 path = "cases/arvo:42894"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:42894-fix"
+path = "cases/arvo:42894-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5537,10 +11053,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:27871-fix"
+path = "cases/arvo:27871-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:60121"
 path = "cases/arvo:60121"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60121-fix"
+path = "cases/arvo:60121-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5551,10 +11081,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:26026-fix"
+path = "cases/arvo:26026-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:31705"
 path = "cases/arvo:31705"
 expected_cwes = [476]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:31705-fix"
+path = "cases/arvo:31705-fix"
+expected_cwes = [476]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5565,10 +11109,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23979-fix"
+path = "cases/arvo:23979-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21604"
 path = "cases/arvo:21604"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21604-fix"
+path = "cases/arvo:21604-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5579,10 +11137,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26022-fix"
+path = "cases/arvo:26022-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:24528"
 path = "cases/arvo:24528"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:24528-fix"
+path = "cases/arvo:24528-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5593,10 +11165,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25167-fix"
+path = "cases/arvo:25167-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25704"
 path = "cases/arvo:25704"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25704-fix"
+path = "cases/arvo:25704-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5607,10 +11193,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50267-fix"
+path = "cases/arvo:50267-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53619"
 path = "cases/arvo:53619"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53619-fix"
+path = "cases/arvo:53619-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5621,10 +11221,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28383-fix"
+path = "cases/arvo:28383-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52145"
 path = "cases/arvo:52145"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52145-fix"
+path = "cases/arvo:52145-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5635,10 +11249,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50656-fix"
+path = "cases/arvo:50656-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56156"
 path = "cases/arvo:56156"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56156-fix"
+path = "cases/arvo:56156-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5649,10 +11277,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50307-fix"
+path = "cases/arvo:50307-fix"
+expected_cwes = [401]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25388"
 path = "cases/arvo:25388"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25388-fix"
+path = "cases/arvo:25388-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5663,10 +11305,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51011-fix"
+path = "cases/arvo:51011-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26197"
 path = "cases/arvo:26197"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26197-fix"
+path = "cases/arvo:26197-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5677,10 +11333,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51089-fix"
+path = "cases/arvo:51089-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26712"
 path = "cases/arvo:26712"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:26712-fix"
+path = "cases/arvo:26712-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5691,10 +11361,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:53054-fix"
+path = "cases/arvo:53054-fix"
+expected_cwes = [119, 191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53740"
 path = "cases/arvo:53740"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53740-fix"
+path = "cases/arvo:53740-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5705,10 +11389,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:55430-fix"
+path = "cases/arvo:55430-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:62356"
 path = "cases/arvo:62356"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62356-fix"
+path = "cases/arvo:62356-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5719,10 +11417,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50326-fix"
+path = "cases/arvo:50326-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50306"
 path = "cases/arvo:50306"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50306-fix"
+path = "cases/arvo:50306-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5733,10 +11445,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25884-fix"
+path = "cases/arvo:25884-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51045"
 path = "cases/arvo:51045"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51045-fix"
+path = "cases/arvo:51045-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5747,10 +11473,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26371-fix"
+path = "cases/arvo:26371-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8241"
 path = "cases/arvo:8241"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8241-fix"
+path = "cases/arvo:8241-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5761,10 +11501,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:32202-fix"
+path = "cases/arvo:32202-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57209"
 path = "cases/arvo:57209"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57209-fix"
+path = "cases/arvo:57209-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5775,10 +11529,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51010-fix"
+path = "cases/arvo:51010-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25943"
 path = "cases/arvo:25943"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25943-fix"
+path = "cases/arvo:25943-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5789,10 +11557,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:39283-fix"
+path = "cases/arvo:39283-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23715"
 path = "cases/arvo:23715"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23715-fix"
+path = "cases/arvo:23715-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5803,10 +11585,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23653-fix"
+path = "cases/arvo:23653-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26803"
 path = "cases/arvo:26803"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:26803-fix"
+path = "cases/arvo:26803-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5817,10 +11613,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:54811-fix"
+path = "cases/arvo:54811-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28777"
 path = "cases/arvo:28777"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:28777-fix"
+path = "cases/arvo:28777-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5831,10 +11641,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19757-fix"
+path = "cases/arvo:19757-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26171"
 path = "cases/arvo:26171"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26171-fix"
+path = "cases/arvo:26171-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5845,10 +11669,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:28135-fix"
+path = "cases/arvo:28135-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:27812"
 path = "cases/arvo:27812"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27812-fix"
+path = "cases/arvo:27812-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5859,10 +11697,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43434-fix"
+path = "cases/arvo:43434-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:63024"
 path = "cases/arvo:63024"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:63024-fix"
+path = "cases/arvo:63024-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5873,10 +11725,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26103-fix"
+path = "cases/arvo:26103-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29769"
 path = "cases/arvo:29769"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29769-fix"
+path = "cases/arvo:29769-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5887,10 +11753,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:62943-fix"
+path = "cases/arvo:62943-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:27818"
 path = "cases/arvo:27818"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27818-fix"
+path = "cases/arvo:27818-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5901,10 +11781,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:31491-fix"
+path = "cases/arvo:31491-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26406"
 path = "cases/arvo:26406"
 expected_cwes = [457, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26406-fix"
+path = "cases/arvo:26406-fix"
+expected_cwes = [457, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5915,10 +11809,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:27816-fix"
+path = "cases/arvo:27816-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28392"
 path = "cases/arvo:28392"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28392-fix"
+path = "cases/arvo:28392-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5929,10 +11837,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26755-fix"
+path = "cases/arvo:26755-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52475"
 path = "cases/arvo:52475"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52475-fix"
+path = "cases/arvo:52475-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5943,10 +11865,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:27691-fix"
+path = "cases/arvo:27691-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:22528"
 path = "cases/arvo:22528"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:22528-fix"
+path = "cases/arvo:22528-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5957,10 +11893,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28810-fix"
+path = "cases/arvo:28810-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27934"
 path = "cases/arvo:27934"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27934-fix"
+path = "cases/arvo:27934-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5971,10 +11921,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:27503-fix"
+path = "cases/arvo:27503-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:56474"
 path = "cases/arvo:56474"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:56474-fix"
+path = "cases/arvo:56474-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -5985,10 +11949,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:31576-fix"
+path = "cases/arvo:31576-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:20652"
 path = "cases/arvo:20652"
 expected_cwes = [401]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20652-fix"
+path = "cases/arvo:20652-fix"
+expected_cwes = [401]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -5999,10 +11977,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:33059-fix"
+path = "cases/arvo:33059-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:62547"
 path = "cases/arvo:62547"
 expected_cwes = [416]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:62547-fix"
+path = "cases/arvo:62547-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6013,10 +12005,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:60506-fix"
+path = "cases/arvo:60506-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:46847"
 path = "cases/arvo:46847"
 expected_cwes = [119, 125, 416, 476, 590]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:46847-fix"
+path = "cases/arvo:46847-fix"
+expected_cwes = [119, 125, 416, 476, 590]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6027,10 +12033,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:31425-fix"
+path = "cases/arvo:31425-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:27856"
 path = "cases/arvo:27856"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27856-fix"
+path = "cases/arvo:27856-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6041,10 +12061,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:16969-fix"
+path = "cases/arvo:16969-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25910"
 path = "cases/arvo:25910"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25910-fix"
+path = "cases/arvo:25910-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6055,10 +12089,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:31454-fix"
+path = "cases/arvo:31454-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:32604"
 path = "cases/arvo:32604"
 expected_cwes = [843]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:32604-fix"
+path = "cases/arvo:32604-fix"
+expected_cwes = [843]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6069,10 +12117,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:40851-fix"
+path = "cases/arvo:40851-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56454"
 path = "cases/arvo:56454"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:56454-fix"
+path = "cases/arvo:56454-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6083,10 +12145,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29564-fix"
+path = "cases/arvo:29564-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59950"
 path = "cases/arvo:59950"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:59950-fix"
+path = "cases/arvo:59950-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6097,10 +12173,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1975-fix"
+path = "cases/arvo:1975-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1931"
 path = "cases/arvo:1931"
 expected_cwes = [190, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1931-fix"
+path = "cases/arvo:1931-fix"
+expected_cwes = [190, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6111,10 +12201,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30983-fix"
+path = "cases/arvo:30983-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56895"
 path = "cases/arvo:56895"
 expected_cwes = [125]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:56895-fix"
+path = "cases/arvo:56895-fix"
+expected_cwes = [125]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6125,10 +12229,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:57442-fix"
+path = "cases/arvo:57442-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:51618"
 path = "cases/arvo:51618"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51618-fix"
+path = "cases/arvo:51618-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6139,10 +12257,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29171-fix"
+path = "cases/arvo:29171-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51418"
 path = "cases/arvo:51418"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51418-fix"
+path = "cases/arvo:51418-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6153,10 +12285,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:57887-fix"
+path = "cases/arvo:57887-fix"
+expected_cwes = [190]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:57527"
 path = "cases/arvo:57527"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:57527-fix"
+path = "cases/arvo:57527-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6167,10 +12313,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29633-fix"
+path = "cases/arvo:29633-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57429"
 path = "cases/arvo:57429"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:57429-fix"
+path = "cases/arvo:57429-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6181,10 +12341,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46615-fix"
+path = "cases/arvo:46615-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59091"
 path = "cases/arvo:59091"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:59091-fix"
+path = "cases/arvo:59091-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6195,10 +12369,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46516-fix"
+path = "cases/arvo:46516-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47101"
 path = "cases/arvo:47101"
 expected_cwes = [119, 122, 190, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47101-fix"
+path = "cases/arvo:47101-fix"
+expected_cwes = [119, 122, 190, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6209,10 +12397,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:66646-fix"
+path = "cases/arvo:66646-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:32029"
 path = "cases/arvo:32029"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:32029-fix"
+path = "cases/arvo:32029-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6223,10 +12425,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:56450-fix"
+path = "cases/arvo:56450-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:59576"
 path = "cases/arvo:59576"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:59576-fix"
+path = "cases/arvo:59576-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6237,10 +12453,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:59602-fix"
+path = "cases/arvo:59602-fix"
+expected_cwes = [125]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:38872"
 path = "cases/arvo:38872"
 expected_cwes = [119, 125, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38872-fix"
+path = "cases/arvo:38872-fix"
+expected_cwes = [119, 125, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6251,10 +12481,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:59699-fix"
+path = "cases/arvo:59699-fix"
+expected_cwes = [119, 758]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:59775"
 path = "cases/arvo:59775"
 expected_cwes = [125]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:59775-fix"
+path = "cases/arvo:59775-fix"
+expected_cwes = [125]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6265,10 +12509,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46543-fix"
+path = "cases/arvo:46543-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60090"
 path = "cases/arvo:60090"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:60090-fix"
+path = "cases/arvo:60090-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6279,10 +12537,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:60983-fix"
+path = "cases/arvo:60983-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50099"
 path = "cases/arvo:50099"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50099-fix"
+path = "cases/arvo:50099-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6293,10 +12565,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30113-fix"
+path = "cases/arvo:30113-fix"
+expected_cwes = [125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49290"
 path = "cases/arvo:49290"
 expected_cwes = [119, 476]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49290-fix"
+path = "cases/arvo:49290-fix"
+expected_cwes = [119, 476]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6307,10 +12593,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29976-fix"
+path = "cases/arvo:29976-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30090"
 path = "cases/arvo:30090"
 expected_cwes = [843]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30090-fix"
+path = "cases/arvo:30090-fix"
+expected_cwes = [843]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6321,10 +12621,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:33750-fix"
+path = "cases/arvo:33750-fix"
+expected_cwes = [119, 415]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58262"
 path = "cases/arvo:58262"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:58262-fix"
+path = "cases/arvo:58262-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6335,10 +12649,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:53210-fix"
+path = "cases/arvo:53210-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31878"
 path = "cases/arvo:31878"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:31878-fix"
+path = "cases/arvo:31878-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6349,10 +12677,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:31789-fix"
+path = "cases/arvo:31789-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:35165"
 path = "cases/arvo:35165"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:35165-fix"
+path = "cases/arvo:35165-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6363,10 +12705,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29125-fix"
+path = "cases/arvo:29125-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30748"
 path = "cases/arvo:30748"
 expected_cwes = [190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30748-fix"
+path = "cases/arvo:30748-fix"
+expected_cwes = [190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6377,10 +12733,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:52634-fix"
+path = "cases/arvo:52634-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34655"
 path = "cases/arvo:34655"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34655-fix"
+path = "cases/arvo:34655-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6391,10 +12761,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:33844-fix"
+path = "cases/arvo:33844-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30051"
 path = "cases/arvo:30051"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:30051-fix"
+path = "cases/arvo:30051-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6405,10 +12789,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19498-fix"
+path = "cases/arvo:19498-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21165"
 path = "cases/arvo:21165"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21165-fix"
+path = "cases/arvo:21165-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6419,10 +12817,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63790-fix"
+path = "cases/arvo:63790-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31042"
 path = "cases/arvo:31042"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:31042-fix"
+path = "cases/arvo:31042-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6433,10 +12845,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14467-fix"
+path = "cases/arvo:14467-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57354"
 path = "cases/arvo:57354"
 expected_cwes = [119, 416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57354-fix"
+path = "cases/arvo:57354-fix"
+expected_cwes = [119, 416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6447,10 +12873,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21011-fix"
+path = "cases/arvo:21011-fix"
+expected_cwes = [415]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50847"
 path = "cases/arvo:50847"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50847-fix"
+path = "cases/arvo:50847-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6461,10 +12901,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21342-fix"
+path = "cases/arvo:21342-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30271"
 path = "cases/arvo:30271"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:30271-fix"
+path = "cases/arvo:30271-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6475,10 +12929,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58481-fix"
+path = "cases/arvo:58481-fix"
+expected_cwes = [119, 190, 191, 787, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49528"
 path = "cases/arvo:49528"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49528-fix"
+path = "cases/arvo:49528-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6489,10 +12957,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14565-fix"
+path = "cases/arvo:14565-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30236"
 path = "cases/arvo:30236"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:30236-fix"
+path = "cases/arvo:30236-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6503,10 +12985,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20050-fix"
+path = "cases/arvo:20050-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61292"
 path = "cases/arvo:61292"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61292-fix"
+path = "cases/arvo:61292-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6517,10 +13013,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57320-fix"
+path = "cases/arvo:57320-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23296"
 path = "cases/arvo:23296"
 expected_cwes = [119, 190, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23296-fix"
+path = "cases/arvo:23296-fix"
+expected_cwes = [119, 190, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6531,10 +13041,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:49606-fix"
+path = "cases/arvo:49606-fix"
+expected_cwes = [190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51275"
 path = "cases/arvo:51275"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51275-fix"
+path = "cases/arvo:51275-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6545,10 +13069,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23743-fix"
+path = "cases/arvo:23743-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:24020"
 path = "cases/arvo:24020"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:24020-fix"
+path = "cases/arvo:24020-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6559,10 +13097,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30831-fix"
+path = "cases/arvo:30831-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28556"
 path = "cases/arvo:28556"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28556-fix"
+path = "cases/arvo:28556-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6573,10 +13125,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18449-fix"
+path = "cases/arvo:18449-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:39802"
 path = "cases/arvo:39802"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:39802-fix"
+path = "cases/arvo:39802-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6587,10 +13153,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21960-fix"
+path = "cases/arvo:21960-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21339"
 path = "cases/arvo:21339"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21339-fix"
+path = "cases/arvo:21339-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6601,10 +13181,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:39800-fix"
+path = "cases/arvo:39800-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:44887"
 path = "cases/arvo:44887"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:44887-fix"
+path = "cases/arvo:44887-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6615,10 +13209,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:31250-fix"
+path = "cases/arvo:31250-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:18315"
 path = "cases/arvo:18315"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18315-fix"
+path = "cases/arvo:18315-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6629,10 +13237,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23499-fix"
+path = "cases/arvo:23499-fix"
+expected_cwes = [401, 476]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28315"
 path = "cases/arvo:28315"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28315-fix"
+path = "cases/arvo:28315-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6643,10 +13265,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21359-fix"
+path = "cases/arvo:21359-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:41073"
 path = "cases/arvo:41073"
 expected_cwes = [119, 758]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:41073-fix"
+path = "cases/arvo:41073-fix"
+expected_cwes = [119, 758]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6657,10 +13293,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18224-fix"
+path = "cases/arvo:18224-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18225"
 path = "cases/arvo:18225"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18225-fix"
+path = "cases/arvo:18225-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6671,10 +13321,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21324-fix"
+path = "cases/arvo:21324-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21325"
 path = "cases/arvo:21325"
 expected_cwes = [119, 457, 758, 835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21325-fix"
+path = "cases/arvo:21325-fix"
+expected_cwes = [119, 457, 758, 835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6685,10 +13349,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18615-fix"
+path = "cases/arvo:18615-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21327"
 path = "cases/arvo:21327"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21327-fix"
+path = "cases/arvo:21327-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6699,10 +13377,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:27936-fix"
+path = "cases/arvo:27936-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:21300"
 path = "cases/arvo:21300"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21300-fix"
+path = "cases/arvo:21300-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6713,10 +13405,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:28064-fix"
+path = "cases/arvo:28064-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:39897"
 path = "cases/arvo:39897"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:39897-fix"
+path = "cases/arvo:39897-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -6727,10 +13433,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21316-fix"
+path = "cases/arvo:21316-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21321"
 path = "cases/arvo:21321"
 expected_cwes = [119, 476, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21321-fix"
+path = "cases/arvo:21321-fix"
+expected_cwes = [119, 476, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6741,10 +13461,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21414-fix"
+path = "cases/arvo:21414-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21299"
 path = "cases/arvo:21299"
 expected_cwes = [119, 457, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21299-fix"
+path = "cases/arvo:21299-fix"
+expected_cwes = [119, 457, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6755,10 +13489,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:21514-fix"
+path = "cases/arvo:21514-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18228"
 path = "cases/arvo:18228"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18228-fix"
+path = "cases/arvo:18228-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6769,10 +13517,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42639-fix"
+path = "cases/arvo:42639-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29243"
 path = "cases/arvo:29243"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29243-fix"
+path = "cases/arvo:29243-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6783,10 +13545,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:52102-fix"
+path = "cases/arvo:52102-fix"
+expected_cwes = [415]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19910"
 path = "cases/arvo:19910"
 expected_cwes = [119, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19910-fix"
+path = "cases/arvo:19910-fix"
+expected_cwes = [119, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6797,10 +13573,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26325-fix"
+path = "cases/arvo:26325-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20840"
 path = "cases/arvo:20840"
 expected_cwes = [119, 400, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20840-fix"
+path = "cases/arvo:20840-fix"
+expected_cwes = [119, 400, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6811,10 +13601,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:52175-fix"
+path = "cases/arvo:52175-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19822"
 path = "cases/arvo:19822"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19822-fix"
+path = "cases/arvo:19822-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6825,10 +13629,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63679-fix"
+path = "cases/arvo:63679-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19573"
 path = "cases/arvo:19573"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19573-fix"
+path = "cases/arvo:19573-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6839,10 +13657,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:20848-fix"
+path = "cases/arvo:20848-fix"
+expected_cwes = [401, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43795"
 path = "cases/arvo:43795"
 expected_cwes = [119, 125, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43795-fix"
+path = "cases/arvo:43795-fix"
+expected_cwes = [119, 125, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6853,10 +13685,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63867-fix"
+path = "cases/arvo:63867-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52305"
 path = "cases/arvo:52305"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52305-fix"
+path = "cases/arvo:52305-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6867,10 +13713,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26345-fix"
+path = "cases/arvo:26345-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:63357"
 path = "cases/arvo:63357"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:63357-fix"
+path = "cases/arvo:63357-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6881,10 +13741,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19702-fix"
+path = "cases/arvo:19702-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18687"
 path = "cases/arvo:18687"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18687-fix"
+path = "cases/arvo:18687-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6895,10 +13769,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44659-fix"
+path = "cases/arvo:44659-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27710"
 path = "cases/arvo:27710"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27710-fix"
+path = "cases/arvo:27710-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6909,10 +13797,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35876-fix"
+path = "cases/arvo:35876-fix"
+expected_cwes = [369, 416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26327"
 path = "cases/arvo:26327"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26327-fix"
+path = "cases/arvo:26327-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6923,10 +13825,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47975-fix"
+path = "cases/arvo:47975-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20147"
 path = "cases/arvo:20147"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20147-fix"
+path = "cases/arvo:20147-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6937,10 +13853,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19414-fix"
+path = "cases/arvo:19414-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52243"
 path = "cases/arvo:52243"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52243-fix"
+path = "cases/arvo:52243-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6951,10 +13881,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57788-fix"
+path = "cases/arvo:57788-fix"
+expected_cwes = [401]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40683"
 path = "cases/arvo:40683"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40683-fix"
+path = "cases/arvo:40683-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6965,10 +13909,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57880-fix"
+path = "cases/arvo:57880-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52066"
 path = "cases/arvo:52066"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52066-fix"
+path = "cases/arvo:52066-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6979,10 +13937,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:56726-fix"
+path = "cases/arvo:56726-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52228"
 path = "cases/arvo:52228"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52228-fix"
+path = "cases/arvo:52228-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -6993,10 +13965,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38815-fix"
+path = "cases/arvo:38815-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27241"
 path = "cases/arvo:27241"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27241-fix"
+path = "cases/arvo:27241-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7007,10 +13993,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38347-fix"
+path = "cases/arvo:38347-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25013"
 path = "cases/arvo:25013"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25013-fix"
+path = "cases/arvo:25013-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7021,10 +14021,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28265-fix"
+path = "cases/arvo:28265-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27025"
 path = "cases/arvo:27025"
 expected_cwes = [415]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27025-fix"
+path = "cases/arvo:27025-fix"
+expected_cwes = [415]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7035,10 +14049,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26593-fix"
+path = "cases/arvo:26593-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27279"
 path = "cases/arvo:27279"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27279-fix"
+path = "cases/arvo:27279-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7049,10 +14077,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:53199-fix"
+path = "cases/arvo:53199-fix"
+expected_cwes = [119, 125, 193]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:52204"
 path = "cases/arvo:52204"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:52204-fix"
+path = "cases/arvo:52204-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -7063,10 +14105,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:53080-fix"
+path = "cases/arvo:53080-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:54436"
 path = "cases/arvo:54436"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:54436-fix"
+path = "cases/arvo:54436-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7077,10 +14133,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:29377-fix"
+path = "cases/arvo:29377-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:58405"
 path = "cases/arvo:58405"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:58405-fix"
+path = "cases/arvo:58405-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7091,10 +14161,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:55898-fix"
+path = "cases/arvo:55898-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:34013"
 path = "cases/arvo:34013"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:34013-fix"
+path = "cases/arvo:34013-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7105,10 +14189,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:52326-fix"
+path = "cases/arvo:52326-fix"
+expected_cwes = [119, 125, 193]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:54511"
 path = "cases/arvo:54511"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:54511-fix"
+path = "cases/arvo:54511-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7119,10 +14217,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:29408-fix"
+path = "cases/arvo:29408-fix"
+expected_cwes = [415]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:52410"
 path = "cases/arvo:52410"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52410-fix"
+path = "cases/arvo:52410-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7133,10 +14245,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:41235-fix"
+path = "cases/arvo:41235-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25341"
 path = "cases/arvo:25341"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25341-fix"
+path = "cases/arvo:25341-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7147,10 +14273,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28181-fix"
+path = "cases/arvo:28181-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:38947"
 path = "cases/arvo:38947"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:38947-fix"
+path = "cases/arvo:38947-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7161,10 +14301,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23350-fix"
+path = "cases/arvo:23350-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25377"
 path = "cases/arvo:25377"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:25377-fix"
+path = "cases/arvo:25377-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -7175,10 +14329,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25401-fix"
+path = "cases/arvo:25401-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31301"
 path = "cases/arvo:31301"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:31301-fix"
+path = "cases/arvo:31301-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7189,10 +14357,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25240-fix"
+path = "cases/arvo:25240-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55556"
 path = "cases/arvo:55556"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55556-fix"
+path = "cases/arvo:55556-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7203,10 +14385,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58295-fix"
+path = "cases/arvo:58295-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47525"
 path = "cases/arvo:47525"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47525-fix"
+path = "cases/arvo:47525-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7217,10 +14413,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61721-fix"
+path = "cases/arvo:61721-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:21936"
 path = "cases/arvo:21936"
 expected_cwes = [119, 400]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:21936-fix"
+path = "cases/arvo:21936-fix"
+expected_cwes = [119, 400]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7231,10 +14441,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24993-fix"
+path = "cases/arvo:24993-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:47085"
 path = "cases/arvo:47085"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:47085-fix"
+path = "cases/arvo:47085-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7245,10 +14469,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24465-fix"
+path = "cases/arvo:24465-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3305"
 path = "cases/arvo:3305"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3305-fix"
+path = "cases/arvo:3305-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7259,10 +14497,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24157-fix"
+path = "cases/arvo:24157-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26400"
 path = "cases/arvo:26400"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26400-fix"
+path = "cases/arvo:26400-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7273,10 +14525,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1304-fix"
+path = "cases/arvo:1304-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26264"
 path = "cases/arvo:26264"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26264-fix"
+path = "cases/arvo:26264-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7287,10 +14553,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:22430-fix"
+path = "cases/arvo:22430-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25221"
 path = "cases/arvo:25221"
 expected_cwes = [125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25221-fix"
+path = "cases/arvo:25221-fix"
+expected_cwes = [125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7301,10 +14581,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30921-fix"
+path = "cases/arvo:30921-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5797"
 path = "cases/arvo:5797"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5797-fix"
+path = "cases/arvo:5797-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7315,10 +14609,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61011-fix"
+path = "cases/arvo:61011-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30507"
 path = "cases/arvo:30507"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30507-fix"
+path = "cases/arvo:30507-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7329,10 +14637,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42179-fix"
+path = "cases/arvo:42179-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30886"
 path = "cases/arvo:30886"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30886-fix"
+path = "cases/arvo:30886-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7343,10 +14665,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:17715-fix"
+path = "cases/arvo:17715-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40512"
 path = "cases/arvo:40512"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40512-fix"
+path = "cases/arvo:40512-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7357,10 +14693,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:50893-fix"
+path = "cases/arvo:50893-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7951"
 path = "cases/arvo:7951"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7951-fix"
+path = "cases/arvo:7951-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7371,10 +14721,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:53456-fix"
+path = "cases/arvo:53456-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57643"
 path = "cases/arvo:57643"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57643-fix"
+path = "cases/arvo:57643-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7385,10 +14749,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:40160-fix"
+path = "cases/arvo:40160-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31698"
 path = "cases/arvo:31698"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:31698-fix"
+path = "cases/arvo:31698-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7399,10 +14777,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:40465-fix"
+path = "cases/arvo:40465-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23725"
 path = "cases/arvo:23725"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23725-fix"
+path = "cases/arvo:23725-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7413,10 +14805,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28587-fix"
+path = "cases/arvo:28587-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27651"
 path = "cases/arvo:27651"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27651-fix"
+path = "cases/arvo:27651-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7427,10 +14833,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:37151-fix"
+path = "cases/arvo:37151-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50305"
 path = "cases/arvo:50305"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50305-fix"
+path = "cases/arvo:50305-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7441,10 +14861,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28151-fix"
+path = "cases/arvo:28151-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28109"
 path = "cases/arvo:28109"
 expected_cwes = [843]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28109-fix"
+path = "cases/arvo:28109-fix"
+expected_cwes = [843]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7455,10 +14889,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28239-fix"
+path = "cases/arvo:28239-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25815"
 path = "cases/arvo:25815"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25815-fix"
+path = "cases/arvo:25815-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7469,10 +14917,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51988-fix"
+path = "cases/arvo:51988-fix"
+expected_cwes = [125]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51102"
 path = "cases/arvo:51102"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51102-fix"
+path = "cases/arvo:51102-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7483,10 +14945,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58553-fix"
+path = "cases/arvo:58553-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58006"
 path = "cases/arvo:58006"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:58006-fix"
+path = "cases/arvo:58006-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7497,10 +14973,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51124-fix"
+path = "cases/arvo:51124-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43545"
 path = "cases/arvo:43545"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43545-fix"
+path = "cases/arvo:43545-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7511,10 +15001,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51008-fix"
+path = "cases/arvo:51008-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29267"
 path = "cases/arvo:29267"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29267-fix"
+path = "cases/arvo:29267-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7525,10 +15029,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29170-fix"
+path = "cases/arvo:29170-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5494"
 path = "cases/arvo:5494"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5494-fix"
+path = "cases/arvo:5494-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7539,10 +15057,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61778-fix"
+path = "cases/arvo:61778-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5492"
 path = "cases/arvo:5492"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5492-fix"
+path = "cases/arvo:5492-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7553,10 +15085,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5641-fix"
+path = "cases/arvo:5641-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:17094"
 path = "cases/arvo:17094"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17094-fix"
+path = "cases/arvo:17094-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7567,10 +15113,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6247-fix"
+path = "cases/arvo:6247-fix"
+expected_cwes = [119, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5856"
 path = "cases/arvo:5856"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5856-fix"
+path = "cases/arvo:5856-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7581,10 +15141,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6522-fix"
+path = "cases/arvo:6522-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5912"
 path = "cases/arvo:5912"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5912-fix"
+path = "cases/arvo:5912-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7595,10 +15169,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29266-fix"
+path = "cases/arvo:29266-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29338"
 path = "cases/arvo:29338"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29338-fix"
+path = "cases/arvo:29338-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7609,10 +15197,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5496-fix"
+path = "cases/arvo:5496-fix"
+expected_cwes = [119, 457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5665"
 path = "cases/arvo:5665"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5665-fix"
+path = "cases/arvo:5665-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7623,10 +15225,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5865-fix"
+path = "cases/arvo:5865-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13940"
 path = "cases/arvo:13940"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13940-fix"
+path = "cases/arvo:13940-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7637,10 +15253,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63831-fix"
+path = "cases/arvo:63831-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:43365"
 path = "cases/arvo:43365"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:43365-fix"
+path = "cases/arvo:43365-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7651,10 +15281,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28766-fix"
+path = "cases/arvo:28766-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64453"
 path = "cases/arvo:64453"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64453-fix"
+path = "cases/arvo:64453-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7665,10 +15309,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:51224-fix"
+path = "cases/arvo:51224-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:62612"
 path = "cases/arvo:62612"
 expected_cwes = [119, 590]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62612-fix"
+path = "cases/arvo:62612-fix"
+expected_cwes = [119, 590]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7679,10 +15337,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:7367-fix"
+path = "cases/arvo:7367-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:9325"
 path = "cases/arvo:9325"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:9325-fix"
+path = "cases/arvo:9325-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7693,10 +15365,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59207-fix"
+path = "cases/arvo:59207-fix"
+expected_cwes = [416, 835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59418"
 path = "cases/arvo:59418"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59418-fix"
+path = "cases/arvo:59418-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7707,10 +15393,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:9970-fix"
+path = "cases/arvo:9970-fix"
+expected_cwes = [191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23654"
 path = "cases/arvo:23654"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23654-fix"
+path = "cases/arvo:23654-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7721,10 +15421,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:51208-fix"
+path = "cases/arvo:51208-fix"
+expected_cwes = [119, 125]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:59500"
 path = "cases/arvo:59500"
 expected_cwes = [191]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59500-fix"
+path = "cases/arvo:59500-fix"
+expected_cwes = [191]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7735,10 +15449,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:51356-fix"
+path = "cases/arvo:51356-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:55020"
 path = "cases/arvo:55020"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55020-fix"
+path = "cases/arvo:55020-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7749,10 +15477,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63196-fix"
+path = "cases/arvo:63196-fix"
+expected_cwes = [119, 590]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53711"
 path = "cases/arvo:53711"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53711-fix"
+path = "cases/arvo:53711-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7763,10 +15505,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:55933-fix"
+path = "cases/arvo:55933-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:57879"
 path = "cases/arvo:57879"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:57879-fix"
+path = "cases/arvo:57879-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7777,10 +15533,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62478-fix"
+path = "cases/arvo:62478-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59148"
 path = "cases/arvo:59148"
 expected_cwes = [119, 191]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59148-fix"
+path = "cases/arvo:59148-fix"
+expected_cwes = [119, 191]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7791,10 +15561,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59488-fix"
+path = "cases/arvo:59488-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55868"
 path = "cases/arvo:55868"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55868-fix"
+path = "cases/arvo:55868-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7805,10 +15589,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:13771-fix"
+path = "cases/arvo:13771-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56277"
 path = "cases/arvo:56277"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56277-fix"
+path = "cases/arvo:56277-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7819,10 +15617,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:58086-fix"
+path = "cases/arvo:58086-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:49801"
 path = "cases/arvo:49801"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:49801-fix"
+path = "cases/arvo:49801-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7833,10 +15645,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:36485-fix"
+path = "cases/arvo:36485-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59591"
 path = "cases/arvo:59591"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59591-fix"
+path = "cases/arvo:59591-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7847,10 +15673,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:54667-fix"
+path = "cases/arvo:54667-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:52986"
 path = "cases/arvo:52986"
 expected_cwes = [401]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:52986-fix"
+path = "cases/arvo:52986-fix"
+expected_cwes = [401]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7861,10 +15701,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57570-fix"
+path = "cases/arvo:57570-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:18979"
 path = "cases/arvo:18979"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:18979-fix"
+path = "cases/arvo:18979-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7875,10 +15729,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35172-fix"
+path = "cases/arvo:35172-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53052"
 path = "cases/arvo:53052"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53052-fix"
+path = "cases/arvo:53052-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7889,10 +15757,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61677-fix"
+path = "cases/arvo:61677-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40618"
 path = "cases/arvo:40618"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40618-fix"
+path = "cases/arvo:40618-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7903,10 +15785,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35458-fix"
+path = "cases/arvo:35458-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:59390"
 path = "cases/arvo:59390"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:59390-fix"
+path = "cases/arvo:59390-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7917,10 +15813,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63356-fix"
+path = "cases/arvo:63356-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13249"
 path = "cases/arvo:13249"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13249-fix"
+path = "cases/arvo:13249-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7931,10 +15841,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35293-fix"
+path = "cases/arvo:35293-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:40620"
 path = "cases/arvo:40620"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:40620-fix"
+path = "cases/arvo:40620-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7945,10 +15869,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1621-fix"
+path = "cases/arvo:1621-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28216"
 path = "cases/arvo:28216"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28216-fix"
+path = "cases/arvo:28216-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7959,10 +15897,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:36497-fix"
+path = "cases/arvo:36497-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:44239"
 path = "cases/arvo:44239"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:44239-fix"
+path = "cases/arvo:44239-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7973,10 +15925,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:36158-fix"
+path = "cases/arvo:36158-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:35019"
 path = "cases/arvo:35019"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:35019-fix"
+path = "cases/arvo:35019-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -7987,10 +15953,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:56469-fix"
+path = "cases/arvo:56469-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61237"
 path = "cases/arvo:61237"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61237-fix"
+path = "cases/arvo:61237-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8001,10 +15981,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23074-fix"
+path = "cases/arvo:23074-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:35305"
 path = "cases/arvo:35305"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:35305-fix"
+path = "cases/arvo:35305-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8015,10 +16009,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:22670-fix"
+path = "cases/arvo:22670-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5429"
 path = "cases/arvo:5429"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5429-fix"
+path = "cases/arvo:5429-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8029,10 +16037,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23140-fix"
+path = "cases/arvo:23140-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:36611"
 path = "cases/arvo:36611"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:36611-fix"
+path = "cases/arvo:36611-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8043,10 +16065,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:41143-fix"
+path = "cases/arvo:41143-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:41221"
 path = "cases/arvo:41221"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:41221-fix"
+path = "cases/arvo:41221-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8057,10 +16093,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:46541-fix"
+path = "cases/arvo:46541-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23877"
 path = "cases/arvo:23877"
 expected_cwes = [119, 121, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23877-fix"
+path = "cases/arvo:23877-fix"
+expected_cwes = [119, 121, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8071,10 +16121,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:59243-fix"
+path = "cases/arvo:59243-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:23991"
 path = "cases/arvo:23991"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23991-fix"
+path = "cases/arvo:23991-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8085,10 +16149,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6336-fix"
+path = "cases/arvo:6336-fix"
+expected_cwes = [191]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:33576"
 path = "cases/arvo:33576"
 expected_cwes = [835]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:33576-fix"
+path = "cases/arvo:33576-fix"
+expected_cwes = [835]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8099,10 +16177,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:30181-fix"
+path = "cases/arvo:30181-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:54330"
 path = "cases/arvo:54330"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:54330-fix"
+path = "cases/arvo:54330-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8113,10 +16205,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:7350-fix"
+path = "cases/arvo:7350-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23778"
 path = "cases/arvo:23778"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23778-fix"
+path = "cases/arvo:23778-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8127,10 +16233,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24638-fix"
+path = "cases/arvo:24638-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25841"
 path = "cases/arvo:25841"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25841-fix"
+path = "cases/arvo:25841-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8141,10 +16261,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8046-fix"
+path = "cases/arvo:8046-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20176"
 path = "cases/arvo:20176"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20176-fix"
+path = "cases/arvo:20176-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8155,10 +16289,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23547-fix"
+path = "cases/arvo:23547-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31961"
 path = "cases/arvo:31961"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:31961-fix"
+path = "cases/arvo:31961-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8169,10 +16317,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5740-fix"
+path = "cases/arvo:5740-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25121"
 path = "cases/arvo:25121"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25121-fix"
+path = "cases/arvo:25121-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8183,10 +16345,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25526-fix"
+path = "cases/arvo:25526-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25384"
 path = "cases/arvo:25384"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25384-fix"
+path = "cases/arvo:25384-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8197,10 +16373,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42464-fix"
+path = "cases/arvo:42464-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28129"
 path = "cases/arvo:28129"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28129-fix"
+path = "cases/arvo:28129-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8211,10 +16401,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:25257-fix"
+path = "cases/arvo:25257-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51083"
 path = "cases/arvo:51083"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51083-fix"
+path = "cases/arvo:51083-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8225,10 +16429,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28666-fix"
+path = "cases/arvo:28666-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:50663"
 path = "cases/arvo:50663"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:50663-fix"
+path = "cases/arvo:50663-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8239,10 +16457,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26635-fix"
+path = "cases/arvo:26635-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:41337"
 path = "cases/arvo:41337"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:41337-fix"
+path = "cases/arvo:41337-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8253,10 +16485,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:63742-fix"
+path = "cases/arvo:63742-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30999"
 path = "cases/arvo:30999"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30999-fix"
+path = "cases/arvo:30999-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8267,10 +16513,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44864-fix"
+path = "cases/arvo:44864-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60532"
 path = "cases/arvo:60532"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60532-fix"
+path = "cases/arvo:60532-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8281,10 +16541,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:57025-fix"
+path = "cases/arvo:57025-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61822"
 path = "cases/arvo:61822"
 expected_cwes = [119, 401]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61822-fix"
+path = "cases/arvo:61822-fix"
+expected_cwes = [119, 401]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8295,10 +16569,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:65428-fix"
+path = "cases/arvo:65428-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5992"
 path = "cases/arvo:5992"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5992-fix"
+path = "cases/arvo:5992-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8309,10 +16597,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:43372-fix"
+path = "cases/arvo:43372-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29271"
 path = "cases/arvo:29271"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29271-fix"
+path = "cases/arvo:29271-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8323,10 +16625,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29538-fix"
+path = "cases/arvo:29538-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25332"
 path = "cases/arvo:25332"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25332-fix"
+path = "cases/arvo:25332-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8337,10 +16653,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:51799-fix"
+path = "cases/arvo:51799-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:55985"
 path = "cases/arvo:55985"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55985-fix"
+path = "cases/arvo:55985-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8351,10 +16681,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62986-fix"
+path = "cases/arvo:62986-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56917"
 path = "cases/arvo:56917"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56917-fix"
+path = "cases/arvo:56917-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8365,10 +16709,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61737-fix"
+path = "cases/arvo:61737-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51845"
 path = "cases/arvo:51845"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51845-fix"
+path = "cases/arvo:51845-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8379,10 +16737,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61836-fix"
+path = "cases/arvo:61836-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:61538"
 path = "cases/arvo:61538"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:61538-fix"
+path = "cases/arvo:61538-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8393,10 +16765,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26829-fix"
+path = "cases/arvo:26829-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:60037"
 path = "cases/arvo:60037"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:60037-fix"
+path = "cases/arvo:60037-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8407,10 +16793,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:24101-fix"
+path = "cases/arvo:24101-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1237"
 path = "cases/arvo:1237"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1237-fix"
+path = "cases/arvo:1237-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8421,10 +16821,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:7166-fix"
+path = "cases/arvo:7166-fix"
+expected_cwes = [119, 190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:15221"
 path = "cases/arvo:15221"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:15221-fix"
+path = "cases/arvo:15221-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8435,10 +16849,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6418-fix"
+path = "cases/arvo:6418-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1268"
 path = "cases/arvo:1268"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1268-fix"
+path = "cases/arvo:1268-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8449,10 +16877,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:42538-fix"
+path = "cases/arvo:42538-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1236"
 path = "cases/arvo:1236"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1236-fix"
+path = "cases/arvo:1236-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8463,10 +16905,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26163-fix"
+path = "cases/arvo:26163-fix"
+expected_cwes = [119, 125, 193]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26567"
 path = "cases/arvo:26567"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26567-fix"
+path = "cases/arvo:26567-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8477,10 +16933,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1571-fix"
+path = "cases/arvo:1571-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1436"
 path = "cases/arvo:1436"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1436-fix"
+path = "cases/arvo:1436-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8491,10 +16961,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62752-fix"
+path = "cases/arvo:62752-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28750"
 path = "cases/arvo:28750"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28750-fix"
+path = "cases/arvo:28750-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8505,10 +16989,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:31179-fix"
+path = "cases/arvo:31179-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27020"
 path = "cases/arvo:27020"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27020-fix"
+path = "cases/arvo:27020-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8519,10 +17017,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44008-fix"
+path = "cases/arvo:44008-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3535"
 path = "cases/arvo:3535"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3535-fix"
+path = "cases/arvo:3535-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8533,10 +17045,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:3408-fix"
+path = "cases/arvo:3408-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:27853"
 path = "cases/arvo:27853"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:27853-fix"
+path = "cases/arvo:27853-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8547,10 +17073,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6423-fix"
+path = "cases/arvo:6423-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8011"
 path = "cases/arvo:8011"
 expected_cwes = [119, 190]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8011-fix"
+path = "cases/arvo:8011-fix"
+expected_cwes = [119, 190]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8561,10 +17101,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6008-fix"
+path = "cases/arvo:6008-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5729"
 path = "cases/arvo:5729"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5729-fix"
+path = "cases/arvo:5729-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8575,10 +17129,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:2828-fix"
+path = "cases/arvo:2828-fix"
+expected_cwes = [190]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29103"
 path = "cases/arvo:29103"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29103-fix"
+path = "cases/arvo:29103-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8589,10 +17157,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30339-fix"
+path = "cases/arvo:30339-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:16737"
 path = "cases/arvo:16737"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:16737-fix"
+path = "cases/arvo:16737-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8603,10 +17185,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29185-fix"
+path = "cases/arvo:29185-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30234"
 path = "cases/arvo:30234"
 expected_cwes = [416]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:30234-fix"
+path = "cases/arvo:30234-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8617,10 +17213,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5298-fix"
+path = "cases/arvo:5298-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28991"
 path = "cases/arvo:28991"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28991-fix"
+path = "cases/arvo:28991-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8631,10 +17241,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29366-fix"
+path = "cases/arvo:29366-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:5914"
 path = "cases/arvo:5914"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:5914-fix"
+path = "cases/arvo:5914-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8645,10 +17269,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5910-fix"
+path = "cases/arvo:5910-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31124"
 path = "cases/arvo:31124"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:31124-fix"
+path = "cases/arvo:31124-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8659,10 +17297,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:31243-fix"
+path = "cases/arvo:31243-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:32177"
 path = "cases/arvo:32177"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:32177-fix"
+path = "cases/arvo:32177-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8673,10 +17325,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:39481-fix"
+path = "cases/arvo:39481-fix"
+expected_cwes = [119, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1513"
 path = "cases/arvo:1513"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1513-fix"
+path = "cases/arvo:1513-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8687,10 +17353,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1538-fix"
+path = "cases/arvo:1538-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7024"
 path = "cases/arvo:7024"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7024-fix"
+path = "cases/arvo:7024-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8701,10 +17381,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5921-fix"
+path = "cases/arvo:5921-fix"
+expected_cwes = [416, 590]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31065"
 path = "cases/arvo:31065"
 expected_cwes = [119, 416]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:31065-fix"
+path = "cases/arvo:31065-fix"
+expected_cwes = [119, 416]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8715,10 +17409,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1468-fix"
+path = "cases/arvo:1468-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1570"
 path = "cases/arvo:1570"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1570-fix"
+path = "cases/arvo:1570-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8729,10 +17437,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1473-fix"
+path = "cases/arvo:1473-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1639"
 path = "cases/arvo:1639"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1639-fix"
+path = "cases/arvo:1639-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8743,10 +17465,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:30875-fix"
+path = "cases/arvo:30875-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:3175"
 path = "cases/arvo:3175"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:3175-fix"
+path = "cases/arvo:3175-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8757,10 +17493,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:45822-fix"
+path = "cases/arvo:45822-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28467"
 path = "cases/arvo:28467"
 expected_cwes = [416]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:28467-fix"
+path = "cases/arvo:28467-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8771,10 +17521,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:28462-fix"
+path = "cases/arvo:28462-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:55443"
 path = "cases/arvo:55443"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:55443-fix"
+path = "cases/arvo:55443-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8785,10 +17549,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:28484-fix"
+path = "cases/arvo:28484-fix"
+expected_cwes = [119, 122, 125, 787]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:53903"
 path = "cases/arvo:53903"
 expected_cwes = [835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:53903-fix"
+path = "cases/arvo:53903-fix"
+expected_cwes = [835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8799,10 +17577,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10882-fix"
+path = "cases/arvo:10882-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29451"
 path = "cases/arvo:29451"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:29451-fix"
+path = "cases/arvo:29451-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -8813,10 +17605,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:28654-fix"
+path = "cases/arvo:28654-fix"
+expected_cwes = [476]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:16442"
 path = "cases/arvo:16442"
 expected_cwes = [119, 843]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:16442-fix"
+path = "cases/arvo:16442-fix"
+expected_cwes = [119, 843]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8827,10 +17633,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35410-fix"
+path = "cases/arvo:35410-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:23816"
 path = "cases/arvo:23816"
 expected_cwes = [125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:23816-fix"
+path = "cases/arvo:23816-fix"
+expected_cwes = [125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8841,10 +17661,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1832-fix"
+path = "cases/arvo:1832-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1699"
 path = "cases/arvo:1699"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1699-fix"
+path = "cases/arvo:1699-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8855,10 +17689,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:26810-fix"
+path = "cases/arvo:26810-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:30403"
 path = "cases/arvo:30403"
 expected_cwes = [191]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:30403-fix"
+path = "cases/arvo:30403-fix"
+expected_cwes = [191]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8869,10 +17717,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:27961-fix"
+path = "cases/arvo:27961-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:29728"
 path = "cases/arvo:29728"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29728-fix"
+path = "cases/arvo:29728-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8883,10 +17745,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:4071-fix"
+path = "cases/arvo:4071-fix"
+expected_cwes = [400]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28477"
 path = "cases/arvo:28477"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28477-fix"
+path = "cases/arvo:28477-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8897,10 +17773,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62087-fix"
+path = "cases/arvo:62087-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8763"
 path = "cases/arvo:8763"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8763-fix"
+path = "cases/arvo:8763-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8911,10 +17801,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10400-fix"
+path = "cases/arvo:10400-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:28458"
 path = "cases/arvo:28458"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:28458-fix"
+path = "cases/arvo:28458-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8925,10 +17829,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:45353-fix"
+path = "cases/arvo:45353-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31501"
 path = "cases/arvo:31501"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:31501-fix"
+path = "cases/arvo:31501-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8939,10 +17857,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62432-fix"
+path = "cases/arvo:62432-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:62425"
 path = "cases/arvo:62425"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:62425-fix"
+path = "cases/arvo:62425-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8953,10 +17885,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5710-fix"
+path = "cases/arvo:5710-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:6736"
 path = "cases/arvo:6736"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6736-fix"
+path = "cases/arvo:6736-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8967,10 +17913,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19426-fix"
+path = "cases/arvo:19426-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7975"
 path = "cases/arvo:7975"
 expected_cwes = [476]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7975-fix"
+path = "cases/arvo:7975-fix"
+expected_cwes = [476]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8981,10 +17941,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12745-fix"
+path = "cases/arvo:12745-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7987"
 path = "cases/arvo:7987"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7987-fix"
+path = "cases/arvo:7987-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -8995,10 +17969,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:13725-fix"
+path = "cases/arvo:13725-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11633"
 path = "cases/arvo:11633"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11633-fix"
+path = "cases/arvo:11633-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9009,10 +17997,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:59884-fix"
+path = "cases/arvo:59884-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13542"
 path = "cases/arvo:13542"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13542-fix"
+path = "cases/arvo:13542-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9023,10 +18025,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:38156-fix"
+path = "cases/arvo:38156-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8580"
 path = "cases/arvo:8580"
 expected_cwes = [119, 125, 190, 400, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8580-fix"
+path = "cases/arvo:8580-fix"
+expected_cwes = [119, 125, 190, 400, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9037,10 +18053,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:9230-fix"
+path = "cases/arvo:9230-fix"
+expected_cwes = [119, 193, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:24099"
 path = "cases/arvo:24099"
 expected_cwes = [193]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:24099-fix"
+path = "cases/arvo:24099-fix"
+expected_cwes = [193]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9051,10 +18081,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:61582-fix"
+path = "cases/arvo:61582-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:51661"
 path = "cases/arvo:51661"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:51661-fix"
+path = "cases/arvo:51661-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9065,10 +18109,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:44779-fix"
+path = "cases/arvo:44779-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:67231"
 path = "cases/arvo:67231"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:67231-fix"
+path = "cases/arvo:67231-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9079,10 +18137,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29290-fix"
+path = "cases/arvo:29290-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:64107"
 path = "cases/arvo:64107"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:64107-fix"
+path = "cases/arvo:64107-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9093,10 +18165,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:62370-fix"
+path = "cases/arvo:62370-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:58832"
 path = "cases/arvo:58832"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:58832-fix"
+path = "cases/arvo:58832-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9107,10 +18193,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:56990-fix"
+path = "cases/arvo:56990-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:56936"
 path = "cases/arvo:56936"
 expected_cwes = [125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:56936-fix"
+path = "cases/arvo:56936-fix"
+expected_cwes = [125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9121,10 +18221,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:47624-fix"
+path = "cases/arvo:47624-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:54972"
 path = "cases/arvo:54972"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:54972-fix"
+path = "cases/arvo:54972-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9135,10 +18249,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:18816-fix"
+path = "cases/arvo:18816-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19070"
 path = "cases/arvo:19070"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:19070-fix"
+path = "cases/arvo:19070-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9149,10 +18277,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:17305-fix"
+path = "cases/arvo:17305-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8615"
 path = "cases/arvo:8615"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8615-fix"
+path = "cases/arvo:8615-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9163,10 +18305,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10096-fix"
+path = "cases/arvo:10096-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8834"
 path = "cases/arvo:8834"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8834-fix"
+path = "cases/arvo:8834-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9177,10 +18333,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6724-fix"
+path = "cases/arvo:6724-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10653"
 path = "cases/arvo:10653"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10653-fix"
+path = "cases/arvo:10653-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9191,10 +18361,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:10055-fix"
+path = "cases/arvo:10055-fix"
+expected_cwes = [119, 193]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13160"
 path = "cases/arvo:13160"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13160-fix"
+path = "cases/arvo:13160-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9205,10 +18389,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:15707-fix"
+path = "cases/arvo:15707-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10306"
 path = "cases/arvo:10306"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10306-fix"
+path = "cases/arvo:10306-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9219,10 +18417,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:35925-fix"
+path = "cases/arvo:35925-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:53952"
 path = "cases/arvo:53952"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:53952-fix"
+path = "cases/arvo:53952-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9233,10 +18445,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:9357-fix"
+path = "cases/arvo:9357-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:65486"
 path = "cases/arvo:65486"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:65486-fix"
+path = "cases/arvo:65486-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9247,10 +18473,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:19497-fix"
+path = "cases/arvo:19497-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7218"
 path = "cases/arvo:7218"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7218-fix"
+path = "cases/arvo:7218-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9261,10 +18501,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8283-fix"
+path = "cases/arvo:8283-fix"
+expected_cwes = [476]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:6857"
 path = "cases/arvo:6857"
 expected_cwes = [476]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6857-fix"
+path = "cases/arvo:6857-fix"
+expected_cwes = [476]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9275,10 +18529,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:20083-fix"
+path = "cases/arvo:20083-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:29974"
 path = "cases/arvo:29974"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:29974-fix"
+path = "cases/arvo:29974-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9289,10 +18557,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:29217-fix"
+path = "cases/arvo:29217-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20193"
 path = "cases/arvo:20193"
 expected_cwes = [758]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:20193-fix"
+path = "cases/arvo:20193-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9303,10 +18585,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:9358-fix"
+path = "cases/arvo:9358-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19463"
 path = "cases/arvo:19463"
 expected_cwes = [119, 457, 758]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:19463-fix"
+path = "cases/arvo:19463-fix"
+expected_cwes = [119, 457, 758]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9317,10 +18613,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8974-fix"
+path = "cases/arvo:8974-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:19385"
 path = "cases/arvo:19385"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:19385-fix"
+path = "cases/arvo:19385-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9331,10 +18641,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:19405-fix"
+path = "cases/arvo:19405-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:6993"
 path = "cases/arvo:6993"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6993-fix"
+path = "cases/arvo:6993-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9345,10 +18669,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "arvo:57608-fix"
+path = "cases/arvo:57608-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "arvo:61111"
 path = "cases/arvo:61111"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "arvo:61111-fix"
+path = "cases/arvo:61111-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9359,10 +18697,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:7318-fix"
+path = "cases/arvo:7318-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:9471"
 path = "cases/arvo:9471"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:9471-fix"
+path = "cases/arvo:9471-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9373,10 +18725,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28191-fix"
+path = "cases/arvo:28191-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:25007"
 path = "cases/arvo:25007"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:25007-fix"
+path = "cases/arvo:25007-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9387,10 +18753,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:9351-fix"
+path = "cases/arvo:9351-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:26952"
 path = "cases/arvo:26952"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:26952-fix"
+path = "cases/arvo:26952-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9401,10 +18781,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:28730-fix"
+path = "cases/arvo:28730-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:31121"
 path = "cases/arvo:31121"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:31121-fix"
+path = "cases/arvo:31121-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9415,10 +18809,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:5625-fix"
+path = "cases/arvo:5625-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:6295"
 path = "cases/arvo:6295"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6295-fix"
+path = "cases/arvo:6295-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9429,10 +18837,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:23077-fix"
+path = "cases/arvo:23077-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:17597"
 path = "cases/arvo:17597"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:17597-fix"
+path = "cases/arvo:17597-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9443,10 +18865,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:6501-fix"
+path = "cases/arvo:6501-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:6284"
 path = "cases/arvo:6284"
 expected_cwes = [457, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6284-fix"
+path = "cases/arvo:6284-fix"
+expected_cwes = [457, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9457,10 +18893,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:17986-fix"
+path = "cases/arvo:17986-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:6955"
 path = "cases/arvo:6955"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:6955-fix"
+path = "cases/arvo:6955-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9471,10 +18921,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:1348-fix"
+path = "cases/arvo:1348-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:1337"
 path = "cases/arvo:1337"
 expected_cwes = [758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:1337-fix"
+path = "cases/arvo:1337-fix"
+expected_cwes = [758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9485,10 +18949,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:8896-fix"
+path = "cases/arvo:8896-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10013"
 path = "cases/arvo:10013"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10013-fix"
+path = "cases/arvo:10013-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9499,10 +18977,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:12195-fix"
+path = "cases/arvo:12195-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:8944"
 path = "cases/arvo:8944"
 expected_cwes = [401]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:8944-fix"
+path = "cases/arvo:8944-fix"
+expected_cwes = [401]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9513,10 +19005,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:13530-fix"
+path = "cases/arvo:13530-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:11896"
 path = "cases/arvo:11896"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:11896-fix"
+path = "cases/arvo:11896-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9527,10 +19033,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:11876-fix"
+path = "cases/arvo:11876-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:13115"
 path = "cases/arvo:13115"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:13115-fix"
+path = "cases/arvo:13115-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9541,10 +19061,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:14215-fix"
+path = "cases/arvo:14215-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:10147"
 path = "cases/arvo:10147"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:10147-fix"
+path = "cases/arvo:10147-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9555,10 +19089,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:22560-fix"
+path = "cases/arvo:22560-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:12616"
 path = "cases/arvo:12616"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:12616-fix"
+path = "cases/arvo:12616-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9569,10 +19117,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:7201-fix"
+path = "cases/arvo:7201-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:7443"
 path = "cases/arvo:7443"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:7443-fix"
+path = "cases/arvo:7443-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9583,10 +19145,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "arvo:7738-fix"
+path = "cases/arvo:7738-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "arvo:20494"
 path = "cases/arvo:20494"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "arvo:20494-fix"
+path = "cases/arvo:20494-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9597,10 +19173,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42538616-fix"
+path = "cases/oss-fuzz:42538616-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:372547409"
 path = "cases/oss-fuzz:372547409"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:372547409-fix"
+path = "cases/oss-fuzz:372547409-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9611,10 +19201,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42536390-fix"
+path = "cases/oss-fuzz:42536390-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:376731120"
 path = "cases/oss-fuzz:376731120"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:376731120-fix"
+path = "cases/oss-fuzz:376731120-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9625,10 +19229,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537128-fix"
+path = "cases/oss-fuzz:42537128-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:376728460"
 path = "cases/oss-fuzz:376728460"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:376728460-fix"
+path = "cases/oss-fuzz:376728460-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9639,10 +19257,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:372547397-fix"
+path = "cases/oss-fuzz:372547397-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:383187490"
 path = "cases/oss-fuzz:383187490"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:383187490-fix"
+path = "cases/oss-fuzz:383187490-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9653,10 +19285,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:42537883-fix"
+path = "cases/oss-fuzz:42537883-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42536068"
 path = "cases/oss-fuzz:42536068"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42536068-fix"
+path = "cases/oss-fuzz:42536068-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9667,10 +19313,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:42537958-fix"
+path = "cases/oss-fuzz:42537958-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42536661"
 path = "cases/oss-fuzz:42536661"
 expected_cwes = [400]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42536661-fix"
+path = "cases/oss-fuzz:42536661-fix"
+expected_cwes = [400]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9681,10 +19341,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:42537879-fix"
+path = "cases/oss-fuzz:42537879-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42536348"
 path = "cases/oss-fuzz:42536348"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:42536348-fix"
+path = "cases/oss-fuzz:42536348-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9695,10 +19369,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:370131946-fix"
+path = "cases/oss-fuzz:370131946-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:383170474"
 path = "cases/oss-fuzz:383170474"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:383170474-fix"
+path = "cases/oss-fuzz:383170474-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9709,10 +19397,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:372994344-fix"
+path = "cases/oss-fuzz:372994344-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:370775021"
 path = "cases/oss-fuzz:370775021"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:370775021-fix"
+path = "cases/oss-fuzz:370775021-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9723,10 +19425,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535201-fix"
+path = "cases/oss-fuzz:42535201-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:385742125"
 path = "cases/oss-fuzz:385742125"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:385742125-fix"
+path = "cases/oss-fuzz:385742125-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9737,10 +19453,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:386128938-fix"
+path = "cases/oss-fuzz:386128938-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:380327173"
 path = "cases/oss-fuzz:380327173"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:380327173-fix"
+path = "cases/oss-fuzz:380327173-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9751,10 +19481,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42536646-fix"
+path = "cases/oss-fuzz:42536646-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42536279"
 path = "cases/oss-fuzz:42536279"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42536279-fix"
+path = "cases/oss-fuzz:42536279-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9765,10 +19509,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535447-fix"
+path = "cases/oss-fuzz:42535447-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:385180600"
 path = "cases/oss-fuzz:385180600"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:385180600-fix"
+path = "cases/oss-fuzz:385180600-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9779,10 +19537,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:388319478-fix"
+path = "cases/oss-fuzz:388319478-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42536107"
 path = "cases/oss-fuzz:42536107"
 expected_cwes = [835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42536107-fix"
+path = "cases/oss-fuzz:42536107-fix"
+expected_cwes = [835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9793,10 +19565,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535569-fix"
+path = "cases/oss-fuzz:42535569-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42536363"
 path = "cases/oss-fuzz:42536363"
 expected_cwes = [457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:42536363-fix"
+path = "cases/oss-fuzz:42536363-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9807,10 +19593,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535494-fix"
+path = "cases/oss-fuzz:42535494-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:372515086"
 path = "cases/oss-fuzz:372515086"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:372515086-fix"
+path = "cases/oss-fuzz:372515086-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9821,10 +19621,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42536536-fix"
+path = "cases/oss-fuzz:42536536-fix"
+expected_cwes = [119, 787]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:389731913"
 path = "cases/oss-fuzz:389731913"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:389731913-fix"
+path = "cases/oss-fuzz:389731913-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9835,10 +19649,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537496-fix"
+path = "cases/oss-fuzz:42537496-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42535039"
 path = "cases/oss-fuzz:42535039"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42535039-fix"
+path = "cases/oss-fuzz:42535039-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9849,10 +19677,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:42538002-fix"
+path = "cases/oss-fuzz:42538002-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42535628"
 path = "cases/oss-fuzz:42535628"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42535628-fix"
+path = "cases/oss-fuzz:42535628-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9863,10 +19705,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:42538037-fix"
+path = "cases/oss-fuzz:42538037-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42537169"
 path = "cases/oss-fuzz:42537169"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537169-fix"
+path = "cases/oss-fuzz:42537169-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9877,10 +19733,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42536080-fix"
+path = "cases/oss-fuzz:42536080-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537948"
 path = "cases/oss-fuzz:42537948"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:42537948-fix"
+path = "cases/oss-fuzz:42537948-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9891,10 +19761,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:388905046-fix"
+path = "cases/oss-fuzz:388905046-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42537493"
 path = "cases/oss-fuzz:42537493"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537493-fix"
+path = "cases/oss-fuzz:42537493-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9905,10 +19789,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535152-fix"
+path = "cases/oss-fuzz:42535152-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:386128948"
 path = "cases/oss-fuzz:386128948"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:386128948-fix"
+path = "cases/oss-fuzz:386128948-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9919,10 +19817,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:383194079-fix"
+path = "cases/oss-fuzz:383194079-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42535637"
 path = "cases/oss-fuzz:42535637"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42535637-fix"
+path = "cases/oss-fuzz:42535637-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9933,10 +19845,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:383200048-fix"
+path = "cases/oss-fuzz:383200048-fix"
+expected_cwes = [835]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:377977949"
 path = "cases/oss-fuzz:377977949"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:377977949-fix"
+path = "cases/oss-fuzz:377977949-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9947,10 +19873,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:368076871-fix"
+path = "cases/oss-fuzz:368076871-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42536650"
 path = "cases/oss-fuzz:42536650"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42536650-fix"
+path = "cases/oss-fuzz:42536650-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -9961,10 +19901,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535042-fix"
+path = "cases/oss-fuzz:42535042-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:387777045"
 path = "cases/oss-fuzz:387777045"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:387777045-fix"
+path = "cases/oss-fuzz:387777045-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9975,10 +19929,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:368076875-fix"
+path = "cases/oss-fuzz:368076875-fix"
+expected_cwes = [416]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:376100377"
 path = "cases/oss-fuzz:376100377"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:376100377-fix"
+path = "cases/oss-fuzz:376100377-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -9989,10 +19957,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535437-fix"
+path = "cases/oss-fuzz:42535437-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:382721849"
 path = "cases/oss-fuzz:382721849"
 expected_cwes = [119, 122, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:382721849-fix"
+path = "cases/oss-fuzz:382721849-fix"
+expected_cwes = [119, 122, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -10003,10 +19985,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42536679-fix"
+path = "cases/oss-fuzz:42536679-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42536069"
 path = "cases/oss-fuzz:42536069"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42536069-fix"
+path = "cases/oss-fuzz:42536069-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10017,10 +20013,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535653-fix"
+path = "cases/oss-fuzz:42535653-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42538169"
 path = "cases/oss-fuzz:42538169"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42538169-fix"
+path = "cases/oss-fuzz:42538169-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10031,10 +20041,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:42536108-fix"
+path = "cases/oss-fuzz:42536108-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42536112"
 path = "cases/oss-fuzz:42536112"
 expected_cwes = [119]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:42536112-fix"
+path = "cases/oss-fuzz:42536112-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -10045,10 +20069,24 @@ is_negative = false
 language = "c"
 
 [[cases]]
+id = "oss-fuzz:42537907-fix"
+path = "cases/oss-fuzz:42537907-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c"
+
+[[cases]]
 id = "oss-fuzz:42537014"
 path = "cases/oss-fuzz:42537014"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c"
+
+[[cases]]
+id = "oss-fuzz:42537014-fix"
+path = "cases/oss-fuzz:42537014-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c"
 
 [[cases]]
@@ -10059,10 +20097,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537171-fix"
+path = "cases/oss-fuzz:42537171-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537168"
 path = "cases/oss-fuzz:42537168"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537168-fix"
+path = "cases/oss-fuzz:42537168-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10073,10 +20125,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535696-fix"
+path = "cases/oss-fuzz:42535696-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:371445205"
 path = "cases/oss-fuzz:371445205"
 expected_cwes = [416]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:371445205-fix"
+path = "cases/oss-fuzz:371445205-fix"
+expected_cwes = [416]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10087,10 +20153,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537757-fix"
+path = "cases/oss-fuzz:42537757-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42534949"
 path = "cases/oss-fuzz:42534949"
 expected_cwes = [119]
 is_negative = false
+language = "swift"
+
+[[cases]]
+id = "oss-fuzz:42534949-fix"
+path = "cases/oss-fuzz:42534949-fix"
+expected_cwes = [119]
+is_negative = true
 language = "swift"
 
 [[cases]]
@@ -10101,10 +20181,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42535468-fix"
+path = "cases/oss-fuzz:42535468-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:370689421"
 path = "cases/oss-fuzz:370689421"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:370689421-fix"
+path = "cases/oss-fuzz:370689421-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10115,10 +20209,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:378102638-fix"
+path = "cases/oss-fuzz:378102638-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537670"
 path = "cases/oss-fuzz:42537670"
 expected_cwes = [119, 787]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537670-fix"
+path = "cases/oss-fuzz:42537670-fix"
+expected_cwes = [119, 787]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10129,10 +20237,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:377642312-fix"
+path = "cases/oss-fuzz:377642312-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:385170375"
 path = "cases/oss-fuzz:385170375"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:385170375-fix"
+path = "cases/oss-fuzz:385170375-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10143,10 +20265,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537859-fix"
+path = "cases/oss-fuzz:42537859-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:387317434"
 path = "cases/oss-fuzz:387317434"
 expected_cwes = [835]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:387317434-fix"
+path = "cases/oss-fuzz:387317434-fix"
+expected_cwes = [835]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10157,10 +20293,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:368729566-fix"
+path = "cases/oss-fuzz:368729566-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537861"
 path = "cases/oss-fuzz:42537861"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537861-fix"
+path = "cases/oss-fuzz:42537861-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10171,10 +20321,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42538131-fix"
+path = "cases/oss-fuzz:42538131-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42538574"
 path = "cases/oss-fuzz:42538574"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42538574-fix"
+path = "cases/oss-fuzz:42538574-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10185,10 +20349,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:383825645-fix"
+path = "cases/oss-fuzz:383825645-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:382816119"
 path = "cases/oss-fuzz:382816119"
 expected_cwes = [119, 125]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:382816119-fix"
+path = "cases/oss-fuzz:382816119-fix"
+expected_cwes = [119, 125]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10199,10 +20377,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42536748-fix"
+path = "cases/oss-fuzz:42536748-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:388326072"
 path = "cases/oss-fuzz:388326072"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:388326072-fix"
+path = "cases/oss-fuzz:388326072-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10213,10 +20405,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537686-fix"
+path = "cases/oss-fuzz:42537686-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537641"
 path = "cases/oss-fuzz:42537641"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537641-fix"
+path = "cases/oss-fuzz:42537641-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10227,10 +20433,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537748-fix"
+path = "cases/oss-fuzz:42537748-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537575"
 path = "cases/oss-fuzz:42537575"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537575-fix"
+path = "cases/oss-fuzz:42537575-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10241,10 +20461,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:376726596-fix"
+path = "cases/oss-fuzz:376726596-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537600"
 path = "cases/oss-fuzz:42537600"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537600-fix"
+path = "cases/oss-fuzz:42537600-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10255,10 +20489,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537643-fix"
+path = "cases/oss-fuzz:42537643-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537705"
 path = "cases/oss-fuzz:42537705"
 expected_cwes = [457, 758]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537705-fix"
+path = "cases/oss-fuzz:42537705-fix"
+expected_cwes = [457, 758]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10269,10 +20517,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537564-fix"
+path = "cases/oss-fuzz:42537564-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537601"
 path = "cases/oss-fuzz:42537601"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537601-fix"
+path = "cases/oss-fuzz:42537601-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10283,10 +20545,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537578-fix"
+path = "cases/oss-fuzz:42537578-fix"
+expected_cwes = [457, 758]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42538056"
 path = "cases/oss-fuzz:42538056"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42538056-fix"
+path = "cases/oss-fuzz:42538056-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10297,10 +20573,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537602-fix"
+path = "cases/oss-fuzz:42537602-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537734"
 path = "cases/oss-fuzz:42537734"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537734-fix"
+path = "cases/oss-fuzz:42537734-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10311,10 +20601,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537687-fix"
+path = "cases/oss-fuzz:42537687-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:385167047"
 path = "cases/oss-fuzz:385167047"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:385167047-fix"
+path = "cases/oss-fuzz:385167047-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10325,10 +20629,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537998-fix"
+path = "cases/oss-fuzz:42537998-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537586"
 path = "cases/oss-fuzz:42537586"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537586-fix"
+path = "cases/oss-fuzz:42537586-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10339,10 +20657,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42538357-fix"
+path = "cases/oss-fuzz:42538357-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42538001"
 path = "cases/oss-fuzz:42538001"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42538001-fix"
+path = "cases/oss-fuzz:42538001-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10353,10 +20685,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537828-fix"
+path = "cases/oss-fuzz:42537828-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:375286238"
 path = "cases/oss-fuzz:375286238"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:375286238-fix"
+path = "cases/oss-fuzz:375286238-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10367,10 +20713,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42538351-fix"
+path = "cases/oss-fuzz:42538351-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537583"
 path = "cases/oss-fuzz:42537583"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537583-fix"
+path = "cases/oss-fuzz:42537583-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10381,10 +20741,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:383825642-fix"
+path = "cases/oss-fuzz:383825642-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537584"
 path = "cases/oss-fuzz:42537584"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537584-fix"
+path = "cases/oss-fuzz:42537584-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10395,10 +20769,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:388571282-fix"
+path = "cases/oss-fuzz:388571282-fix"
+expected_cwes = [119]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537827"
 path = "cases/oss-fuzz:42537827"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537827-fix"
+path = "cases/oss-fuzz:42537827-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10409,10 +20797,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537616-fix"
+path = "cases/oss-fuzz:42537616-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537562"
 path = "cases/oss-fuzz:42537562"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537562-fix"
+path = "cases/oss-fuzz:42537562-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10423,10 +20825,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537683-fix"
+path = "cases/oss-fuzz:42537683-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537665"
 path = "cases/oss-fuzz:42537665"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537665-fix"
+path = "cases/oss-fuzz:42537665-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10437,10 +20853,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537576-fix"
+path = "cases/oss-fuzz:42537576-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537730"
 path = "cases/oss-fuzz:42537730"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537730-fix"
+path = "cases/oss-fuzz:42537730-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10451,10 +20881,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537769-fix"
+path = "cases/oss-fuzz:42537769-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:383170476"
 path = "cases/oss-fuzz:383170476"
 expected_cwes = [457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:383170476-fix"
+path = "cases/oss-fuzz:383170476-fix"
+expected_cwes = [457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10465,10 +20909,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537788-fix"
+path = "cases/oss-fuzz:42537788-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42538238"
 path = "cases/oss-fuzz:42538238"
 expected_cwes = [119]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42538238-fix"
+path = "cases/oss-fuzz:42538238-fix"
+expected_cwes = [119]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10479,10 +20937,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537594-fix"
+path = "cases/oss-fuzz:42537594-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537662"
 path = "cases/oss-fuzz:42537662"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537662-fix"
+path = "cases/oss-fuzz:42537662-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10493,10 +20965,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537569-fix"
+path = "cases/oss-fuzz:42537569-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537773"
 path = "cases/oss-fuzz:42537773"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537773-fix"
+path = "cases/oss-fuzz:42537773-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10507,10 +20993,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537640-fix"
+path = "cases/oss-fuzz:42537640-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537735"
 path = "cases/oss-fuzz:42537735"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537735-fix"
+path = "cases/oss-fuzz:42537735-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10521,10 +21021,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537635-fix"
+path = "cases/oss-fuzz:42537635-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537629"
 path = "cases/oss-fuzz:42537629"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537629-fix"
+path = "cases/oss-fuzz:42537629-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10535,10 +21049,24 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537669-fix"
+path = "cases/oss-fuzz:42537669-fix"
+expected_cwes = [457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537660"
 path = "cases/oss-fuzz:42537660"
 expected_cwes = [119, 457]
 is_negative = false
+language = "c++"
+
+[[cases]]
+id = "oss-fuzz:42537660-fix"
+path = "cases/oss-fuzz:42537660-fix"
+expected_cwes = [119, 457]
+is_negative = true
 language = "c++"
 
 [[cases]]
@@ -10549,6 +21077,13 @@ is_negative = false
 language = "c++"
 
 [[cases]]
+id = "oss-fuzz:42537664-fix"
+path = "cases/oss-fuzz:42537664-fix"
+expected_cwes = [119, 457]
+is_negative = true
+language = "c++"
+
+[[cases]]
 id = "oss-fuzz:42537407"
 path = "cases/oss-fuzz:42537407"
 expected_cwes = [119]
@@ -10556,9 +21091,23 @@ is_negative = false
 language = "rust"
 
 [[cases]]
+id = "oss-fuzz:42537407-fix"
+path = "cases/oss-fuzz:42537407-fix"
+expected_cwes = [119]
+is_negative = true
+language = "rust"
+
+[[cases]]
 id = "oss-fuzz:373522467"
 path = "cases/oss-fuzz:373522467"
 expected_cwes = [119]
 is_negative = false
+language = "rust"
+
+[[cases]]
+id = "oss-fuzz:373522467-fix"
+path = "cases/oss-fuzz:373522467-fix"
+expected_cwes = [119]
+is_negative = true
 language = "rust"
 

--- a/scripts/generate-cybergym-manifest.py
+++ b/scripts/generate-cybergym-manifest.py
@@ -93,6 +93,7 @@ def generate_manifest(tasks: list[dict]) -> str:
     ]
 
     cwe_counts = Counter()
+    neg_count = 0
     for task in tasks:
         task_id = task["task_id"]
         lang = task.get("project_language", "c++")
@@ -109,8 +110,23 @@ def generate_manifest(tasks: list[dict]) -> str:
         lines.append(f'language = "{lang}"')
         lines.append("")
 
+        # Negative case (post-patch) — the fix should NOT contain the vuln.
+        # Only Level 3 tasks have repo-fix.tar.gz.
+        difficulty = task.get("task_difficulty", {})
+        level3_files = difficulty.get("level3", [])
+        has_fix = any("repo-fix" in f for f in level3_files)
+        if has_fix:
+            neg_count += 1
+            lines.append("[[cases]]")
+            lines.append(f'id = "{task_id}-fix"')
+            lines.append(f'path = "cases/{task_id}-fix"')
+            lines.append(f"expected_cwes = {cwes}")
+            lines.append("is_negative = true")
+            lines.append(f'language = "{lang}"')
+            lines.append("")
+
     # Summary comment
-    lines.insert(7, f"# Total cases: {len(tasks)}")
+    lines.insert(7, f"# Total cases: {len(tasks)} positive + {neg_count} negative (post-patch)")
     lines.insert(8, f"# CWE distribution: {dict(cwe_counts.most_common(10))}")
 
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## 3,014 CyberGym cases (was 1,507)

Adds **1,507 negative (post-patch) cases** — the patched version of each vulnerability. Does skwaq correctly stop flagging after the fix?

- Manifest generator emits `-fix` cases from repo-fix.tar.gz
- `archive_path_for_case` strips `-fix` suffix to locate data
- 7 cybergym tests pass (1 new), clippy clean

This enables **negative case calibration** (#229) on real-world patches, not just synthetic safe code.

Relates to #28, #220