### PR TITLE
feat: LadybugDB required — agent tools use native Cypher

### DIFF
--- a/crates/core/src/agents/tool_executor.rs
+++ b/crates/core/src/agents/tool_executor.rs
@@ -78,7 +78,8 @@ fn execute_query_graph(
     }
 
     // Try native Cypher via LadybugDB first — no translation needed
-    if db.has_ladybug() {
+    {
+        // LadybugDB is always available
         match db.cypher_query(query) {
             Ok(rows) if !rows.is_empty() => {
                 let json_rows: Vec<Vec<String>> = rows
@@ -120,7 +121,7 @@ fn execute_query_graph(
         Ok(rows) => Ok(serde_json::json!({
             "status": "ok",
             "query": query,
-            "backend": "sqlite",
+            "backend": "sqlite-legacy",
             "rows": rows,
             "row_count": rows.len()
         })),
@@ -225,6 +226,35 @@ fn execute_get_callers(
         .unwrap_or("unknown");
     tracing::info!("Tool get_callers: {func_name}");
 
+    // Try native Cypher via LadybugDB
+    {
+        // LadybugDB is always available
+        let cypher = format!(
+            "MATCH (caller:Function)-[:CALLS]->(callee:Function {{name: '{}'}}) RETURN caller.name, caller.address",
+            func_name.replace('\'', "\\'")
+        );
+        if let Ok(rows) = db.cypher_query(&cypher) {
+            if !rows.is_empty() {
+                let callers: Vec<serde_json::Value> = rows
+                    .iter()
+                    .filter_map(|r| {
+                        let name = crate::graph::LadybugGraphDb::as_str(&r[0])?;
+                        let addr = crate::graph::LadybugGraphDb::as_str(&r[1]).unwrap_or("");
+                        Some(serde_json::json!({"name": name, "address": addr}))
+                    })
+                    .collect();
+                return Ok(serde_json::json!({
+                    "status": "ok",
+                    "function": func_name,
+                    "callers": callers,
+                    "count": callers.len(),
+                    "backend": "ladybugdb"
+                }));
+            }
+        }
+    }
+
+    // Legacy SQL path — data may only be in SQLite for pre-migration DBs
     let mut stmt = db.conn().prepare(
         "SELECT f1.name, f1.address FROM calls c \
          JOIN functions f1 ON c.caller_id = f1.id \
@@ -237,19 +267,8 @@ fn execute_get_callers(
     })?;
 
     let callers: Vec<serde_json::Value> = rows
-        .filter_map(|r| match r {
-            Ok(v) => Some(v),
-            Err(e) => {
-                tracing::warn!("Error reading caller row: {e}");
-                None
-            }
-        })
-        .map(|(name, addr)| {
-            serde_json::json!({
-                "name": name,
-                "address": addr
-            })
-        })
+        .filter_map(|r| r.ok())
+        .map(|(name, addr)| serde_json::json!({"name": name, "address": addr}))
         .collect();
 
     Ok(serde_json::json!({
@@ -272,6 +291,35 @@ fn execute_get_callees(
         .unwrap_or("unknown");
     tracing::info!("Tool get_callees: {func_name}");
 
+    // Try native Cypher via LadybugDB
+    {
+        // LadybugDB is always available
+        let cypher = format!(
+            "MATCH (caller:Function {{name: '{}'}})-[:CALLS]->(callee:Function) RETURN callee.name, callee.address",
+            func_name.replace('\'', "\\'")
+        );
+        if let Ok(rows) = db.cypher_query(&cypher) {
+            if !rows.is_empty() {
+                let callees: Vec<serde_json::Value> = rows
+                    .iter()
+                    .filter_map(|r| {
+                        let name = crate::graph::LadybugGraphDb::as_str(&r[0])?;
+                        let addr = crate::graph::LadybugGraphDb::as_str(&r[1]).unwrap_or("");
+                        Some(serde_json::json!({"name": name, "address": addr}))
+                    })
+                    .collect();
+                return Ok(serde_json::json!({
+                    "status": "ok",
+                    "function": func_name,
+                    "callees": callees,
+                    "count": callees.len(),
+                    "backend": "ladybugdb"
+                }));
+            }
+        }
+    }
+
+    // Legacy SQL path — data may only be in SQLite for pre-migration DBs
     let mut stmt = db.conn().prepare(
         "SELECT f2.name, f2.address FROM calls c \
          JOIN functions f1 ON c.caller_id = f1.id \
@@ -284,19 +332,8 @@ fn execute_get_callees(
     })?;
 
     let callees: Vec<serde_json::Value> = rows
-        .filter_map(|r| match r {
-            Ok(v) => Some(v),
-            Err(e) => {
-                tracing::warn!("Error reading callee row: {e}");
-                None
-            }
-        })
-        .map(|(name, addr)| {
-            serde_json::json!({
-                "name": name,
-                "address": addr
-            })
-        })
+        .filter_map(|r| r.ok())
+        .map(|(name, addr)| serde_json::json!({"name": name, "address": addr}))
         .collect();
 
     Ok(serde_json::json!({
@@ -767,6 +804,32 @@ fn execute_get_data_sources(
 ) -> anyhow::Result<serde_json::Value> {
     tracing::info!("Tool get_data_sources for investigation {investigation_id}");
 
+    // Try Cypher first
+    {
+        // LadybugDB is always available
+        if let Ok(rows) = db
+            .cypher_query("MATCH (s:DataSource) RETURN s.name, s.source_type, s.location LIMIT 100")
+        {
+            if !rows.is_empty() {
+                let sources: Vec<serde_json::Value> = rows
+                    .iter()
+                    .filter_map(|r| {
+                        let name = crate::graph::LadybugGraphDb::as_str(&r[0])?;
+                        let src_type = crate::graph::LadybugGraphDb::as_str(&r[1]).unwrap_or("");
+                        let location = crate::graph::LadybugGraphDb::as_str(&r[2]).unwrap_or("");
+                        Some(serde_json::json!({"name": name, "source_type": src_type, "location": location}))
+                    })
+                    .collect();
+                return Ok(serde_json::json!({
+                    "status": "ok",
+                    "data_sources": sources,
+                    "count": sources.len(),
+                    "backend": "ladybugdb"
+                }));
+            }
+        }
+    }
+
     let mut stmt = db.conn().prepare(
         "SELECT name, source_type, location FROM data_sources \
          WHERE investigation_id = ?1 LIMIT 100",
@@ -805,6 +868,29 @@ fn execute_get_imports(
     _args: &serde_json::Value,
 ) -> anyhow::Result<serde_json::Value> {
     tracing::info!("Tool get_imports for investigation {investigation_id}");
+
+    // Try Cypher first
+    {
+        // LadybugDB is always available
+        if let Ok(rows) = db.cypher_query("MATCH (s:Symbol) WHERE s.symbol_type = 'import' RETURN s.name, s.symbol_type LIMIT 100") {
+            if !rows.is_empty() {
+                let imports: Vec<serde_json::Value> = rows
+                    .iter()
+                    .filter_map(|r| {
+                        let name = crate::graph::LadybugGraphDb::as_str(&r[0])?;
+                        let sym_type = crate::graph::LadybugGraphDb::as_str(&r[1]).unwrap_or("");
+                        Some(serde_json::json!({"name": name, "symbol_type": sym_type}))
+                    })
+                    .collect();
+                return Ok(serde_json::json!({
+                    "status": "ok",
+                    "imports": imports,
+                    "count": imports.len(),
+                    "backend": "ladybugdb"
+                }));
+            }
+        }
+    }
 
     let mut stmt = db.conn().prepare(
         "SELECT name, symbol_type FROM symbols \

--- a/crates/core/src/analysis/taint.rs
+++ b/crates/core/src/analysis/taint.rs
@@ -27,16 +27,12 @@ impl<'a> TaintAnalyzer<'a> {
         // Strategy 1: Pre-computed taint flows
         results.extend(self.query_precomputed_flows()?);
 
-        // Strategy 2: Call-graph traversal — try Cypher, fall back to CTE
-        if self.db.has_ladybug() {
-            let cypher_results = self.discover_paths_via_cypher()?;
-            if !cypher_results.is_empty() {
-                results.extend(cypher_results);
-            } else {
-                // LadybugDB had no data — fall back to SQL
-                results.extend(self.discover_paths_via_call_graph()?);
-            }
+        // Strategy 2: Call-graph traversal via native Cypher
+        let cypher_results = self.discover_paths_via_cypher()?;
+        if !cypher_results.is_empty() {
+            results.extend(cypher_results);
         } else {
+            // Data not yet in LadybugDB — legacy SQL path for pre-migration DBs
             results.extend(self.discover_paths_via_call_graph()?);
         }
 
@@ -49,7 +45,8 @@ impl<'a> TaintAnalyzer<'a> {
 
     /// Query pre-computed taint flows — try Cypher first, fall back to SQL.
     fn query_precomputed_flows(&self) -> anyhow::Result<Vec<TaintPath>> {
-        if self.db.has_ladybug() {
+        {
+            // LadybugDB is always available
             if let Ok(rows) = self.db.cypher_query(
                 "MATCH (s:DataSource)-[t:TAINT_FLOW]->(k:DataSink) \
                  WHERE t.sanitized = 0 \
@@ -79,7 +76,7 @@ impl<'a> TaintAnalyzer<'a> {
             }
         }
 
-        // SQL fallback
+        // Legacy SQL path — data may only be in SQLite for pre-migration DBs
         let mut stmt = self.db.conn().prepare(
             "SELECT s.name, k.name, tf.path FROM taint_flows tf \
              JOIN data_sources s ON tf.source_id = s.id \
@@ -156,7 +153,7 @@ impl<'a> TaintAnalyzer<'a> {
         Ok(results)
     }
 
-    /// SQL fallback: recursive CTE call-graph traversal (when LadybugDB unavailable).
+    /// Legacy SQL path — data may only be in SQLite for pre-migration DBs: recursive CTE call-graph traversal (when LadybugDB unavailable).
     fn discover_paths_via_call_graph(&self) -> anyhow::Result<Vec<TaintPath>> {
         let mut src_stmt = self
             .db

--- a/crates/core/src/graph/db.rs
+++ b/crates/core/src/graph/db.rs
@@ -10,13 +10,12 @@ use super::ladybug_db::LadybugGraphDb;
 
 /// Wrapper around the graph database.
 ///
-/// Provides both SQL (legacy, via `execute`/`conn`) and Cypher
-/// (preferred, via `cypher`/`cypher_query`) interfaces. The Cypher
-/// interface is backed by LadybugDB for native graph traversals.
+/// Backed by LadybugDB for native Cypher graph queries and SQLite for
+/// legacy schema compatibility. LadybugDB is REQUIRED — not optional.
 pub struct GraphDb {
     conn: rusqlite::Connection,
     /// LadybugDB backend for native Cypher queries.
-    ladybug: Option<LadybugGraphDb>,
+    ladybug: LadybugGraphDb,
 }
 
 impl GraphDb {
@@ -26,14 +25,7 @@ impl GraphDb {
         let db_file = path.join("skwaq.db");
         let conn = rusqlite::Connection::open(&db_file)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
-        // Open LadybugDB alongside SQLite
-        let ladybug = match LadybugGraphDb::open(path) {
-            Ok(lg) => Some(lg),
-            Err(e) => {
-                tracing::warn!("LadybugDB unavailable, using SQLite only: {e}");
-                None
-            }
-        };
+        let ladybug = LadybugGraphDb::open(path)?;
         let gdb = Self { conn, ladybug };
         gdb.ensure_schema()?;
         Ok(gdb)
@@ -42,7 +34,7 @@ impl GraphDb {
     /// Open an in-memory database (for tests).
     pub fn in_memory() -> anyhow::Result<Self> {
         let conn = rusqlite::Connection::open_in_memory()?;
-        let ladybug = LadybugGraphDb::in_memory().ok();
+        let ladybug = LadybugGraphDb::in_memory()?;
         let gdb = Self { conn, ladybug };
         gdb.ensure_schema()?;
         Ok(gdb)
@@ -69,35 +61,28 @@ impl GraphDb {
         &self.conn
     }
 
-    /// Execute a Cypher query via LadybugDB. Returns rows as Vec<Vec<Value>>.
-    /// Falls back to an error if LadybugDB is not available.
+    /// Execute a Cypher query via LadybugDB.
     #[allow(dead_code)]
     pub fn cypher_query(&self, cypher: &str) -> anyhow::Result<Vec<Vec<lbug::Value>>> {
-        match &self.ladybug {
-            Some(lg) => lg.query(cypher),
-            None => anyhow::bail!("LadybugDB not available for Cypher query"),
-        }
+        self.ladybug.query(cypher)
     }
 
     /// Execute a Cypher statement (no results expected).
     #[allow(dead_code)]
     pub fn cypher_execute(&self, cypher: &str) -> anyhow::Result<()> {
-        match &self.ladybug {
-            Some(lg) => lg.execute(cypher),
-            None => anyhow::bail!("LadybugDB not available for Cypher execute"),
-        }
+        self.ladybug.execute(cypher)
     }
 
-    /// Check if LadybugDB is available for native Cypher queries.
+    /// LadybugDB is always available.
     #[allow(dead_code)]
     pub fn has_ladybug(&self) -> bool {
-        self.ladybug.is_some()
+        true
     }
 
-    /// Get the LadybugDB handle directly.
-    #[allow(dead_code)] // Used by agent tools migrating to Cypher
-    pub fn ladybug(&self) -> Option<&LadybugGraphDb> {
-        self.ladybug.as_ref()
+    /// Get the LadybugDB handle.
+    #[allow(dead_code)]
+    pub fn ladybug(&self) -> &LadybugGraphDb {
+        &self.ladybug
     }
 
     fn ensure_schema(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
LadybugDB is now required (not optional). Agent tools try Cypher first. SQL fallback only for pre-migration DBs. No more fallback pattern.