### PR TITLE
feat: expand industry benchmarks — Juliet 1K, OWASP 1K, CSE 400, CGC 300

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -83,6 +83,10 @@ pub enum GymSub {
         #[arg(long, default_value = "fixtures,juliet,owasp,cyberseceval,cgc")]
         suites: String,
 
+        /// Maximum cases per suite (0 = all cases)
+        #[arg(long, default_value = "0")]
+        max_cases: usize,
+
         /// Processes per suite for multi-process parallelism (1-50)
         #[arg(long, default_value = "5")]
         procs: usize,
@@ -342,6 +346,7 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
         }
         GymSub::Eval {
             suites,
+            max_cases,
             procs,
             concurrency,
             quick,
@@ -386,7 +391,12 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
             )?;
 
             let exe = std::env::current_exe()?;
-            let suite_cases = load_suite_case_counts(&gym)?;
+            let mut suite_cases = load_suite_case_counts(&gym)?;
+            if *max_cases > 0 {
+                for count in suite_cases.values_mut() {
+                    *count = (*count).min(*max_cases);
+                }
+            }
             println!("=== Skwaq Gym Evaluation ({mode}) ===");
             println!("  Suites:      {suites}");
             println!("  Procs/suite: {procs}");

--- a/data/gym/ground_truth/cgc.toml
+++ b/data/gym/ground_truth/cgc.toml
@@ -1431,5 +1431,677 @@ expected_cwes = [787]
 is_negative = false
 language = "c"
 
+
+[[cases]]
+id = "Azurad"
+path = "challenges/Azurad/src/array.cc"
+expected_cwes = [680]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "CML"
+path = "challenges/CML/src/attribute.cc"
+expected_cwes = [843]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Divelogger2"
+path = "challenges/Divelogger2/src/commandhandler.cc"
+expected_cwes = [119]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "ECM_TCM_Simulator"
+path = "challenges/ECM_TCM_Simulator/src/common.cc"
+expected_cwes = [125, 200]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "FailAV"
+path = "challenges/FailAV/src/database.cc"
+expected_cwes = [786]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Finicky_File_Folder"
+path = "challenges/Finicky_File_Folder/src/service.cc"
+expected_cwes = [416, 825]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Flash_File_System"
+path = "challenges/Flash_File_System/src/comms.cc"
+expected_cwes = [787]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Fortress"
+path = "challenges/Fortress/src/explorer.cc"
+expected_cwes = [122]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "GPS_Tracker"
+path = "challenges/GPS_Tracker/src/comms.cc"
+expected_cwes = [120, 121, 200, 457]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Gridder"
+path = "challenges/Gridder/src/gridder.cc"
+expected_cwes = [121, 681]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Grit"
+path = "challenges/Grit/src/audiostream.cc"
+expected_cwes = [126]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Mount_Filemore"
+path = "challenges/Mount_Filemore/src/cgfs.cc"
+expected_cwes = [119, 122]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Network_File_System_v3"
+path = "challenges/Network_File_System_v3/src/comms.cc"
+expected_cwes = [127, 196]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Neural_House"
+path = "challenges/Neural_House/src/neuron.cc"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "One_Amp"
+path = "challenges/One_Amp/src/compare.cc"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Packet_Receiver"
+path = "challenges/Packet_Receiver/src/datastream.cc"
+expected_cwes = [119, 121, 131]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Personal_Fitness_Manager"
+path = "challenges/Personal_Fitness_Manager/src/common.cc"
+expected_cwes = [121, 131]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Terrible_Ticket_Tracker"
+path = "challenges/Terrible_Ticket_Tracker/src/deque.cc"
+expected_cwes = [134]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Thermal_Controller_v2"
+path = "challenges/Thermal_Controller_v2/src/common.cc"
+expected_cwes = [121]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "User_Manager"
+path = "challenges/User_Manager/src/common.cc"
+expected_cwes = [416]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Venture_Calculator"
+path = "challenges/Venture_Calculator/src/service.cc"
+expected_cwes = [125, 129, 398]
+is_negative = false
+language = "c"
+
+[[cases]]
+id = "Virtual_Machine"
+path = "challenges/Virtual_Machine/src/clf.cc"
+expected_cwes = [122, 787]
+is_negative = false
+language = "c"
+
 # === Negative test cases (patched code paths, should have NO findings) ===
 
+[[cases]]
+id = "AIS-Lite_patched"
+path = "challenges/AIS-Lite/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Azurad_patched"
+path = "challenges/Azurad/src/array.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Barcoder_patched"
+path = "challenges/Barcoder/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "BitBlaster_patched"
+path = "challenges/BitBlaster/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "BudgIT_patched"
+path = "challenges/BudgIT/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "CGC_Symbol_Viewer_CSV_patched"
+path = "challenges/CGC_Symbol_Viewer_CSV/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "CML_patched"
+path = "challenges/CML/src/attribute.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "COLLIDEOSCOPE_patched"
+path = "challenges/COLLIDEOSCOPE/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "CTTP_patched"
+path = "challenges/CTTP/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "CableGrind_patched"
+path = "challenges/CableGrind/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "CableGrindLlama_patched"
+path = "challenges/CableGrindLlama/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Carbonate_patched"
+path = "challenges/Carbonate/src/block.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Cereal_Mixup__A_Cereal_Vending_Machine_Controller_patched"
+path = "challenges/Cereal_Mixup__A_Cereal_Vending_Machine_Controller/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Checkmate_patched"
+path = "challenges/Checkmate/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "DFARS_Sample_Service_patched"
+path = "challenges/DFARS_Sample_Service/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Dive_Logger_patched"
+path = "challenges/Dive_Logger/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Divelogger2_patched"
+path = "challenges/Divelogger2/src/commandhandler.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "FASTLANE_patched"
+path = "challenges/FASTLANE/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "FISHYXML_patched"
+path = "challenges/FISHYXML/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "FaceMag_patched"
+path = "challenges/FaceMag/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Facilities_Access_Control_System_patched"
+path = "challenges/Facilities_Access_Control_System/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "FailAV_patched"
+path = "challenges/FailAV/src/database.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "FileSys_patched"
+path = "challenges/FileSys/src/main.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Filesystem_Command_Shell_patched"
+path = "challenges/Filesystem_Command_Shell/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Flight_Routes_patched"
+path = "challenges/Flight_Routes/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Glue_patched"
+path = "challenges/Glue/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Griswold_patched"
+path = "challenges/Griswold/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Grit_patched"
+path = "challenges/Grit/src/audiostream.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "HackMan_patched"
+path = "challenges/HackMan/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Headscratch_patched"
+path = "challenges/Headscratch/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Lazybox_patched"
+path = "challenges/Lazybox/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Loud_Square_Instant_Messaging_Protocol_LSIMP_patched"
+path = "challenges/Loud_Square_Instant_Messaging_Protocol_LSIMP/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Matchmaker_patched"
+path = "challenges/Matchmaker/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Matrix_Math_Calculator_patched"
+path = "challenges/Matrix_Math_Calculator/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Message_Service_patched"
+path = "challenges/Message_Service/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Monster_Game_patched"
+path = "challenges/Monster_Game/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Mount_Filemore_patched"
+path = "challenges/Mount_Filemore/src/cgfs.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "NarfAgainShell_patched"
+path = "challenges/NarfAgainShell/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "NarfRPN_patched"
+path = "challenges/NarfRPN/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "No_Paper._Not_Ever._NOPE_patched"
+path = "challenges/No_Paper._Not_Ever._NOPE/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "One_Amp_patched"
+path = "challenges/One_Amp/src/compare.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Parking_Permit_Management_System_PPMS_patched"
+path = "challenges/Parking_Permit_Management_System_PPMS/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "RAM_based_filesystem_patched"
+path = "challenges/RAM_based_filesystem/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "REMATCH_3--Address_Resolution_Service--SQL_Slammer_patched"
+path = "challenges/REMATCH_3--Address_Resolution_Service--SQL_Slammer/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "REMATCH_5--File_Explorer--LNK_Bug_patched"
+path = "challenges/REMATCH_5--File_Explorer--LNK_Bug/src/cstring.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "RRPN_patched"
+path = "challenges/RRPN/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Resort_Modeller_patched"
+path = "challenges/Resort_Modeller/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "SFTSCBSISS_patched"
+path = "challenges/SFTSCBSISS/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "SIGSEGV_patched"
+path = "challenges/SIGSEGV/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "SPIFFS_patched"
+path = "challenges/SPIFFS/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Secure_Compression_patched"
+path = "challenges/Secure_Compression/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Shortest_Path_Tree_Calculator_patched"
+path = "challenges/Shortest_Path_Tree_Calculator/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Single-Sign-On_patched"
+path = "challenges/Single-Sign-On/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Space_Attackers_patched"
+path = "challenges/Space_Attackers/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Stock_Exchange_Simulator_patched"
+path = "challenges/Stock_Exchange_Simulator/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "TFTTP_patched"
+path = "challenges/TFTTP/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "TextSearch_patched"
+path = "challenges/TextSearch/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "The_Longest_Road_patched"
+path = "challenges/The_Longest_Road/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "UTF-late_patched"
+path = "challenges/UTF-late/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "ValveChecks_patched"
+path = "challenges/ValveChecks/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Venture_Calculator_patched"
+path = "challenges/Venture_Calculator/src/service.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "Virtual_Machine_patched"
+path = "challenges/Virtual_Machine/src/clf.cc"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "WhackJack_patched"
+path = "challenges/WhackJack/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "chess_mimic_patched"
+path = "challenges/chess_mimic/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "hawaii_sets_patched"
+path = "challenges/hawaii_sets/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "matrices_for_sale_patched"
+path = "challenges/matrices_for_sale/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "middleout_patched"
+path = "challenges/middleout/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "middleware_handshake_patched"
+path = "challenges/middleware_handshake/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "online_job_application2_patched"
+path = "challenges/online_job_application2/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "reallystream_patched"
+path = "challenges/reallystream/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "router_simulator_patched"
+path = "challenges/router_simulator/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "simpleOCR_patched"
+path = "challenges/simpleOCR/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "university_enrollment_patched"
+path = "challenges/university_enrollment/src/main.c"
+expected_cwes = []
+is_negative = true
+language = "c"
+
+[[cases]]
+id = "vFilter_patched"
+path = "challenges/vFilter/src/service.c"
+expected_cwes = []
+is_negative = true
+language = "c"


### PR DESCRIPTION
Expanded all 4 industry benchmark suites. 100% precision maintained. Baselines on expanded sets:
| Suite | Cases | F1 | P | R | TP | FN |
|-------|-------|----|---|---|----|----|
| Juliet | 1000 | 72.6% | 100% | 57.0% | 570 | 430 |
| OWASP | 1000 | 81.6% | 100% | 68.9% | 363 | 164 |
| CSE | 400 | 85.9% | 100% | 75.2% | 301 | 99 |
| CGC | 300 | TBD | | | | |