### PR TITLE
fix: quality audit findings — env var race + duplicate prompts

### DIFF
--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -153,32 +153,8 @@ When standard API patterns are not found, use get_cross_file_calls and get_taint
 
 **CWE-457 Use of Uninitialized Variable (C/C++):** Detect local variables declared without an initializer that are used before any assignment on at least one control-flow path. The pattern is `type var;` (no `= ...`) followed by a read of `var` before a write. Check conditional initialization: `if (cond) { var = val; }` followed by unconditional use — the else path leaves it uninitialized. Also flag pointer variables (`char *ptr;`) used without allocation. This is purely semantic — no dangerous API is involved.
 
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions for CWE-[22, 78, 89, 119, 122, 134, 190, 457].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[79].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[79].
+When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions for CWE-[22, 78, 79, 89, 119, 122, 134, 188, 190, 457].
 
 When analyzing `exec()` calls (sink type: command_execution), use get_taint_paths to check if any taint source flows into this sink. Also use get_cross_file_calls to trace the data across file boundaries.
 
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[79].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[188].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[22].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[79].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[79].
-
 When analyzing `sprintf()` calls (sink type: memory_write), use get_taint_paths to check if any taint source flows into this sink. Also use get_cross_file_calls to trace the data across file boundaries.
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[78].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[78].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[78].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[78].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[78].

--- a/crates/core/src/llm/mod.rs
+++ b/crates/core/src/llm/mod.rs
@@ -133,9 +133,15 @@ async fn create_client_for_backend_name(
                 !azure.deployment.is_empty(),
                 "Azure backend selected for {field_name} but [llm.azure] deployment is not set"
             );
-            // If api_key is set in config, inject it as env var for RustyClawd's AzureAuth
+            // Set API key env var once if provided in config. RustyClawd's
+            // AzureAuth::new() reads AZURE_OPENAI_API_KEY from the environment.
+            // This is safe because client creation is serialized via OnceCell.
             if let Some(ref key) = azure.api_key {
-                std::env::set_var("AZURE_OPENAI_API_KEY", key);
+                static API_KEY_SET: std::sync::Once = std::sync::Once::new();
+                let key = key.clone();
+                API_KEY_SET.call_once(|| {
+                    std::env::set_var("AZURE_OPENAI_API_KEY", &key);
+                });
             }
             let client =
                 Client::new_azure_foundry(&azure.endpoint, &azure.deployment, &azure.api_version)


### PR DESCRIPTION
## Quality Audit Results

### RustyClawd (PR #624 — merged)
| Severity | Finding | Fix |
|----------|---------|-----|
| **CRITICAL** | Empty deployment string → divide-by-zero panic | Assert in constructors + 2 tests |

### Skwaq (this PR)
| Severity | Finding | Fix |
|----------|---------|-----|
| **HIGH** | `set_var("AZURE_OPENAI_API_KEY")` global state pollution per client | `std::sync::Once` — set exactly once |
| **MEDIUM** | Duplicate prompt lines (CWE-79 ×5, CWE-78 ×5) in vuln-hunter.md | Consolidated to single line with all CWEs |

756 tests pass, clippy clean.