### PR TITLE
fix(gym): generate proper Rust SourcePattern when applying proposals

### DIFF
--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -2055,16 +2055,28 @@ pub fn apply_accepted_proposals(cycle: &ImprovementCycle) -> anyhow::Result<usiz
         let content = std::fs::read_to_string(target)?;
 
         let new_content = if proposal.patch.find.is_empty() {
-            // Append mode: find the C/C++ pattern array end and insert before it.
-            // Look for the last `]` in the c_cpp_patterns() function.
+            // Append mode: generate a proper SourcePattern struct and insert
+            // before the closing `]` of the c_cpp_patterns() array.
             if let Some(insert_pos) = content.rfind("    ]\n}") {
+                let regex_str = &proposal.patch.replace;
+                let category = infer_danger_category(&proposal.target_cwes);
+                let reason = proposal
+                    .description
+                    .chars()
+                    .take(120)
+                    .collect::<String>()
+                    .replace('"', "'");
+
                 let mut result = content[..insert_pos].to_string();
                 result.push_str(&format!(
-                    "        // Self-improvement: {} (from case {})\n\
-                     {}\n",
-                    proposal.description.chars().take(60).collect::<String>(),
-                    proposal.source_case,
-                    proposal.patch.replace,
+                    "        // Self-improvement: from case {} (CWEs {:?})\n\
+                     \x20       SourcePattern {{\n\
+                     \x20           regex: r\"{regex_str}\",\n\
+                     \x20           category: DangerCategory::{category},\n\
+                     \x20           severity: Severity::High,\n\
+                     \x20           reason: \"{reason}\",\n\
+                     \x20       }},\n",
+                    proposal.source_case, proposal.target_cwes,
                 ));
                 result.push_str(&content[insert_pos..]);
                 result
@@ -2103,6 +2115,35 @@ pub fn apply_accepted_proposals(cycle: &ImprovementCycle) -> anyhow::Result<usiz
     }
 
     Ok(applied)
+}
+
+/// Infer the DangerCategory name from target CWE numbers.
+fn infer_danger_category(cwes: &[u32]) -> &'static str {
+    for &cwe in cwes {
+        match cwe {
+            78 | 77 | 643 | 90 => return "Injection",
+            119 | 120 | 121 | 122 | 125 | 787 => return "Memory",
+            134 => return "FormatString",
+            190 | 191 | 128 => return "IntegerOverflow",
+            416 | 415 => return "UseAfterFree",
+            476 | 252 => return "NullDeref",
+            22 | 23 | 36 => return "PathTraversal",
+            114 | 427 => return "UnsafeCode",
+            362 | 367 => return "Race",
+            377 => return "TempFile",
+            400 => return "ResourceExhaustion",
+            401 | 772 => return "ResourceLeak",
+            457 | 665 => return "UninitializedVar",
+            502 => return "Deserialization",
+            590 => return "InvalidFree",
+            843 => return "TypeConfusion",
+            272 | 284 => return "AccessControl",
+            226 | 534 => return "InformationExposure",
+            666 | 390 => return "ErrorHandling",
+            _ => continue,
+        }
+    }
+    "Memory" // safe default for unknown CWEs
 }
 
 /// Print improvement proposals in a human-readable format.


### PR DESCRIPTION
Applied proposals were raw regex strings. Now generates valid compilable `SourcePattern` structs with inferred `DangerCategory` from target CWEs.

21 improve tests pass, clippy clean.

Relates to #28