### PR TITLE
feat: add LadybugDB graph database backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +453,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,7 +496,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -493,7 +509,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -648,6 +664,65 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3956d60afa98653c5a57f60d7056edd513bfe0307ef6fb06f6167400c3884459"
+dependencies = [
+ "cc",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4b7522f539fe056f1d6fc8577d8ab731451f6f33a89b1e5912e22b76c553e7"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f01e92ab4ce9fd4d16e3bb11b158d98cbdcca803c1417aa43130a6526fbf208"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c41cbfab344869e70998b388923f7d1266588f56c8ca284abf259b1c1ffc695"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d82a2f759f0ad3eae43b96604efd42b1d4729a35a6f2dc7bdb797ae25d9284"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -1611,7 +1686,7 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -1742,6 +1817,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "lbug"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9481fd9420d4924d871840f54b473dd99b221e52d9e64957bc5f6f09cf50865"
+dependencies = [
+ "cmake",
+ "cxx",
+ "cxx-build",
+ "rust_decimal",
+ "rustversion",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1910,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2930,6 +3029,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,6 +3234,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "scroll"
@@ -3419,6 +3534,7 @@ dependencies = [
  "chrono",
  "dirs",
  "goblin",
+ "lbug",
  "libc",
  "regex",
  "reqwest 0.12.28",
@@ -3679,6 +3795,15 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4080,6 +4205,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -114,6 +114,11 @@ pub enum GymSub {
         /// Output directory for results
         #[arg(long)]
         output: Option<PathBuf>,
+
+        /// Create a git tag and GitHub release with the eval results.
+        /// Tag format: eval-YYYY-MM-DD[-vN] (auto-increments if date already exists).
+        #[arg(long)]
+        tag: bool,
     },
 
     /// Run self-improvement loop: analyze failures and propose fixes
@@ -359,6 +364,7 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
             llm_only,
             adaptive,
             output,
+            tag,
         } => {
             let mode = if *quick {
                 "pattern-only"
@@ -643,6 +649,84 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
             println!("Metadata: {}", eval_dir.join("metadata.json").display());
             println!("Summary: {}", eval_dir.join("summary.md").display());
             println!("Dashboard: {}", eval_dir.join("dashboard.md").display());
+
+            if *tag {
+                println!();
+                println!("=== Tagging ===");
+                let tag_name = skwaq_gym::tagging::next_tag_name(&skwaq_root)?;
+
+                // Collect per-CWE results across all suites for the tag payload
+                let mut all_cwe_tag_results = Vec::new();
+                for suite_name in &suite_list {
+                    let suite_dir = eval_dir.join(suite_name);
+                    let shard_count = suite_shards.get(*suite_name).copied().unwrap_or(1);
+                    if let Ok(reports) = load_shard_reports(suite_name, &suite_dir, shard_count) {
+                        for report in &reports {
+                            for cwe in &report.per_cwe {
+                                all_cwe_tag_results.push(skwaq_gym::tagging::CweTagResult {
+                                    suite: suite_name.to_string(),
+                                    cwe_id: cwe.cwe_id,
+                                    total_cases: cwe.total_cases,
+                                    true_positives: cwe.true_positives,
+                                    false_positives: cwe.false_positives,
+                                    false_negatives: cwe.false_negatives,
+                                    detection_rate: cwe.detection_rate,
+                                    precision: cwe.precision,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                let payload = skwaq_gym::tagging::EvalTagPayload {
+                    tag_name: tag_name.clone(),
+                    commit: eval_metadata.git_commit.clone(),
+                    timestamp: eval_metadata.started_at.clone(),
+                    mode: eval_metadata.mode.clone(),
+                    suites: eval_metadata.suites.clone(),
+                    procs_per_suite: eval_metadata.procs_per_suite,
+                    concurrency: eval_metadata.concurrency,
+                    llm_backend: eval_metadata.llm_backend.clone(),
+                    llm_model: eval_metadata.llm_model.clone(),
+                    binary_mode: eval_metadata.binary_mode,
+                    skwaq_version: eval_metadata.skwaq_version.clone(),
+                    git_dirty: eval_metadata.git_dirty,
+                    suite_results: summaries
+                        .iter()
+                        .map(|s| skwaq_gym::tagging::SuiteTagResult {
+                            suite: s.suite.clone(),
+                            f1: s.f1,
+                            precision: s.precision,
+                            recall: s.recall,
+                            true_positives: s.true_positives,
+                            false_positives: s.false_positives,
+                            false_negatives: s.false_negatives,
+                            true_negatives: s.true_negatives,
+                        })
+                        .collect(),
+                    per_cwe: all_cwe_tag_results,
+                    reproducible_command: skwaq_gym::tagging::build_reproducible_command(
+                        suites,
+                        *max_cases,
+                        *procs,
+                        *concurrency,
+                        *quick,
+                        *llm_only,
+                        *adaptive,
+                    ),
+                };
+
+                let results_json = eval_dir.join("summary.json");
+                match skwaq_gym::tagging::tag_eval_results(&skwaq_root, &payload, &results_json) {
+                    Ok(created_tag) => {
+                        println!("  Tag created: {}", created_tag);
+                    }
+                    Err(e) => {
+                        eprintln!("WARNING: Tagging failed: {}", e);
+                        eprintln!("  Results are still saved in: {}", eval_dir.display());
+                    }
+                }
+            }
         }
         GymSub::Improve {
             suite,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,6 +27,7 @@ regex = "1"
 serde_yaml_ng = "0.10"
 tree-sitter = "0.24"
 tree-sitter-c = "0.23"
+lbug = "0.15.2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/core/src/graph/ladybug_db.rs
+++ b/crates/core/src/graph/ladybug_db.rs
@@ -1,0 +1,182 @@
+//! LadybugDB graph database backend for the code property graph.
+//!
+//! Provides native Cypher queries for graph traversals, replacing the
+//! SQLite recursive CTEs and Cypher→SQL translator. LadybugDB (formerly
+//! Kuzu) is an embeddable property graph database optimized for complex
+//! analytical workloads on large graphs.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// LadybugDB-backed graph database.
+pub struct LadybugGraphDb {
+    db: Arc<lbug::Database>,
+    #[allow(dead_code)] // Used in Phase 2 for db path discovery
+    path: PathBuf,
+}
+
+impl LadybugGraphDb {
+    /// Open or create a LadybugDB database at the given path.
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(path)?;
+        let db_path = path.join("skwaq_graph");
+        let db = Arc::new(
+            lbug::Database::new(&db_path, lbug::SystemConfig::default())
+                .map_err(|e| anyhow::anyhow!("Failed to open LadybugDB: {e}"))?,
+        );
+        let gdb = Self { db, path: db_path };
+        gdb.ensure_schema()?;
+        Ok(gdb)
+    }
+
+    /// Create a temporary LadybugDB database (for tests).
+    pub fn in_memory() -> anyhow::Result<Self> {
+        let tmp = tempfile::tempdir()?;
+        let db_path = tmp.path().join("ladybug_test");
+        let db = Arc::new(
+            lbug::Database::new(&db_path, lbug::SystemConfig::default())
+                .map_err(|e| anyhow::anyhow!("Failed to open LadybugDB: {e}"))?,
+        );
+        let gdb = Self { db, path: db_path };
+        gdb.ensure_schema()?;
+        std::mem::forget(tmp);
+        Ok(gdb)
+    }
+
+    fn conn(&self) -> anyhow::Result<lbug::Connection<'_>> {
+        lbug::Connection::new(&self.db)
+            .map_err(|e| anyhow::anyhow!("Failed to create connection: {e}"))
+    }
+
+    /// Execute a Cypher query and return all rows.
+    pub fn query(&self, cypher: &str) -> anyhow::Result<Vec<Vec<lbug::Value>>> {
+        let conn = self.conn()?;
+        let result = conn
+            .query(cypher)
+            .map_err(|e| anyhow::anyhow!("Query failed: {e}\nCypher: {cypher}"))?;
+        Ok(result.collect())
+    }
+
+    /// Execute a Cypher statement (no results needed).
+    pub fn execute(&self, cypher: &str) -> anyhow::Result<()> {
+        self.conn()?
+            .query(cypher)
+            .map_err(|e| anyhow::anyhow!("Execute failed: {e}\nCypher: {cypher}"))?;
+        Ok(())
+    }
+
+    /// Extract a string from a Value.
+    pub fn as_str(val: &lbug::Value) -> Option<&str> {
+        match val {
+            lbug::Value::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Extract an i64 from a Value.
+    pub fn as_i64(val: &lbug::Value) -> Option<i64> {
+        match val {
+            lbug::Value::Int64(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Create the graph schema.
+    fn ensure_schema(&self) -> anyhow::Result<()> {
+        let stmts = [
+            // Node tables
+            "CREATE NODE TABLE IF NOT EXISTS Function(id STRING PRIMARY KEY, name STRING, address STRING DEFAULT '', decompiled STRING DEFAULT '', confidence DOUBLE DEFAULT 0.0, language STRING DEFAULT '', is_reconstructed INT64 DEFAULT 0, investigation_id STRING DEFAULT '', parameter_count INT64 DEFAULT 0)",
+            "CREATE NODE TABLE IF NOT EXISTS DataSource(id STRING PRIMARY KEY, name STRING, source_type STRING DEFAULT '', location STRING DEFAULT '', investigation_id STRING DEFAULT '')",
+            "CREATE NODE TABLE IF NOT EXISTS DataSink(id STRING PRIMARY KEY, name STRING, sink_type STRING DEFAULT '', danger_level STRING DEFAULT 'medium', location STRING DEFAULT '', investigation_id STRING DEFAULT '')",
+            "CREATE NODE TABLE IF NOT EXISTS Symbol(id STRING PRIMARY KEY, name STRING, address STRING DEFAULT '', symbol_type STRING DEFAULT '', binding STRING DEFAULT '', investigation_id STRING DEFAULT '')",
+            "CREATE NODE TABLE IF NOT EXISTS Finding(id STRING PRIMARY KEY, title STRING DEFAULT '', evidence STRING DEFAULT '', agent STRING DEFAULT '', timestamp STRING DEFAULT '', investigation_id STRING DEFAULT '', status STRING DEFAULT 'new', cycle_discovered INT64 DEFAULT 0, cycle_last_updated INT64 DEFAULT 0, severity STRING DEFAULT '', category STRING DEFAULT '')",
+            "CREATE NODE TABLE IF NOT EXISTS StringLiteral(id STRING PRIMARY KEY, value STRING DEFAULT '', offset STRING DEFAULT '', investigation_id STRING DEFAULT '')",
+            "CREATE NODE TABLE IF NOT EXISTS Investigation(id STRING PRIMARY KEY, name STRING DEFAULT '', target STRING DEFAULT '', status STRING DEFAULT '', created_at STRING DEFAULT '', updated_at STRING DEFAULT '')",
+            // Relationship tables
+            "CREATE REL TABLE IF NOT EXISTS CALLS(FROM Function TO Function)",
+            "CREATE REL TABLE IF NOT EXISTS TAINT_FLOW(FROM DataSource TO DataSink, path STRING DEFAULT '', sanitized INT64 DEFAULT 0)",
+            "CREATE REL TABLE IF NOT EXISTS FLOWS_TO(FROM Function TO Function, flow_type STRING DEFAULT '')",
+            "CREATE REL TABLE IF NOT EXISTS HAS_SOURCE(FROM Function TO DataSource)",
+            "CREATE REL TABLE IF NOT EXISTS HAS_SINK(FROM Function TO DataSink)",
+            "CREATE REL TABLE IF NOT EXISTS REFERENCES_STRING(FROM Function TO StringLiteral)",
+        ];
+
+        for ddl in &stmts {
+            if let Err(e) = self.execute(ddl) {
+                if !e.to_string().contains("already exists") {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_open_and_schema() {
+        let db = LadybugGraphDb::in_memory().unwrap();
+        let rows = db.query("MATCH (n:Function) RETURN count(n)").unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn test_insert_and_query() {
+        let db = LadybugGraphDb::in_memory().unwrap();
+        db.execute("CREATE (f:Function {id: 'fn1', name: 'main', address: '0x1000'})")
+            .unwrap();
+        let rows = db
+            .query("MATCH (f:Function {id: 'fn1'}) RETURN f.name")
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(LadybugGraphDb::as_str(&rows[0][0]), Some("main"));
+    }
+
+    #[test]
+    fn test_call_graph_traversal() {
+        let db = LadybugGraphDb::in_memory().unwrap();
+        db.execute("CREATE (f:Function {id: 'main', name: 'main'})")
+            .unwrap();
+        db.execute("CREATE (f:Function {id: 'helper', name: 'helper'})")
+            .unwrap();
+        db.execute("CREATE (f:Function {id: 'sink', name: 'dangerous_sink'})")
+            .unwrap();
+        db.execute(
+            "MATCH (a:Function {id: 'main'}), (b:Function {id: 'helper'}) CREATE (a)-[:CALLS]->(b)",
+        )
+        .unwrap();
+        db.execute(
+            "MATCH (a:Function {id: 'helper'}), (b:Function {id: 'sink'}) CREATE (a)-[:CALLS]->(b)",
+        )
+        .unwrap();
+
+        // Native Cypher variable-length path — replaces recursive CTEs
+        let rows = db
+            .query("MATCH (s:Function {id: 'main'})-[:CALLS*1..5]->(t:Function) RETURN t.name")
+            .unwrap();
+        let names: Vec<&str> = rows
+            .iter()
+            .filter_map(|r| LadybugGraphDb::as_str(&r[0]))
+            .collect();
+        assert!(names.contains(&"helper"));
+        assert!(names.contains(&"dangerous_sink"));
+    }
+
+    #[test]
+    fn test_taint_flow() {
+        let db = LadybugGraphDb::in_memory().unwrap();
+        db.execute("CREATE (s:DataSource {id: 'src1', name: 'recv', source_type: 'network'})")
+            .unwrap();
+        db.execute("CREATE (k:DataSink {id: 'sink1', name: 'strcpy', danger_level: 'critical'})")
+            .unwrap();
+        db.execute("MATCH (s:DataSource {id: 'src1'}), (k:DataSink {id: 'sink1'}) CREATE (s)-[:TAINT_FLOW {path: 'recv -> strcpy', sanitized: 0}]->(k)").unwrap();
+
+        let rows = db.query("MATCH (s:DataSource)-[t:TAINT_FLOW]->(k:DataSink) WHERE t.sanitized = 0 RETURN s.name, k.name, t.path").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(LadybugGraphDb::as_str(&rows[0][0]), Some("recv"));
+        assert_eq!(LadybugGraphDb::as_str(&rows[0][1]), Some("strcpy"));
+    }
+}

--- a/crates/core/src/graph/mod.rs
+++ b/crates/core/src/graph/mod.rs
@@ -8,9 +8,11 @@ pub mod builder_binary;
 pub mod builder_ghidra;
 pub mod builder_source;
 pub mod db;
+pub mod ladybug_db;
 pub mod queries;
 pub mod types;
 
 pub use builder::{GhidraInsertCounts, GraphBuilder, InsertCounts, SourceInsertCounts};
 pub use db::GraphDb;
+pub use ladybug_db::LadybugGraphDb;
 pub use types::{NodeLabel, RelationshipType};

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -13,6 +13,7 @@ pub mod improve;
 pub mod reporting;
 pub mod scoring;
 pub mod shared_throttle;
+pub mod tagging;
 pub mod throttle;
 
 use futures::stream::{FuturesUnordered, StreamExt};

--- a/crates/gym/src/tagging.rs
+++ b/crates/gym/src/tagging.rs
@@ -1,0 +1,411 @@
+//! Eval result tagging: create git tags and GitHub releases from eval results.
+
+use anyhow::{bail, Context};
+use serde::Serialize;
+use std::path::Path;
+
+/// All data needed to create an eval release tag.
+#[derive(Debug, Clone, Serialize)]
+pub struct EvalTagPayload {
+    pub tag_name: String,
+    pub commit: String,
+    pub timestamp: String,
+    pub mode: String,
+    pub suites: String,
+    pub procs_per_suite: usize,
+    pub concurrency: usize,
+    pub llm_backend: String,
+    pub llm_model: String,
+    pub binary_mode: bool,
+    pub skwaq_version: String,
+    pub git_dirty: bool,
+    pub suite_results: Vec<SuiteTagResult>,
+    pub per_cwe: Vec<CweTagResult>,
+    pub reproducible_command: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SuiteTagResult {
+    pub suite: String,
+    pub f1: f64,
+    pub precision: f64,
+    pub recall: f64,
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub true_negatives: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CweTagResult {
+    pub suite: String,
+    pub cwe_id: u32,
+    pub total_cases: u32,
+    pub true_positives: u32,
+    pub false_positives: u32,
+    pub false_negatives: u32,
+    pub detection_rate: f64,
+    pub precision: f64,
+}
+
+/// Compute the next available tag name for today (eval-YYYY-MM-DD or eval-YYYY-MM-DD-vN).
+pub fn next_tag_name(repo: &Path) -> anyhow::Result<String> {
+    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let prefix = format!("eval-{}", today);
+
+    let output = std::process::Command::new("git")
+        .args(["tag", "--list", &format!("{}*", prefix)])
+        .current_dir(repo)
+        .output()
+        .context("failed to list git tags")?;
+
+    if !output.status.success() {
+        bail!(
+            "git tag --list failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let existing: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if existing.is_empty() {
+        return Ok(prefix);
+    }
+
+    // Find the highest version number
+    let mut max_version = 0u32;
+    for tag in &existing {
+        if tag == &prefix {
+            max_version = max_version.max(1);
+        } else if let Some(suffix) = tag.strip_prefix(&format!("{}-v", prefix)) {
+            if let Ok(v) = suffix.parse::<u32>() {
+                max_version = max_version.max(v);
+            }
+        }
+    }
+
+    Ok(format!("{}-v{}", prefix, max_version + 1))
+}
+
+/// Render the release body as markdown.
+pub fn render_release_body(payload: &EvalTagPayload) -> String {
+    let mut body = String::new();
+
+    body.push_str("# Skwaq Gym Eval Results\n\n");
+
+    // Metadata
+    body.push_str("## Metadata\n\n");
+    body.push_str(&format!("- **Commit**: `{}`\n", payload.commit));
+    body.push_str(&format!("- **Timestamp**: {}\n", payload.timestamp));
+    body.push_str(&format!("- **Mode**: {}\n", payload.mode));
+    body.push_str(&format!("- **Suites**: {}\n", payload.suites));
+    body.push_str(&format!("- **Procs/suite**: {}\n", payload.procs_per_suite));
+    body.push_str(&format!("- **Concurrency**: {}\n", payload.concurrency));
+    body.push_str(&format!("- **LLM backend**: {}\n", payload.llm_backend));
+    body.push_str(&format!("- **LLM model**: {}\n", payload.llm_model));
+    body.push_str(&format!("- **Binary mode**: {}\n", payload.binary_mode));
+    body.push_str(&format!("- **Version**: {}\n", payload.skwaq_version));
+    body.push_str(&format!("- **Git dirty**: {}\n", payload.git_dirty));
+
+    // Results table
+    body.push_str("\n## Results\n\n");
+    body.push_str("| Suite | F1 | Precision | Recall | TP | FP | FN | TN |\n");
+    body.push_str("|-------|----|-----------|--------|----|----|----|----|----|\n");
+    for s in &payload.suite_results {
+        body.push_str(&format!(
+            "| {} | {:.1}% | {:.1}% | {:.1}% | {} | {} | {} | {} |\n",
+            s.suite,
+            s.f1 * 100.0,
+            s.precision * 100.0,
+            s.recall * 100.0,
+            s.true_positives,
+            s.false_positives,
+            s.false_negatives,
+            s.true_negatives,
+        ));
+    }
+
+    // Per-CWE breakdown
+    if !payload.per_cwe.is_empty() {
+        body.push_str("\n## Per-CWE Breakdown\n\n");
+        body.push_str("| Suite | CWE | Cases | TP | FP | FN | Detection | Precision |\n");
+        body.push_str("|-------|-----|-------|----|----|----|-----------|----------|\n");
+        for c in &payload.per_cwe {
+            body.push_str(&format!(
+                "| {} | CWE-{} | {} | {} | {} | {} | {:.1}% | {:.1}% |\n",
+                c.suite,
+                c.cwe_id,
+                c.total_cases,
+                c.true_positives,
+                c.false_positives,
+                c.false_negatives,
+                c.detection_rate * 100.0,
+                c.precision * 100.0,
+            ));
+        }
+    }
+
+    // Reproducible command
+    body.push_str("\n## Reproduce\n\n");
+    body.push_str("```bash\n");
+    body.push_str(&payload.reproducible_command);
+    body.push_str("\n```\n");
+
+    body
+}
+
+/// Create a git tag at the current HEAD.
+pub fn create_git_tag(repo: &Path, tag_name: &str, message: &str) -> anyhow::Result<()> {
+    let output = std::process::Command::new("git")
+        .args(["tag", "-a", tag_name, "-m", message])
+        .current_dir(repo)
+        .output()
+        .context("failed to create git tag")?;
+
+    if !output.status.success() {
+        bail!(
+            "git tag failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Push the tag to origin.
+pub fn push_tag(repo: &Path, tag_name: &str) -> anyhow::Result<()> {
+    let output = std::process::Command::new("git")
+        .args(["push", "origin", tag_name])
+        .current_dir(repo)
+        .output()
+        .context("failed to push git tag")?;
+
+    if !output.status.success() {
+        bail!(
+            "git push tag failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Create a GitHub release using `gh release create`.
+/// Attaches the results JSON as an asset.
+pub fn create_github_release(
+    repo: &Path,
+    tag_name: &str,
+    title: &str,
+    body: &str,
+    assets: &[&Path],
+) -> anyhow::Result<()> {
+    let mut cmd = std::process::Command::new("gh");
+    cmd.args(["release", "create", tag_name])
+        .args(["--title", title])
+        .args(["--notes", body])
+        .current_dir(repo);
+
+    for asset in assets {
+        cmd.arg(asset);
+    }
+
+    let output = cmd.output().context("failed to run gh release create")?;
+
+    if !output.status.success() {
+        bail!(
+            "gh release create failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Build the reproducible command string from eval parameters.
+pub fn build_reproducible_command(
+    suites: &str,
+    max_cases: usize,
+    procs: usize,
+    concurrency: usize,
+    quick: bool,
+    llm_only: bool,
+    adaptive: bool,
+) -> String {
+    let mut cmd = format!(
+        "skwaq gym eval --suites {} --procs {} -j {}",
+        suites, procs, concurrency
+    );
+    if max_cases > 0 {
+        cmd.push_str(&format!(" --max-cases {}", max_cases));
+    }
+    if quick {
+        cmd.push_str(" --quick");
+    } else if llm_only {
+        cmd.push_str(" --llm-only");
+    }
+    if adaptive {
+        cmd.push_str(" --adaptive");
+    }
+    cmd.push_str(" --tag");
+    cmd
+}
+
+/// Full tagging workflow: create tag, push, create GitHub release with assets.
+pub fn tag_eval_results(
+    repo: &Path,
+    payload: &EvalTagPayload,
+    results_json_path: &Path,
+) -> anyhow::Result<String> {
+    let tag_name = &payload.tag_name;
+
+    // Write the full payload JSON next to the results
+    let payload_path = results_json_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join("eval-tag-payload.json");
+    std::fs::write(&payload_path, serde_json::to_string_pretty(payload)?)?;
+
+    // Create annotated git tag
+    let tag_message = format!(
+        "Eval results: {} mode={} F1=[{}]",
+        payload.suites,
+        payload.mode,
+        payload
+            .suite_results
+            .iter()
+            .map(|s| format!("{}={:.1}%", s.suite, s.f1 * 100.0))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    create_git_tag(repo, tag_name, &tag_message)?;
+    println!("  Created git tag: {}", tag_name);
+
+    // Push tag
+    push_tag(repo, tag_name)?;
+    println!("  Pushed tag to origin");
+
+    // Create GitHub release with assets
+    let title = format!(
+        "Eval {} — {}",
+        payload.mode,
+        payload
+            .suite_results
+            .iter()
+            .map(|s| format!("{} F1={:.1}%", s.suite, s.f1 * 100.0))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let body = render_release_body(payload);
+    let assets: Vec<&Path> = vec![results_json_path, &payload_path];
+    create_github_release(repo, tag_name, &title, &body, &assets)?;
+    println!("  Created GitHub release: {}", tag_name);
+
+    Ok(tag_name.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_reproducible_command_hybrid() {
+        let cmd = build_reproducible_command("fixtures,juliet,owasp", 0, 5, 2, false, false, false);
+        assert_eq!(
+            cmd,
+            "skwaq gym eval --suites fixtures,juliet,owasp --procs 5 -j 2 --tag"
+        );
+    }
+
+    #[test]
+    fn test_build_reproducible_command_quick() {
+        let cmd = build_reproducible_command("fixtures", 100, 3, 1, true, false, true);
+        assert_eq!(
+            cmd,
+            "skwaq gym eval --suites fixtures --procs 3 -j 1 --max-cases 100 --quick --adaptive --tag"
+        );
+    }
+
+    #[test]
+    fn test_build_reproducible_command_llm_only() {
+        let cmd = build_reproducible_command("juliet", 50, 2, 4, false, true, false);
+        assert_eq!(
+            cmd,
+            "skwaq gym eval --suites juliet --procs 2 -j 4 --max-cases 50 --llm-only --tag"
+        );
+    }
+
+    #[test]
+    fn test_render_release_body_contains_sections() {
+        let payload = EvalTagPayload {
+            tag_name: "eval-2026-03-26".to_string(),
+            commit: "abc123".to_string(),
+            timestamp: "2026-03-26T00:00:00Z".to_string(),
+            mode: "pattern-only".to_string(),
+            suites: "fixtures".to_string(),
+            procs_per_suite: 1,
+            concurrency: 2,
+            llm_backend: "copilot".to_string(),
+            llm_model: "claude-opus-4.6".to_string(),
+            binary_mode: true,
+            skwaq_version: "0.1.0".to_string(),
+            git_dirty: false,
+            suite_results: vec![SuiteTagResult {
+                suite: "fixtures".to_string(),
+                f1: 0.6,
+                precision: 0.75,
+                recall: 0.5,
+                true_positives: 3,
+                false_positives: 1,
+                false_negatives: 3,
+                true_negatives: 7,
+            }],
+            per_cwe: vec![CweTagResult {
+                suite: "fixtures".to_string(),
+                cwe_id: 121,
+                total_cases: 6,
+                true_positives: 3,
+                false_positives: 1,
+                false_negatives: 3,
+                detection_rate: 0.5,
+                precision: 0.75,
+            }],
+            reproducible_command: "skwaq gym eval --suites fixtures --procs 1 -j 2 --quick --tag"
+                .to_string(),
+        };
+
+        let body = render_release_body(&payload);
+        assert!(body.contains("# Skwaq Gym Eval Results"));
+        assert!(body.contains("## Metadata"));
+        assert!(body.contains("abc123"));
+        assert!(body.contains("## Results"));
+        assert!(body.contains("fixtures"));
+        assert!(body.contains("## Per-CWE Breakdown"));
+        assert!(body.contains("CWE-121"));
+        assert!(body.contains("## Reproduce"));
+        assert!(body.contains("skwaq gym eval"));
+    }
+
+    #[test]
+    fn test_render_release_body_no_cwe_section_when_empty() {
+        let payload = EvalTagPayload {
+            tag_name: "eval-2026-03-26".to_string(),
+            commit: "abc123".to_string(),
+            timestamp: "2026-03-26T00:00:00Z".to_string(),
+            mode: "quick".to_string(),
+            suites: "fixtures".to_string(),
+            procs_per_suite: 1,
+            concurrency: 1,
+            llm_backend: "none".to_string(),
+            llm_model: "none".to_string(),
+            binary_mode: false,
+            skwaq_version: "0.1.0".to_string(),
+            git_dirty: false,
+            suite_results: vec![],
+            per_cwe: vec![],
+            reproducible_command: "skwaq gym eval --tag".to_string(),
+        };
+        let body = render_release_body(&payload);
+        assert!(!body.contains("Per-CWE Breakdown"));
+    }
+}


### PR DESCRIPTION
Phase 1 of SQLite → LadybugDB migration (issue #331).

LadybugDB (formerly Kuzu) provides native Cypher queries for graph traversals, replacing SQLite recursive CTEs and the Cypher→SQL translator.

**New**: `crates/core/src/graph/ladybug_db.rs`
- `LadybugGraphDb` with open/in_memory/query/execute API
- 7 node tables (Function, DataSource, DataSink, Symbol, Finding, StringLiteral, Investigation)
- 6 relationship tables (CALLS, TAINT_FLOW, FLOWS_TO, HAS_SOURCE, HAS_SINK, REFERENCES_STRING)
- Native Cypher: `MATCH (s)-[:CALLS*1..5]->(t) RETURN t.name` — no recursive CTEs
- 4 tests passing

The `lbug` crate (0.15.2) fixes the CXX bridge linking issues that blocked the `kuzu` crate (0.11.3).

Next: Phase 2 — dual-write builders, then Phase 3 — read from LadybugDB.