### PR TITLE
feat: CWE-501 trust boundary patterns (+4.1% OWASP F1)

### DIFF
--- a/crates/core/src/analysis/patterns_source.rs
+++ b/crates/core/src/analysis/patterns_source.rs
@@ -714,8 +714,27 @@ fn java_patterns() -> &'static [SourcePattern] {
             severity: Severity::Medium,
             reason: "Session setAttribute may store untrusted data across trust boundary (CWE-501)",
         },
-        // Cookie creation covered by broader pattern above (line ~332):
-        //   r"\bnew\s+[\w.]*Cookie\s*\("
+        // Trust boundary: getParameterMap() is an untrusted source (OWASP gap)
+        SourcePattern {
+            regex: r"\bgetParameterMap\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Medium,
+            reason: "getParameterMap() returns untrusted user input; validate before use in session/security context (CWE-501)",
+        },
+        // Trust boundary: getHeaders()/getHeaderNames() as untrusted source
+        SourcePattern {
+            regex: r"\b(?:getHeaders|getHeaderNames)\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Medium,
+            reason: "HTTP headers are untrusted input; validate before storing in session (CWE-501)",
+        },
+        // Trust boundary: putValue is legacy session storage (same as setAttribute)
+        SourcePattern {
+            regex: r"\bputValue\s*\(",
+            category: DangerCategory::Injection,
+            severity: Severity::Medium,
+            reason: "Session putValue stores data across trust boundary (CWE-501); validate input first",
+        },
     ]
 }
 


### PR DESCRIPTION
## Summary
Add missing HTTP source API patterns for trust boundary violation detection.

## New Patterns
- `getParameterMap()` — untrusted parameter map source
- `getHeaders()`/`getHeaderNames()` — untrusted header sources
- `putValue()` — legacy session storage sink

## Benchmark Results
| Suite | F1 | Previous | Change |
|-------|----|----------|--------|
| **OWASP** (500) | **92.7%** | 88.6% | **+4.1%** |
| Fixtures (99) | 93.2% | 93.2% | — |
| CyberSecEval (100) | 86.6% | 86.6% | — |

CWE-501: **16.7% → 100%** (15/15 cases detected)

## Test plan
- [x] OWASP 500 cases: F1=92.7%, P=100%
- [x] Cross-validation: no regressions on fixtures or CyberSecEval

🤖 Generated with [Claude Code](https://claude.com/claude-code)