### PR TITLE
fix(gym): bias synthesis prompt toward precision

### DIFF
--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -1328,14 +1328,22 @@ async fn llm_synthesize_with_limits(
         "You are a lead security reviewer evaluating vulnerability findings from two sources:\n\
          1. PATTERN DETECTION (automated regex-based, high precision, limited understanding)\n\
          2. LLM AGENTS (AI-powered deep analysis, better understanding, may hallucinate)\n\n\
-         Your job: decide which findings are REAL vulnerabilities.\n\n\
+         Your job: decide which findings are REAL vulnerabilities vs false positives.\n\
+         Your default stance is SKEPTICAL. Most automated findings are noise.\n\n\
          For each finding, respond with one line:\n\
-         CONFIRM <id> — strong evidence from one or both sources\n\
-         REVIEW <id> — plausible finding, but the evidence is conflicting or incomplete and needs a second pass\n\
-         REJECT <id> — insufficient evidence, likely false positive\n\n\
-         Only REJECT findings where you are confident they are false positives.\n\
-         Use REVIEW when the finding may be real but you need a stricter second-pass check.\n\
-         When evidence is strong enough, prefer CONFIRM over REVIEW.\n\n",
+         CONFIRM <id> — concrete evidence that the vulnerability is real and exploitable\n\
+         REVIEW <id> — plausible but evidence is incomplete; needs stricter second pass\n\
+         REJECT <id> — insufficient evidence, pattern matched safe code, or LLM hallucination\n\n\
+         REJECT a finding when:\n\
+         - The detected API is used safely (e.g. printf with a literal format string)\n\
+         - The finding is speculative without evidence of data flow to a dangerous sink\n\
+         - The LLM agent described a generic vulnerability class without pointing to specific code\n\
+         - Safe wrappers (strncpy, snprintf) are used correctly with proper bounds\n\n\
+         CONFIRM only when:\n\
+         - There is a clear path from untrusted input to a dangerous operation\n\
+         - The code lacks bounds checking, validation, or sanitization on that path\n\
+         - Both sources agree, or one source provides strong concrete evidence\n\n\
+         When in doubt, REJECT. False positives are worse than false negatives.\n\n",
     );
 
     append_findings_for_prompt(&mut prompt, "=== PATTERN FINDINGS ===\n", pattern_findings);


### PR DESCRIPTION
## Root Cause: Synthesis Prompt Biased Toward CONFIRM

The synthesis prompt said: *"Only REJECT findings where you are confident they are false positives."* This created a confirmation bias — the LLM defaulted to confirming speculative findings.

### Fix
New prompt is **skeptical by default**:
- *"Most automated findings are noise"*
- REJECT when: safe API usage, speculative findings, generic descriptions, safe wrappers
- CONFIRM only with: clear untrusted input → dangerous operation path, lacking validation
- *"When in doubt, REJECT. False positives are worse than false negatives."*

### Combined with #246
Together, these two PRs address the full precision failure:
1. #246: LLM-only findings no longer bypass synthesis
2. This PR: Synthesis LLM is now precision-biased

Relates to #28