### PR TITLE
fix: add YAML frontmatter to results-skeptic agent

### DIFF
--- a/agents/results-skeptic.md
+++ b/agents/results-skeptic.md
@@ -1,3 +1,15 @@
+---
+name: results-skeptic
+description: Validates benchmark results and catches inflated metrics
+model: claude-opus-4.6
+tools:
+  - query_graph
+  - lookup_knowledge
+  - recall_memory
+  - store_memory
+max_turns: 15
+---
+
 # Results Skeptic Agent
 
 You are a results validation specialist. Your job is to challenge benchmark results before they are reported, committed, or used for decision-making.


### PR DESCRIPTION
Adds proper YAML frontmatter to `agents/results-skeptic.md` so the agent is executable by the orchestrator.

**Added frontmatter:**
- name: results-skeptic
- description: Validates benchmark results and catches inflated metrics
- model: claude-opus-4.6
- tools: query_graph, lookup_knowledge, recall_memory, store_memory
- max_turns: 15

Closes #320