### PR TITLE
fix(gym): scale overfitting reviewer budget with proposal count

### DIFF
--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -1020,7 +1020,14 @@ async fn run_overfitting_review(
         .await
         .map_err(|e| anyhow::anyhow!("overfitting review requires an LLM client: {e}"))?;
 
-    let budget_amount = config.analysis.default_token_budget.min(20_000);
+    // Scale budget with proposal count — each proposal needs ~1500 tokens for
+    // the structured review JSON (verdict, reason, evidence_refs).
+    let base_budget = 10_000_u64;
+    let per_proposal = 1_500_u64;
+    let budget_amount = config
+        .analysis
+        .default_token_budget
+        .min(base_budget + proposals.len() as u64 * per_proposal);
     let knowledge_context = build_overfitting_knowledge_context(knowledge_db, &proposals)?;
 
     let mut proposal_text = format!(


### PR DESCRIPTION
Reviewer budget was fixed at 20K tokens. Juliet improve produced 15 proposals → JSON truncated. Now scales: 10K + 1.5K per proposal.

21 improve tests pass, clippy clean.

Relates to #28