### PR TITLE
feat: wire round-robin multi-deployment into skwaq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3006,7 +3006,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3044,7 +3044,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3515,7 +3515,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustyclawd-core"
 version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=0198b74#0198b74d6dd4d177e64f584e7e707a3d2a9402d3"
+source = "git+https://github.com/rysweet/RustyClawd?rev=4121bb1#4121bb1033db5ca32bc5e647036cbc9f6037fc98"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "rustyclawd-tools"
 version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=0198b74#0198b74d6dd4d177e64f584e7e707a3d2a9402d3"
+source = "git+https://github.com/rysweet/RustyClawd?rev=4121bb1#4121bb1033db5ca32bc5e647036cbc9f6037fc98"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/rysweet/skwaq"
 [workspace.dependencies]
 # RustyClawd agent framework — pinned to a known-good main commit for reproducible builds.
 # To update: run `cargo update -p rustyclawd-core -p rustyclawd-tools --precise <commit>`
-rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "0198b74" }
-rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "0198b74" }
+rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "4121bb1" }
+rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "4121bb1" }
 
 # Async
 tokio = { version = "1", features = ["full"] }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -73,7 +73,8 @@ pub struct AzureConfig {
     /// Azure AI Services endpoint (e.g. "https://xxx.cognitiveservices.azure.com/")
     #[serde(default)]
     pub endpoint: String,
-    /// Model deployment name (e.g. "gpt-51-skwaq")
+    /// Model deployment name(s). Comma-separated for round-robin load balancing
+    /// across multiple deployments (e.g. "gpt-54-skwaq,gpt-54-skwaq-2,gpt-54-skwaq-3").
     #[serde(default)]
     pub deployment: String,
     /// Azure OpenAI API version

--- a/skwaq.azure.toml
+++ b/skwaq.azure.toml
@@ -13,7 +13,10 @@ embeddings = "ollama"
 
 [llm.azure]
 endpoint = "https://<your-resource>.cognitiveservices.azure.com/"
-deployment = "<your-deployment-name>"
+# Single deployment:
+# deployment = "<your-deployment-name>"
+# Round-robin across multiple deployments (3x throughput):
+deployment = "<deploy-1>,<deploy-2>,<deploy-3>"
 api_version = "2024-10-21"
 # api_key = "set AZURE_OPENAI_API_KEY env var instead"
 


### PR DESCRIPTION
Updates RustyClawd pin to 4121bb1 for multi-deployment round-robin. Comma-separated deployment names in `[llm.azure] deployment` spread load across N×1M TPM.

```toml
[llm.azure]
deployment = "gpt-54-skwaq,gpt-54-skwaq-2,gpt-54-skwaq-3"
```

756 tests pass.