### PR TITLE
docs: remove (No LLM) from baselines table heading

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -231,7 +231,7 @@ flowchart TB
             <tr><td>Fixtures</td><td>skwaq team</td><td>99</td><td>Mixed</td><td>Regression suite</td></tr>
         </table>
 
-        <h3>Current Baselines &mdash; Pattern+Dataflow Mode (No LLM)</h3>
+        <h3>Current Baselines &mdash; Pattern+Dataflow Mode</h3>
         <table>
             <tr><th>Suite</th><th>Cases</th><th>F1</th><th>Precision</th><th>Recall</th><th>TP</th><th>FP</th><th>FN</th><th>TN</th></tr>
             <tr><td>Fixtures</td><td>99</td><td class="highlight">93.2%</td><td>98.0%</td><td>88.8%</td><td>103</td><td>2</td><td>13</td><td>11</td></tr>


### PR DESCRIPTION
## Summary
- Remove "(No LLM)" from the Current Baselines heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)