### PR TITLE
fix: raise max_tokens to 128K (model max) for agent tool calling

### DIFF
--- a/crates/core/src/llm/traits.rs
+++ b/crates/core/src/llm/traits.rs
@@ -87,7 +87,7 @@ where
         return Ok("Analysis stopped: token budget exhausted.".into());
     }
 
-    let mut request = CreateMessageRequest::new(model, vec![Message::user(user_prompt)], 4096)
+    let mut request = CreateMessageRequest::new(model, vec![Message::user(user_prompt)], 128_000)
         .with_system(system_prompt.to_string());
 
     // Only set tools if non-empty — Anthropic API rejects empty tools arrays.


### PR DESCRIPTION
## Problem
`max_tokens` was set to 4096 (originally) then 16384 — both far too low for claude-opus-4.6 which supports 128K output tokens. This prevented agents from entering multi-turn tool calling loops because they'd exhaust their output budget on the first text response.

## Fix
Set `max_tokens` to 128,000 — the actual model maximum for claude-opus-4.6.

## Impact
Agents can now:
- Execute multi-turn tool calling (query_graph → read_function → recall_memory → create_finding)
- Leverage the graph infrastructure (tree-sitter flows, taint analysis)
- Use memory system (recall_memory tool)
- Actually create findings via create_finding tool

This is THE critical fix for transitioning from pattern-only to truly agentic vulnerability detection.