### PR TITLE
feat: wire Azure AI Foundry backend into skwaq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustyclawd-core"
 version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=8bf3b0745c67e108b874bcc0508fe351d72a6f8d#8bf3b0745c67e108b874bcc0508fe351d72a6f8d"
+source = "git+https://github.com/rysweet/RustyClawd?rev=800a7c0#800a7c0e734b07aa8e47e817333d4e9030096071"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "rustyclawd-tools"
 version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=8bf3b0745c67e108b874bcc0508fe351d72a6f8d#8bf3b0745c67e108b874bcc0508fe351d72a6f8d"
+source = "git+https://github.com/rysweet/RustyClawd?rev=800a7c0#800a7c0e734b07aa8e47e817333d4e9030096071"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/rysweet/skwaq"
 [workspace.dependencies]
 # RustyClawd agent framework — pinned to a known-good main commit for reproducible builds.
 # To update: run `cargo update -p rustyclawd-core -p rustyclawd-tools --precise <commit>`
-rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "8bf3b0745c67e108b874bcc0508fe351d72a6f8d" }
-rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "8bf3b0745c67e108b874bcc0508fe351d72a6f8d" }
+rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "800a7c0" }
+rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "800a7c0" }
 
 # Async
 tokio = { version = "1", features = ["full"] }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -37,6 +37,8 @@ pub struct LlmConfig {
     pub copilot: CopilotConfig,
     #[serde(default)]
     pub ollama: OllamaConfig,
+    #[serde(default)]
+    pub azure: AzureConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,6 +63,34 @@ pub struct OllamaConfig {
     pub model: String,
     #[serde(default = "default_embedding_model")]
     pub embedding_model: String,
+}
+
+/// Azure OpenAI configuration for Azure AI Foundry deployments.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AzureConfig {
+    /// Azure AI Services endpoint (e.g. "https://xxx.cognitiveservices.azure.com/")
+    #[serde(default)]
+    pub endpoint: String,
+    /// Model deployment name (e.g. "gpt-51-skwaq")
+    #[serde(default)]
+    pub deployment: String,
+    /// Azure OpenAI API version
+    #[serde(default = "default_azure_api_version")]
+    pub api_version: String,
+}
+
+impl Default for AzureConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: String::new(),
+            deployment: String::new(),
+            api_version: default_azure_api_version(),
+        }
+    }
+}
+
+fn default_azure_api_version() -> String {
+    "2024-10-21".into()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -153,6 +183,7 @@ impl Default for LlmConfig {
             embeddings: default_ollama(),
             copilot: CopilotConfig::default(),
             ollama: OllamaConfig::default(),
+            azure: AzureConfig::default(),
         }
     }
 }

--- a/crates/core/src/llm/mod.rs
+++ b/crates/core/src/llm/mod.rs
@@ -28,6 +28,7 @@ use anyhow::Context;
 /// Backend selection is explicit:
 /// - `"copilot"` -- GitHub Copilot via `api.githubcopilot.com`.
 /// - `"anthropic"` -- Anthropic Messages API (`ANTHROPIC_API_KEY`).
+/// - `"azure"` -- Azure AI Foundry via `DefaultAzureCredential`.
 ///
 /// Any other value is rejected. skwaq does not silently switch providers.
 pub async fn create_client(config: &LlmConfig) -> anyhow::Result<Client> {
@@ -36,12 +37,12 @@ pub async fn create_client(config: &LlmConfig) -> anyhow::Result<Client> {
 
 /// Create a client for reasoning stages using `[llm].reasoning`.
 pub async fn create_reasoning_client(config: &LlmConfig) -> anyhow::Result<Client> {
-    create_client_for_backend(config.reasoning.trim(), "llm.reasoning").await
+    create_client_for_backend(config, config.reasoning.trim(), "llm.reasoning").await
 }
 
 /// Create a client for decompilation stages using `[llm].decompilation`.
 pub async fn create_decompilation_client(config: &LlmConfig) -> anyhow::Result<Client> {
-    create_client_for_backend(config.decompilation.trim(), "llm.decompilation").await
+    create_client_for_backend(config, config.decompilation.trim(), "llm.decompilation").await
 }
 
 /// Create the clients needed by the agent pipeline.
@@ -78,29 +79,42 @@ pub async fn create_pipeline_clients(
         (&reasoning_backend, &decompilation_backend)
     {
         if reasoning_backend == decompilation_backend {
-            let client = create_client_for_backend_name(reasoning_backend, "llm.reasoning").await?;
+            let client =
+                create_client_for_backend_name(config, reasoning_backend, "llm.reasoning").await?;
             return Ok((Some(client.clone()), Some(client)));
         }
     }
 
     let reasoning = match reasoning_backend {
-        Some(backend) => Some(create_client_for_backend_name(&backend, "llm.reasoning").await?),
+        Some(backend) => {
+            Some(create_client_for_backend_name(config, &backend, "llm.reasoning").await?)
+        }
         None => None,
     };
     let decompilation = match decompilation_backend {
-        Some(backend) => Some(create_client_for_backend_name(&backend, "llm.decompilation").await?),
+        Some(backend) => {
+            Some(create_client_for_backend_name(config, &backend, "llm.decompilation").await?)
+        }
         None => None,
     };
 
     Ok((reasoning, decompilation))
 }
 
-async fn create_client_for_backend(raw_backend: &str, field_name: &str) -> anyhow::Result<Client> {
+async fn create_client_for_backend(
+    config: &LlmConfig,
+    raw_backend: &str,
+    field_name: &str,
+) -> anyhow::Result<Client> {
     let backend = validate_backend_name(raw_backend, field_name)?;
-    create_client_for_backend_name(&backend, field_name).await
+    create_client_for_backend_name(config, &backend, field_name).await
 }
 
-async fn create_client_for_backend_name(backend: &str, field_name: &str) -> anyhow::Result<Client> {
+async fn create_client_for_backend_name(
+    config: &LlmConfig,
+    backend: &str,
+    field_name: &str,
+) -> anyhow::Result<Client> {
     match backend {
         "copilot" => {
             let client = Client::new_copilot().await.map_err(|e| {
@@ -109,6 +123,25 @@ async fn create_client_for_backend_name(backend: &str, field_name: &str) -> anyh
             Ok(client)
         }
         "anthropic" => create_anthropic_client(),
+        "azure" => {
+            let azure = &config.azure;
+            anyhow::ensure!(
+                !azure.endpoint.is_empty(),
+                "Azure backend selected for {field_name} but [llm.azure] endpoint is not set"
+            );
+            anyhow::ensure!(
+                !azure.deployment.is_empty(),
+                "Azure backend selected for {field_name} but [llm.azure] deployment is not set"
+            );
+            let client =
+                Client::new_azure_foundry(&azure.endpoint, &azure.deployment, &azure.api_version)
+                    .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to create Azure AI Foundry client for {field_name}: {e}"
+                    )
+                })?;
+            Ok(client)
+        }
         _ => unreachable!("validate_backend_name rejected unsupported backends"),
     }
 }
@@ -196,14 +229,14 @@ fn create_anthropic_client() -> anyhow::Result<Client> {
 
 fn validate_backend_name(raw_backend: &str, field_name: &str) -> anyhow::Result<String> {
     let backend = raw_backend.trim().to_ascii_lowercase();
-    if !matches!(backend.as_str(), "copilot" | "anthropic") {
+    if !matches!(backend.as_str(), "copilot" | "anthropic" | "azure") {
         let display = if backend.is_empty() {
             "<empty>"
         } else {
             backend.as_str()
         };
         anyhow::bail!(
-            "Unsupported {} backend {:?}. Set {} explicitly to \"copilot\" or \"anthropic\"; hidden fallback is disabled.",
+            "Unsupported {} backend {:?}. Set {} explicitly to \"copilot\", \"anthropic\", or \"azure\"; hidden fallback is disabled.",
             field_name,
             display,
             field_name


### PR DESCRIPTION
## Summary
Wires up RustyClawd's new `Backend::AzureFoundry` (PR rysweet/RustyClawd#621) into skwaq's LLM layer.

## Why Azure AI Foundry?
- Supports **both** OpenAI models (GPT-5.x) **and** third-party models (Claude, Llama, etc.) through the same endpoint
- More future-proof than Azure OpenAI — when Anthropic models become available in our subscription, they work automatically
- Auth via `az login` / managed identity (`DefaultAzureCredential` equivalent)
- **2-4x cheaper** than Anthropic direct for benchmark runs (~$75-150 per 20M-token run)

## Changes
- `AzureConfig` struct in `config.rs` (endpoint, deployment, api_version)
- `validate_backend_name` accepts `"azure"`
- `create_client_for_backend_name` calls `Client::new_azure_foundry()`
- `LlmConfig` threaded through backend creation for Azure config access
- RustyClawd pin updated to `800a7c0` (includes `Backend::AzureFoundry`)
- Removed unused `azure_identity`/`azure_core` deps

## Usage
```toml
[llm]
reasoning = "azure"
decompilation = "azure"

[llm.azure]
endpoint = "https://rysweetballist5347662217.cognitiveservices.azure.com/"
deployment = "gpt-51-skwaq"
api_version = "2024-10-21"
```

## Testing
- 747 tests pass (0 failures)
- clippy clean with `-D warnings`