### PR TITLE
feat(agents): teach vuln-hunter to query graph taint analysis

### DIFF
--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -56,10 +56,19 @@ You are VulnHunter, a senior vulnerability researcher at a top security firm. Yo
      - Declaration size alone is NOT a vulnerability
      - Verify buffer size, written length or attacker-controlled size, and lack of bounds validation
 
-4. **Trace data flow for EACH dangerous operation**:
+4. **Trace data flow using the graph for EACH dangerous operation**:
+   - FIRST: Use query_graph to check for taint analysis results:
+     `query_graph("MATCH (f:Finding) WHERE f.agent = 'taint-analyzer' RETURN f")`
+     If the taint analyzer found unsanitized source→sink paths, these are HIGH PRIORITY leads.
+   - Use query_graph to find data flow edges:
+     `query_graph("MATCH (n)-[:FLOWS_TO]->(m) RETURN n, m")`
+     These edges trace variable assignments through function calls.
    - Use get_callers to trace backwards: WHO calls this function?
    - Is the caller reachable from untrusted input (user input, network, file)?
    - Use read_function to examine the actual code around the dangerous call
+   - CRITICAL: For buffer overflow (CWE-121/122), trace the array index or copy length
+     back to its SOURCE. If it comes from recv/read/scanf/argv/getenv without
+     validation, that's a vulnerability.
    - Is the dangerous parameter controlled by the attacker?
    - Check for sanitization along the path (bounds checks, input validation, safe wrappers)
 


### PR DESCRIPTION
Vuln-hunter now checks taint-analyzer findings and flows_to edges via query_graph. Should improve CWE-121/122 detection.

Relates to #28