### PR TITLE
chore: update RustyClawd rev (runtime agents fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,7 +3034,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustyclawd-core"
 version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=916f321a10c9d5390eebe4273c9cb9e0c91d0c17#916f321a10c9d5390eebe4273c9cb9e0c91d0c17"
+source = "git+https://github.com/rysweet/RustyClawd?rev=8bf3b0745c67e108b874bcc0508fe351d72a6f8d#8bf3b0745c67e108b874bcc0508fe351d72a6f8d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3056,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "rustyclawd-tools"
 version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=916f321a10c9d5390eebe4273c9cb9e0c91d0c17#916f321a10c9d5390eebe4273c9cb9e0c91d0c17"
+source = "git+https://github.com/rysweet/RustyClawd?rev=8bf3b0745c67e108b874bcc0508fe351d72a6f8d#8bf3b0745c67e108b874bcc0508fe351d72a6f8d"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/rysweet/skwaq"
 [workspace.dependencies]
 # RustyClawd agent framework — pinned to a known-good main commit for reproducible builds.
 # To update: run `cargo update -p rustyclawd-core -p rustyclawd-tools -p rustyclawd-cli --precise <commit>`
-rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "916f321a10c9d5390eebe4273c9cb9e0c91d0c17" }
-rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "916f321a10c9d5390eebe4273c9cb9e0c91d0c17" }
-rustyclawd-cli = { git = "https://github.com/rysweet/RustyClawd", rev = "916f321a10c9d5390eebe4273c9cb9e0c91d0c17" }
+rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "8bf3b0745c67e108b874bcc0508fe351d72a6f8d" }
+rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "8bf3b0745c67e108b874bcc0508fe351d72a6f8d" }
+rustyclawd-cli = { git = "https://github.com/rysweet/RustyClawd", rev = "8bf3b0745c67e108b874bcc0508fe351d72a6f8d" }
 
 # Async
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Updates RustyClawd to include PR #601 (wire runtime agents to Task tool).