### PR TITLE
docs: add hero image to landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,6 +43,10 @@
         <h1>Skwaq</h1>
         <p class="subtitle">A self-improving, multi-agent vulnerability analyzer that bootstrapped from a short spec into a competitive detection system &mdash; using AI agents to analyze, benchmark, and improve their own investigation methodology.</p>
 
+        <div style="text-align:center; margin: 1.5rem 0;">
+            <img src="https://github.com/user-attachments/assets/8213c8c0-6138-4690-929a-9675a0584c6a" alt="Skwaq — multi-agent vulnerability analyzer" style="max-width:480px; width:100%; border-radius:12px; border:1px solid #21262d;">
+        </div>
+
         <div class="nav">
             <a href="#what">What It Is</a>
             <a href="#story">The Story</a>


### PR DESCRIPTION
Adds the image from #338, sized to 480px max-width. Closes #338.