### PR TITLE
feat: OpenTelemetry observability + ratatui TUI dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +223,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +385,21 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -479,6 +547,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,7 +578,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -509,7 +591,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -617,6 +699,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -732,8 +839,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -751,12 +868,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1302,12 +1443,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1324,6 +1471,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1434,6 +1583,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1608,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1519,7 +1681,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1667,6 +1829,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1686,8 +1858,17 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1698,6 +1879,19 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1721,6 +1915,24 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1923,6 +2135,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1961,7 +2179,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "log",
  "md-5",
@@ -1974,6 +2192,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "weezl",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2045,6 +2272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2283,7 +2517,7 @@ dependencies = [
  "serde_urlencoded",
  "snafu",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "url",
@@ -2353,6 +2587,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2710,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -2665,6 +2971,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,7 +3006,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2715,7 +3044,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2805,6 +3134,27 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "rayon"
@@ -2917,7 +3267,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -2960,7 +3310,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3055,6 +3405,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3062,7 +3425,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3398,7 +3761,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -3411,7 +3774,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -3460,6 +3823,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3513,6 +3897,8 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "rustyclawd-tools",
  "serde",
  "serde_json",
@@ -3521,6 +3907,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -3536,6 +3923,7 @@ dependencies = [
  "goblin",
  "lbug",
  "libc",
+ "opentelemetry",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
@@ -3549,6 +3937,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-opentelemetry",
  "tree-sitter",
  "tree-sitter-c",
  "uuid",
@@ -3561,11 +3950,18 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "crossterm",
  "dirs",
  "flate2",
  "futures",
+ "futures-util",
+ "humantime",
  "indicatif",
  "memmap2",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "ratatui",
  "rayon",
  "regex",
  "reqwest 0.12.28",
@@ -3580,6 +3976,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-opentelemetry",
  "uuid",
  "walkdir",
  "zip",
@@ -3620,6 +4017,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -3649,6 +4056,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -3697,6 +4110,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -3782,7 +4217,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3923,7 +4358,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3956,6 +4391,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3999,7 +4445,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4012,6 +4458,56 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -4043,7 +4539,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4103,6 +4599,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4207,6 +4721,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4214,9 +4745,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -4301,7 +4832,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "once_cell",
  "proc-macro-error2",
  "proc-macro2",
@@ -4446,7 +4977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4485,7 +5016,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -4526,6 +5057,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4533,6 +5080,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4798,7 +5351,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4829,7 +5382,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -4848,7 +5401,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -4871,7 +5424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -5028,7 +5581,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap",
+ "indexmap 2.13.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,17 @@ toml = "0.8"
 anyhow = "1"
 thiserror = "2"
 
-# Logging
+# Logging / Observability
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+tracing-opentelemetry = "0.28"
+opentelemetry = "0.27"
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.27", features = ["tonic"] }
+
+# TUI
+ratatui = "0.29"
+crossterm = "0.28"
 
 # HTTP
 reqwest = { version = "0.12", features = ["json", "stream"] }
@@ -56,6 +64,7 @@ sha2 = "0.10"
 tempfile = "3"
 dirs = "6"
 libc = "0.2"
+humantime = "2"
 
 [profile.release]
 opt-level = 3

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,3 +23,6 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
 tempfile = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+tracing-opentelemetry = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,6 +28,8 @@ serde_yaml_ng = "0.10"
 tree-sitter = "0.24"
 tree-sitter-c = "0.23"
 lbug = "0.15.2"
+opentelemetry = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub analysis: AnalysisConfig,
     #[serde(default)]
     pub output: OutputConfig,
+    #[serde(default)]
+    pub observability: ObservabilityConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -226,6 +228,36 @@ impl Default for OutputConfig {
     fn default() -> Self {
         Self {
             default_format: default_format(),
+        }
+    }
+}
+
+/// Observability configuration for OpenTelemetry export.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObservabilityConfig {
+    /// OTLP gRPC endpoint (e.g. "http://localhost:4317"). When set, spans are
+    /// exported via OTLP in addition to the local JSONL file.
+    #[serde(default)]
+    pub otlp_endpoint: Option<String>,
+    /// Azure Monitor connection string. When set, spans are exported to
+    /// Application Insights.
+    #[serde(default)]
+    pub azure_monitor_connection_string: Option<String>,
+    /// Local telemetry directory. Defaults to ~/.skwaq/telemetry.
+    #[serde(default = "default_telemetry_dir")]
+    pub telemetry_dir: String,
+}
+
+fn default_telemetry_dir() -> String {
+    "~/.skwaq/telemetry".into()
+}
+
+impl Default for ObservabilityConfig {
+    fn default() -> Self {
+        Self {
+            otlp_endpoint: None,
+            azure_monitor_connection_string: None,
+            telemetry_dir: default_telemetry_dir(),
         }
     }
 }

--- a/crates/gym/Cargo.toml
+++ b/crates/gym/Cargo.toml
@@ -27,12 +27,24 @@ zip = "2"
 walkdir = "2"
 rayon = "1"
 futures = "0.3"
+futures-util = "0.3"
 indicatif = "0.17"
 regex = "1"
 memmap2 = "0.9.10"
+humantime = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
 
 [features]
 test-heuristic-api = []
+otlp = ["opentelemetry-otlp"]
+
+[dependencies.opentelemetry-otlp]
+workspace = true
+optional = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -14,7 +14,9 @@ pub mod reporting;
 pub mod scoring;
 pub mod shared_throttle;
 pub mod tagging;
+pub mod telemetry;
 pub mod throttle;
+pub mod tui;
 
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::pin::Pin;

--- a/crates/gym/src/telemetry.rs
+++ b/crates/gym/src/telemetry.rs
@@ -1,0 +1,363 @@
+//! OpenTelemetry telemetry: span pipeline, JSONL file exporter, and query helpers.
+//!
+//! Tier 1 (always on): file exporter writes spans to `~/.skwaq/telemetry/spans.jsonl`.
+//! Tier 3 (opt-in, feature `otlp`): OTLP gRPC export when configured.
+
+use futures_util::future::BoxFuture;
+use opentelemetry::trace::TraceError;
+use opentelemetry_sdk::{
+    export::trace::{ExportResult, SpanData, SpanExporter},
+    trace::TracerProvider,
+};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+/// Resolved telemetry directory (expanded from config).
+fn resolve_telemetry_dir(configured: &str) -> PathBuf {
+    if configured.starts_with("~/") || configured.starts_with("~\\") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(&configured[2..]);
+        }
+    }
+    PathBuf::from(configured)
+}
+
+/// Ensure the telemetry directory exists.
+fn ensure_dir(dir: &Path) -> anyhow::Result<()> {
+    if !dir.exists() {
+        fs::create_dir_all(dir)?;
+    }
+    Ok(())
+}
+
+// ── JSONL file exporter ────────────────────────────────────────────
+
+/// A lightweight span record written to the JSONL file.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SpanRecord {
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
+    pub name: String,
+    pub start_time: String,
+    pub end_time: String,
+    pub duration_ms: f64,
+    pub status: String,
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Exporter that appends span records as JSONL to a file.
+#[derive(Debug)]
+struct JsonlFileExporter {
+    path: PathBuf,
+}
+
+impl JsonlFileExporter {
+    fn new(dir: &Path) -> anyhow::Result<Self> {
+        ensure_dir(dir)?;
+        Ok(Self {
+            path: dir.join("spans.jsonl"),
+        })
+    }
+}
+
+impl SpanExporter for JsonlFileExporter {
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .map_err(|e| TraceError::Other(Box::new(e)))?;
+
+            for span in &batch {
+                let parent = {
+                    let id = span.parent_span_id.to_string();
+                    if id == "0000000000000000" {
+                        None
+                    } else {
+                        Some(id)
+                    }
+                };
+
+                let mut attrs = serde_json::Map::new();
+                for kv in span.attributes.iter() {
+                    attrs.insert(
+                        kv.key.to_string(),
+                        serde_json::Value::String(kv.value.to_string()),
+                    );
+                }
+
+                let duration = span
+                    .end_time
+                    .duration_since(span.start_time)
+                    .unwrap_or_default();
+
+                let record = SpanRecord {
+                    trace_id: span.span_context.trace_id().to_string(),
+                    span_id: span.span_context.span_id().to_string(),
+                    parent_span_id: parent,
+                    name: span.name.to_string(),
+                    start_time: humantime::format_rfc3339(span.start_time).to_string(),
+                    end_time: humantime::format_rfc3339(span.end_time).to_string(),
+                    duration_ms: duration.as_secs_f64() * 1000.0,
+                    status: format!("{:?}", span.status),
+                    attributes: attrs,
+                };
+
+                if let Ok(json) = serde_json::to_string(&record) {
+                    let _ = writeln!(file, "{json}");
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+// ── Provider setup ─────────────────────────────────────────────────
+
+/// Initialise the OpenTelemetry [`TracerProvider`] with a JSONL file exporter
+/// (always on) and optionally an OTLP exporter (feature-gated).
+///
+/// Returns the provider so callers can register a `tracing-opentelemetry` layer.
+pub fn init_tracer_provider(
+    telemetry_dir: &str,
+    _otlp_endpoint: Option<&str>,
+) -> anyhow::Result<TracerProvider> {
+    let dir = resolve_telemetry_dir(telemetry_dir);
+    let file_exporter = JsonlFileExporter::new(&dir)?;
+
+    // Use simple exporter (synchronous, low overhead for file I/O)
+    let builder = TracerProvider::builder().with_simple_exporter(file_exporter);
+
+    // Tier 3: OTLP export (feature-gated)
+    #[cfg(feature = "otlp")]
+    let builder = {
+        if let Some(endpoint) = _otlp_endpoint {
+            use opentelemetry_otlp::WithExportConfig;
+            let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint(endpoint)
+                .build()?;
+            builder.with_simple_exporter(otlp_exporter)
+        } else {
+            builder
+        }
+    };
+
+    let provider = builder.build();
+    Ok(provider)
+}
+
+/// Rotate the spans file if it exceeds `max_bytes` (default 50 MB).
+pub fn rotate_spans_file(telemetry_dir: &str, max_bytes: u64) -> anyhow::Result<()> {
+    let dir = resolve_telemetry_dir(telemetry_dir);
+    let path = dir.join("spans.jsonl");
+    if !path.exists() {
+        return Ok(());
+    }
+    let meta = fs::metadata(&path)?;
+    if meta.len() > max_bytes {
+        let rotated = dir.join("spans.jsonl.1");
+        if rotated.exists() {
+            fs::remove_file(&rotated)?;
+        }
+        fs::rename(&path, &rotated)?;
+    }
+    Ok(())
+}
+
+// ── Query helpers ──────────────────────────────────────────────────
+
+/// Read and filter span records from the JSONL file.
+pub fn query_spans(
+    telemetry_dir: &str,
+    name_filter: Option<&str>,
+    attr_filter: Option<(&str, &str)>,
+    limit: usize,
+) -> anyhow::Result<Vec<SpanRecord>> {
+    let dir = resolve_telemetry_dir(telemetry_dir);
+    let path = dir.join("spans.jsonl");
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file = std::fs::File::open(&path)?;
+    let reader = BufReader::new(file);
+    let mut results = Vec::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: SpanRecord = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        if let Some(name) = name_filter {
+            if !record.name.contains(name) {
+                continue;
+            }
+        }
+
+        if let Some((key, value)) = attr_filter {
+            match record.attributes.get(key) {
+                Some(v) if v.as_str() == Some(value) => {}
+                _ => continue,
+            }
+        }
+
+        results.push(record);
+        if results.len() >= limit {
+            break;
+        }
+    }
+
+    Ok(results)
+}
+
+/// Print a formatted summary of telemetry spans to stdout.
+pub fn print_span_summary(spans: &[SpanRecord]) {
+    if spans.is_empty() {
+        println!("No spans found.");
+        return;
+    }
+
+    println!(
+        "{:<30} {:>10} {:>12} KEY ATTRIBUTES",
+        "SPAN", "DURATION", "STATUS"
+    );
+    println!("{}", "-".repeat(80));
+
+    for span in spans {
+        let key_attrs: Vec<String> = span
+            .attributes
+            .iter()
+            .filter(|(k, _)| {
+                matches!(
+                    k.as_str(),
+                    "suite" | "case_id" | "agent_name" | "verdict" | "tokens_in" | "tokens_out"
+                )
+            })
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+
+        println!(
+            "{:<30} {:>8.1}ms {:>12} {}",
+            truncate(&span.name, 30),
+            span.duration_ms,
+            &span.status,
+            key_attrs.join(", ")
+        );
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max - 3])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_telemetry_dir_tilde() {
+        let dir = resolve_telemetry_dir("~/.skwaq/telemetry");
+        assert!(dir.to_string_lossy().contains(".skwaq/telemetry"));
+        assert!(!dir.to_string_lossy().starts_with('~'));
+    }
+
+    #[test]
+    fn test_resolve_telemetry_dir_absolute() {
+        let dir = resolve_telemetry_dir("/tmp/telemetry");
+        assert_eq!(dir, PathBuf::from("/tmp/telemetry"));
+    }
+
+    #[test]
+    fn test_query_spans_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let results = query_spans(dir.path().to_str().unwrap(), None, None, 100).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_query_spans_with_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spans.jsonl");
+        let record = SpanRecord {
+            trace_id: "abc".into(),
+            span_id: "def".into(),
+            parent_span_id: None,
+            name: "gym.case".into(),
+            start_time: "2026-01-01T00:00:00Z".into(),
+            end_time: "2026-01-01T00:00:01Z".into(),
+            duration_ms: 1000.0,
+            status: "Ok".into(),
+            attributes: serde_json::Map::new(),
+        };
+        std::fs::write(&path, serde_json::to_string(&record).unwrap()).unwrap();
+
+        let results = query_spans(dir.path().to_str().unwrap(), Some("gym"), None, 100).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "gym.case");
+    }
+
+    #[test]
+    fn test_query_spans_with_attr_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spans.jsonl");
+        let mut attrs = serde_json::Map::new();
+        attrs.insert("suite".into(), serde_json::Value::String("fixtures".into()));
+        let record = SpanRecord {
+            trace_id: "abc".into(),
+            span_id: "def".into(),
+            parent_span_id: None,
+            name: "gym.case".into(),
+            start_time: "2026-01-01T00:00:00Z".into(),
+            end_time: "2026-01-01T00:00:01Z".into(),
+            duration_ms: 1000.0,
+            status: "Ok".into(),
+            attributes: attrs,
+        };
+        std::fs::write(&path, serde_json::to_string(&record).unwrap()).unwrap();
+
+        let results = query_spans(
+            dir.path().to_str().unwrap(),
+            None,
+            Some(("suite", "fixtures")),
+            100,
+        )
+        .unwrap();
+        assert_eq!(results.len(), 1);
+
+        let results = query_spans(
+            dir.path().to_str().unwrap(),
+            None,
+            Some(("suite", "juliet")),
+            100,
+        )
+        .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_rotate_spans_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spans.jsonl");
+        std::fs::write(&path, "x".repeat(200)).unwrap();
+
+        rotate_spans_file(dir.path().to_str().unwrap(), 100).unwrap();
+
+        assert!(!path.exists());
+        assert!(dir.path().join("spans.jsonl.1").exists());
+    }
+}

--- a/crates/gym/src/tui.rs
+++ b/crates/gym/src/tui.rs
@@ -1,0 +1,464 @@
+//! Ratatui-based TUI dashboard for viewing gym run status, agent stats,
+//! and benchmark history in the terminal.
+//!
+//! Launch with `skwaq gym dashboard --live` for real-time monitoring
+//! or `skwaq gym dashboard` for a static snapshot of the last run.
+
+use crate::history::HistoryDb;
+use crate::telemetry::query_spans;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+    Frame, Terminal,
+};
+use std::io::stdout;
+use std::time::{Duration, Instant};
+
+/// Run the live TUI dashboard.
+pub fn run_live(history_db: &HistoryDb, telemetry_dir: &str) -> anyhow::Result<()> {
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    let backend = ratatui::backend::CrosstermBackend::new(stdout());
+    let mut terminal = Terminal::new(backend)?;
+
+    let tick_rate = Duration::from_secs(2);
+    let mut last_tick = Instant::now();
+
+    loop {
+        let state = DashboardState::load(history_db, telemetry_dir)?;
+        terminal.draw(|f| render(f, &state))?;
+
+        let timeout = tick_rate.saturating_sub(last_tick.elapsed());
+        if event::poll(timeout)? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('q') {
+                    break;
+                }
+            }
+        }
+        if last_tick.elapsed() >= tick_rate {
+            last_tick = Instant::now();
+        }
+    }
+
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    Ok(())
+}
+
+/// Run the static (non-interactive) dashboard — prints to stdout and exits.
+pub fn run_static(history_db: &HistoryDb, telemetry_dir: &str) -> anyhow::Result<()> {
+    let state = DashboardState::load(history_db, telemetry_dir)?;
+    print_static(&state);
+    Ok(())
+}
+
+// ── Dashboard state ────────────────────────────────────────────────
+
+struct SuiteStats {
+    name: String,
+    f1_history: Vec<f64>,
+    latest_f1: f64,
+    latest_precision: f64,
+    latest_recall: f64,
+    cases: u32,
+    tp: u32,
+    fp: u32,
+    r#fn: u32,
+}
+
+struct AgentStats {
+    name: String,
+    call_count: u64,
+    avg_tokens: f64,
+    avg_duration_ms: f64,
+}
+
+struct ApiHealth {
+    total_requests: u64,
+    rate_limit_retries: u64,
+    errors: u64,
+}
+
+struct DashboardState {
+    suites: Vec<SuiteStats>,
+    agents: Vec<AgentStats>,
+    api_health: ApiHealth,
+    recent_span_count: usize,
+}
+
+impl DashboardState {
+    fn load(db: &HistoryDb, telemetry_dir: &str) -> anyhow::Result<Self> {
+        let mut suites = Vec::new();
+        for suite_name in &[
+            "fixtures",
+            "juliet",
+            "owasp",
+            "cyberseceval",
+            "cgc",
+            "cybergym",
+        ] {
+            let runs = db.recent_finished_runs_for_suite(suite_name, 20)?;
+            if runs.is_empty() {
+                continue;
+            }
+            let latest = &runs[0];
+            let f1_history: Vec<f64> = runs.iter().rev().map(|r| r.f1 * 100.0).collect();
+            suites.push(SuiteStats {
+                name: suite_name.to_string(),
+                f1_history,
+                latest_f1: latest.f1 * 100.0,
+                latest_precision: latest.precision * 100.0,
+                latest_recall: latest.recall * 100.0,
+                cases: latest.true_positives
+                    + latest.false_positives
+                    + latest.false_negatives
+                    + latest.true_negatives,
+                tp: latest.true_positives,
+                fp: latest.false_positives,
+                r#fn: latest.false_negatives,
+            });
+        }
+
+        // Agent stats from recent telemetry spans
+        let agent_spans =
+            query_spans(telemetry_dir, Some("gym.agent"), None, 10000).unwrap_or_default();
+        let mut agent_map: std::collections::HashMap<String, (u64, f64, f64)> =
+            std::collections::HashMap::new();
+        for span in &agent_spans {
+            let name = span
+                .attributes
+                .get("agent_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let tokens: f64 = span
+                .attributes
+                .get("tokens_out")
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0);
+            let entry = agent_map.entry(name).or_insert((0, 0.0, 0.0));
+            entry.0 += 1;
+            entry.1 += tokens;
+            entry.2 += span.duration_ms;
+        }
+        let agents: Vec<AgentStats> = agent_map
+            .into_iter()
+            .map(|(name, (count, total_tokens, total_ms))| AgentStats {
+                name,
+                call_count: count,
+                avg_tokens: if count > 0 {
+                    total_tokens / count as f64
+                } else {
+                    0.0
+                },
+                avg_duration_ms: if count > 0 {
+                    total_ms / count as f64
+                } else {
+                    0.0
+                },
+            })
+            .collect();
+
+        // API health from LLM request spans
+        let llm_spans =
+            query_spans(telemetry_dir, Some("llm.request"), None, 10000).unwrap_or_default();
+        let total_requests = llm_spans.len() as u64;
+        let rate_limit_retries = llm_spans
+            .iter()
+            .filter(|s| s.attributes.get("retry").is_some())
+            .count() as u64;
+        let errors = llm_spans
+            .iter()
+            .filter(|s| s.status.contains("Error"))
+            .count() as u64;
+
+        Ok(DashboardState {
+            suites,
+            agents,
+            api_health: ApiHealth {
+                total_requests,
+                rate_limit_retries,
+                errors,
+            },
+            recent_span_count: agent_spans.len() + llm_spans.len(),
+        })
+    }
+}
+
+// ── TUI rendering ──────────────────────────────────────────────────
+
+fn render(f: &mut Frame, state: &DashboardState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Title
+            Constraint::Min(10),   // Main content
+            Constraint::Length(4), // API Health
+        ])
+        .split(f.area());
+
+    // Title bar
+    let title = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " SKWAQ GYM DASHBOARD ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(
+            "  {} spans tracked  [q] quit",
+            state.recent_span_count
+        )),
+    ]))
+    .block(Block::default().borders(Borders::BOTTOM));
+    f.render_widget(title, chunks[0]);
+
+    // Main content: suites table + agent stats side-by-side
+    let main_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+        .split(chunks[1]);
+
+    render_suites(f, main_chunks[0], state);
+    render_agents(f, main_chunks[1], state);
+
+    // API health bar
+    render_api_health(f, chunks[2], state);
+}
+
+fn render_suites(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let header = Row::new(vec![
+        "Suite", "Cases", "F1%", "Prec%", "Rec%", "TP", "FP", "FN", "Trend",
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row> = state
+        .suites
+        .iter()
+        .map(|s| {
+            let f1_color = if s.latest_f1 >= 90.0 {
+                Color::Green
+            } else if s.latest_f1 >= 80.0 {
+                Color::Yellow
+            } else {
+                Color::Red
+            };
+            let trend = sparkline_ascii(&s.f1_history, 8);
+            Row::new(vec![
+                Cell::from(s.name.clone()),
+                Cell::from(format!("{}", s.cases)),
+                Cell::from(format!("{:.1}", s.latest_f1)).style(Style::default().fg(f1_color)),
+                Cell::from(format!("{:.1}", s.latest_precision)),
+                Cell::from(format!("{:.1}", s.latest_recall)),
+                Cell::from(format!("{}", s.tp)),
+                Cell::from(format!("{}", s.fp)),
+                Cell::from(format!("{}", s.r#fn)),
+                Cell::from(trend),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(12),
+            Constraint::Length(6),
+            Constraint::Length(6),
+            Constraint::Length(6),
+            Constraint::Length(6),
+            Constraint::Length(5),
+            Constraint::Length(5),
+            Constraint::Length(5),
+            Constraint::Length(10),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .title(" Benchmark Results ")
+            .borders(Borders::ALL),
+    );
+    f.render_widget(table, area);
+}
+
+fn render_agents(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let header = Row::new(vec!["Agent", "Calls", "Avg Tok", "Avg ms"]).style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row> = state
+        .agents
+        .iter()
+        .map(|a| {
+            Row::new(vec![
+                Cell::from(a.name.clone()),
+                Cell::from(format!("{}", a.call_count)),
+                Cell::from(format!("{:.0}", a.avg_tokens)),
+                Cell::from(format!("{:.0}", a.avg_duration_ms)),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(18),
+            Constraint::Length(7),
+            Constraint::Length(9),
+            Constraint::Length(9),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .title(" Agent Stats ")
+            .borders(Borders::ALL),
+    );
+    f.render_widget(table, area);
+}
+
+fn render_api_health(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let h = &state.api_health;
+    let text = Line::from(vec![
+        Span::styled(" API: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(format!("{} requests", h.total_requests)),
+        Span::raw("  │  "),
+        Span::styled(
+            format!("{} rate-limit retries", h.rate_limit_retries),
+            Style::default().fg(if h.rate_limit_retries > 0 {
+                Color::Yellow
+            } else {
+                Color::Green
+            }),
+        ),
+        Span::raw("  │  "),
+        Span::styled(
+            format!("{} errors", h.errors),
+            Style::default().fg(if h.errors > 0 {
+                Color::Red
+            } else {
+                Color::Green
+            }),
+        ),
+    ]);
+    let widget =
+        Paragraph::new(text).block(Block::default().title(" API Health ").borders(Borders::ALL));
+    f.render_widget(widget, area);
+}
+
+/// Generate ASCII sparkline from values (▁▂▃▄▅▆▇█).
+fn sparkline_ascii(values: &[f64], width: usize) -> String {
+    if values.is_empty() {
+        return String::new();
+    }
+    let blocks = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let range = (max - min).max(1.0);
+
+    values
+        .iter()
+        .rev()
+        .take(width)
+        .rev()
+        .map(|v| {
+            let idx = ((v - min) / range * 7.0).round() as usize;
+            blocks[idx.min(7)]
+        })
+        .collect()
+}
+
+// ── Static (non-TUI) output ────────────────────────────────────────
+
+fn print_static(state: &DashboardState) {
+    println!("\n  ╔══════════════════════════════════════════════════╗");
+    println!("  ║         SKWAQ GYM DASHBOARD                     ║");
+    println!("  ╚══════════════════════════════════════════════════╝\n");
+
+    if state.suites.is_empty() {
+        println!("  No benchmark runs found. Run `skwaq gym run <suite>` first.\n");
+        return;
+    }
+
+    println!(
+        "  {:<12} {:>6} {:>7} {:>7} {:>7} {:>5} {:>5} {:>5}  TREND",
+        "SUITE", "CASES", "F1%", "PREC%", "REC%", "TP", "FP", "FN"
+    );
+    println!("  {}", "─".repeat(75));
+
+    for s in &state.suites {
+        let trend = sparkline_ascii(&s.f1_history, 8);
+        println!(
+            "  {:<12} {:>6} {:>6.1} {:>6.1} {:>6.1} {:>5} {:>5} {:>5}  {}",
+            s.name,
+            s.cases,
+            s.latest_f1,
+            s.latest_precision,
+            s.latest_recall,
+            s.tp,
+            s.fp,
+            s.r#fn,
+            trend
+        );
+    }
+
+    if !state.agents.is_empty() {
+        println!(
+            "\n  {:<18} {:>7} {:>9} {:>9}",
+            "AGENT", "CALLS", "AVG TOK", "AVG MS"
+        );
+        println!("  {}", "─".repeat(50));
+        for a in &state.agents {
+            println!(
+                "  {:<18} {:>7} {:>9.0} {:>9.0}",
+                a.name, a.call_count, a.avg_tokens, a.avg_duration_ms
+            );
+        }
+    }
+
+    let h = &state.api_health;
+    println!(
+        "\n  API: {} requests | {} rate-limit retries | {} errors\n",
+        h.total_requests, h.rate_limit_retries, h.errors
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sparkline_ascii() {
+        let s = sparkline_ascii(&[50.0, 60.0, 70.0, 80.0, 90.0], 5);
+        assert_eq!(s.chars().count(), 5);
+        assert!(s.contains('█'));
+        assert!(s.contains('▁'));
+    }
+
+    #[test]
+    fn test_sparkline_ascii_empty() {
+        assert_eq!(sparkline_ascii(&[], 5), "");
+    }
+
+    #[test]
+    fn test_sparkline_ascii_single() {
+        let s = sparkline_ascii(&[90.0], 5);
+        assert_eq!(s.chars().count(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
Three-tier observability for skwaq gym, no Docker required.

**Tier 1** (always on): JSONL span exporter to `~/.skwaq/telemetry/spans.jsonl` via tracing-opentelemetry. Query with `skwaq gym telemetry`.

**Tier 2**: Ratatui TUI dashboard — `skwaq gym dashboard --live` for real-time, `skwaq gym dashboard` for static snapshot. Shows benchmark results with F1 sparklines, per-agent token/latency stats, API health.

**Tier 3** (opt-in): OTLP export behind `otlp` cargo feature for Grafana/Tempo/Azure Monitor.

756 tests pass (9 new), clippy clean.