### PR TITLE
feat: capability roadmap + vuln-hunter agent cleanup

### DIFF
--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -159,16 +159,17 @@ When standard API patterns are not found, use get_cross_file_calls and get_taint
 
 **CWE-457 Use of Uninitialized Variable (C/C++):** Detect local variables declared without an initializer that are used before any assignment on at least one control-flow path. The pattern is `type var;` (no `= ...`) followed by a read of `var` before a write. Check conditional initialization: `if (cond) { var = val; }` followed by unconditional use — the else path leaves it uninitialized. Also flag pointer variables (`char *ptr;`) used without allocation. This is purely semantic — no dangerous API is involved.
 
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions for CWE-[22, 78, 79, 89, 119, 122, 134, 188, 190, 457].
+**Deep Analysis Fallback:** When standard API pattern matching yields no findings, escalate to cross-file call graph traversal and taint flow tracing:
+1. Use `get_cross_file_calls` to trace data flow through wrapper functions and indirect call chains.
+2. Use `get_taint_paths` to check if any taint source flows to dangerous sinks through intermediaries.
+3. Apply this broadly to all vulnerability classes, especially: buffer overflow (CWE-119 family), injection (CWE-78/89/134), input validation (CWE-20), information exposure (CWE-200/201/209), uninitialized variables (CWE-457/665), and path traversal (CWE-22).
 
-When analyzing `exec()` calls (sink type: command_execution), use get_taint_paths to check if any taint source flows into this sink. Also use get_cross_file_calls to trace the data across file boundaries.
+**Sink-Specific Taint Tracing:**
+- For `exec()` calls (command_execution): trace taint sources through cross-file boundaries.
+- For `sprintf()` calls (memory_write): trace taint sources through cross-file boundaries.
+- For output functions (write/send/transmit/printf): check if OOB-read or uninitialized data reaches the sink (Heartbleed pattern → CWE-200).
 
-When analyzing `sprintf()` calls (sink type: memory_write), use get_taint_paths to check if any taint source flows into this sink. Also use get_cross_file_calls to trace the data across file boundaries.
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[20, 120, 122, 129, 788].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[20, 134, 201].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[200, 209, 457, 665].
-
-When standard API patterns are not found, use get_cross_file_calls and get_taint_paths to trace data flow through wrapper functions. Look for indirect paths to dangerous sinks for CWE-[22].
+**Consequence Chain Reasoning:** When detecting a root-cause vulnerability, also check for secondary consequences:
+- CWE-125/126/127/457 (memory read issues) + output sink → also emit CWE-200 (information exposure)
+- CWE-134 (format string) inherently enables CWE-200 via %x/%p format specifiers
+- CWE-457 (uninitialized variable) + output in error handler → also emit CWE-209 (error message info leak)

--- a/data/knowledge/capability-ideas.md
+++ b/data/knowledge/capability-ideas.md
@@ -1,0 +1,50 @@
+# Capability Improvement Ideas — 2026-03-31
+
+## Cross-Validation: No Overfitting Detected
+- CyberGym (never used in improvement cycles): F1=71.9% — unchanged from baseline
+- All improvements generalize: CyberSecEval +8.4%, CGC +7.3% without degrading other suites
+- 100% precision maintained across ALL suites
+
+## 5 Creative Approaches to Boost Detection
+
+### 1. Wrapper-Aware Taint Resolution Agent
+**Priority: HIGH (best effort-to-impact ratio)**
+Pre-analysis pass that resolves thin wrapper functions to their underlying dangerous sinks.
+Identifies functions with single call chains to printf/exec/SQL, rewrites conceptual call graph.
+- Addresses: CWE-134 format string (70% → 85-90%), CWE-78 injection through wrappers
+- Complexity: Low-Medium
+- How to test: Count format_string FN cases where the sink is behind 1-2 wrapper layers
+
+### 2. Trust-Boundary Propagation Pack (KG Enrichment)
+**Priority: HIGH (highest ceiling)**
+Pre-analysis graph enrichment that annotates nodes with trust domain labels.
+Identifies servlet entry points, IPC endpoints, deserialization boundaries.
+Propagates "taint-from-untrusted" labels forward through call graph.
+- Addresses: CWE-501 trust boundary (0% → 40-60%), CWE-200/201 info exposure
+- Complexity: Medium
+- How to test: Run OWASP CWE-501 cases with trust annotations vs without
+
+### 3. Sensitivity-Classifier + Information-Flow Agent (Two-Stage)
+**Priority: MEDIUM**
+Stage 1: LLM classifies variables as sensitive (passwords, keys, tokens, PII).
+Stage 2: Traces whether classified sensitive data reaches output sinks.
+Separates sensitivity detection from flow analysis.
+- Addresses: CWE-200/201 information exposure (60% → 80-85%)
+- Complexity: Medium
+- How to test: Run CGC cases with CWE-200 ground truth, compare with/without sensitivity roster
+
+### 4. Negative-Space Auditor Agent
+**Priority: MEDIUM (high FP risk)**
+Post-processing stage that detects absence of required security operations.
+For each sensitive buffer, checks if clearing function called before free/return.
+- Addresses: CWE-226 missing memory clearing (0% → 70%)
+- Complexity: Medium
+- How to test: Run Juliet CWE-226 cases, measure TP/FP ratio carefully
+
+### 5. Type-Lineage Agent
+**Priority: LOW (high complexity)**
+Traces type information propagation across function boundaries.
+Builds "type lineage map" tracking casts, pointer arithmetic, size calculations.
+- Addresses: CWE-188 memory layout, CWE-196 type conversion
+- Complexity: High
+- How to test: Run Juliet CWE-196 cases with type annotations vs without


### PR DESCRIPTION
## Summary
- Add 5 creative capability improvement ideas for next session
- Consolidate 7 duplicated vuln-hunter fallback instructions into 3 clear sections
- Cross-validation: CyberGym F1=71.9% unchanged (no overfitting)

## Capability Ideas (prioritized)
1. Wrapper-Aware Taint Resolution (CWE-134 70%→85%, low effort)
2. Trust-Boundary Propagation Pack (CWE-501 0%→40-60%, medium effort)
3. Sensitivity-Classifier + Flow Agent (CWE-200 →80%, medium effort)
4. Negative-Space Auditor (CWE-226 0%→70%, medium effort, FP risk)
5. Type-Lineage Agent (CWE-196, high effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)