### PR TITLE
fix: remove artificial token budget limits — raise to 250K

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -129,7 +129,7 @@ fn default_fp_target() -> f64 {
     0.15
 }
 fn default_token_budget() -> u64 {
-    100_000
+    250_000
 }
 fn default_format() -> String {
     "text".into()

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -170,7 +170,7 @@ static SYNTHESIS_STATS: std::sync::LazyLock<SynthesisStats> =
     std::sync::LazyLock::new(SynthesisStats::new);
 
 const GHIDRA_ANALYSIS_TIMEOUT_SECS: u64 = 300;
-const SYNTHESIS_REFINEMENT_MAX_BUDGET: u64 = 10_000;
+const SYNTHESIS_REFINEMENT_MAX_BUDGET: u64 = 50_000;
 
 /// Get the global synthesis stats. Call [`SynthesisStats::report`] at end of run.
 pub fn synthesis_stats() -> &'static SynthesisStats {
@@ -1182,13 +1182,7 @@ async fn synthesize_findings(
                 pattern_findings.len(),
                 llm_findings.len(),
             );
-            llm_synthesize_with_limits(
-                &pattern_findings,
-                &llm_findings,
-                timeout_secs.min(10),
-                Some(6_000),
-            )
-            .await
+            llm_synthesize_with_limits(&pattern_findings, &llm_findings, timeout_secs, None).await
         }
         SynthesisRoute::ExpertRouted(domain) => {
             SYNTHESIS_STATS.record_expert_routed();
@@ -1279,10 +1273,7 @@ async fn llm_synthesize_expert(
     append_findings_for_prompt(&mut prompt, "\n=== LLM AGENT FINDINGS ===\n", llm_findings);
     prompt.push_str("\nEvaluate each finding. Respond with CONFIRM or REJECT for each ID.\n");
 
-    let budget_amount = config
-        .analysis
-        .default_token_budget
-        .min(10_000 + (pattern_findings.len() + llm_findings.len()) as u64 * 500);
+    let budget_amount = config.analysis.default_token_budget;
     let mut budget = skwaq_core::llm::TokenBudget::new(budget_amount);
     let model = &config.llm.copilot.model;
 
@@ -1351,11 +1342,8 @@ async fn llm_synthesize_with_limits(
 
     prompt.push_str("\nEvaluate each finding. Respond with CONFIRM or REJECT for each ID.\n");
 
-    // Budget scales with number of findings to evaluate
-    let budget_amount = config.analysis.default_token_budget.min(
-        max_budget_override
-            .unwrap_or(10_000 + (pattern_findings.len() + llm_findings.len()) as u64 * 500),
-    );
+    // Use full budget or override if specified
+    let budget_amount = max_budget_override.unwrap_or(config.analysis.default_token_budget);
     let mut budget = skwaq_core::llm::TokenBudget::new(budget_amount);
     let model = &config.llm.copilot.model;
     let synthesis_started = Instant::now();
@@ -1645,7 +1633,7 @@ async fn run_llm_pipeline(
     // reasoning lane independently so they do not force decompilation auth;
     // binary/decompile pipelines still cache the full pair together.
     let pipeline_clients = cached_pipeline_clients(&config, &pipeline, file_str).await?;
-    let budget_amount = config.analysis.default_token_budget.min(100_000);
+    let budget_amount = config.analysis.default_token_budget;
     let mut budget = skwaq_core::llm::TokenBudget::new(budget_amount);
 
     let target = std::path::Path::new(file_str)

--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -22,8 +22,8 @@ const IMPROVE_KB_SNIPPET_CHAR_LIMIT: usize = 700;
 const IMPROVE_KB_FIXED_QUERIES: [&str; 2] = ["methodology", "cwe-families"];
 const FAILURE_ANALYST_MIN_CASES: usize = 5;
 const FAILURE_ANALYST_MAX_CASES: usize = 20;
-const FAILURE_ANALYST_TARGET_BUDGET_PER_CASE: u64 = 10_000;
-const FAILURE_ANALYST_MAX_BUDGET_PER_CASE: u64 = 30_000;
+const FAILURE_ANALYST_TARGET_BUDGET_PER_CASE: u64 = 50_000;
+const FAILURE_ANALYST_MAX_BUDGET_PER_CASE: u64 = 100_000;
 
 /// A proposed improvement from the failure-analyst agent.
 #[derive(Debug, Clone)]
@@ -444,7 +444,7 @@ async fn run_failure_analyst_agent(
 
     for (i, fn_case) in false_negatives.iter().enumerate().take(case_limit) {
         let mut budget = skwaq_core::llm::TokenBudget::new(budget_per_case);
-        let source_excerpt_len = fn_case.source_content.len().min(4000);
+        let source_excerpt_len = fn_case.source_content.len().min(32_000);
         if fn_case.source_content.len() > source_excerpt_len {
             tracing::warn!(
                 "Truncating source context for case {} from {} to {} bytes",
@@ -548,7 +548,7 @@ async fn run_failure_analyst_agent(
                 anyhow::anyhow!("failure analyst failed on case {}: {e}", fn_case.case_id)
             })?;
 
-        let mut formatter_budget = skwaq_core::llm::TokenBudget::new(budget_per_case.min(10_000));
+        let mut formatter_budget = skwaq_core::llm::TokenBudget::new(budget_per_case.min(50_000));
         let formatted_output = format_failure_analyst_output(
             &config,
             agent.model.as_str(),
@@ -1020,14 +1020,9 @@ async fn run_overfitting_review(
         .await
         .map_err(|e| anyhow::anyhow!("overfitting review requires an LLM client: {e}"))?;
 
-    // Scale budget with proposal count — each proposal needs ~1500 tokens for
-    // the structured review JSON (verdict, reason, evidence_refs).
-    let base_budget = 10_000_u64;
-    let per_proposal = 1_500_u64;
-    let budget_amount = config
-        .analysis
-        .default_token_budget
-        .min(base_budget + proposals.len() as u64 * per_proposal);
+    // Use full budget — the reviewer needs enough tokens to evaluate all proposals
+    // with detailed structured JSON output.
+    let budget_amount = config.analysis.default_token_budget;
     let knowledge_context = build_overfitting_knowledge_context(knowledge_db, &proposals)?;
 
     let mut proposal_text = format!(
@@ -2353,20 +2348,22 @@ mod tests {
 
     #[test]
     fn test_failure_analyst_case_limit_scales_with_budget() {
-        assert_eq!(failure_analyst_case_limit(100_000, 50), 10);
-        assert_eq!(failure_analyst_case_limit(250_000, 50), 20);
-        assert_eq!(failure_analyst_case_limit(30_000, 50), 5);
-        assert_eq!(failure_analyst_case_limit(100_000, 3), 3);
-        assert_eq!(failure_analyst_case_limit(100_000, 0), 0);
+        // TARGET_BUDGET_PER_CASE = 50_000, MIN_CASES = 5, MAX_CASES = 20
+        assert_eq!(failure_analyst_case_limit(250_000, 50), 5); // 250K/50K = 5
+        assert_eq!(failure_analyst_case_limit(500_000, 50), 10); // 500K/50K = 10
+        assert_eq!(failure_analyst_case_limit(50_000, 50), 5); // 50K/50K = 1 → clamped to MIN 5
+        assert_eq!(failure_analyst_case_limit(250_000, 3), 3); // capped by FN count
+        assert_eq!(failure_analyst_case_limit(250_000, 0), 0);
     }
 
     #[test]
     fn test_failure_analyst_budget_per_case_respects_total_budget() {
-        assert_eq!(failure_analyst_budget_per_case(100_000, 10), 10_000);
-        assert_eq!(failure_analyst_budget_per_case(30_000, 5), 6_000);
-        assert_eq!(failure_analyst_budget_per_case(1_000_000, 20), 30_000);
+        // MAX_BUDGET_PER_CASE = 100_000
+        assert_eq!(failure_analyst_budget_per_case(250_000, 5), 50_000);
+        assert_eq!(failure_analyst_budget_per_case(100_000, 5), 20_000);
+        assert_eq!(failure_analyst_budget_per_case(5_000_000, 20), 100_000); // capped at MAX
         assert_eq!(failure_analyst_budget_per_case(1, 5), 1);
-        assert_eq!(failure_analyst_budget_per_case(100_000, 0), 0);
+        assert_eq!(failure_analyst_budget_per_case(250_000, 0), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Every LLM budget was artificially capped

Juliet improve cycle (19 proposals) failed because the overfitting reviewer couldn't fit structured JSON in 38K tokens. Investigation found artificial caps everywhere:

| Component | Before | After |
|-----------|--------|-------|
| Default token budget | 100K | **250K** |
| Failure analyst per case | 10K target, 30K max | **50K target, 100K max** |
| Overfitting reviewer | 10K + N×1.5K | **Full budget** |
| Expert synthesis | 10K + N×500 | **Full budget** |
| Full synthesis | 10K + N×500 | **Full budget** |
| Pipeline budget | 100K cap | **Full budget** |
| Refinement max | 10K | **50K** |
| Source excerpt | 4K chars | **32K chars** |
| Semantic fast-path | 10s timeout, 6K budget | **Full timeout, full budget** |

These limits were added as cost-saving measures during development but they throttle agent capability and cause truncation failures in production.

Relates to #28