### PR TITLE
feat: wrapper-aware taint resolution for CWE-134

### DIFF
--- a/crates/core/src/analysis/patterns_binary.rs
+++ b/crates/core/src/analysis/patterns_binary.rs
@@ -25,6 +25,33 @@ impl DangerousApiDetector {
         }
     }
 
+    /// If `func_name` wraps exactly one dangerous API, return the wrapped name.
+    fn resolve_wrapper_sink(&self, db: &GraphDb, func_name: &str) -> Option<String> {
+        let base = func_name.split('@').next().unwrap_or(func_name);
+        if self.entries.iter().any(|e| e.name == base) {
+            return None;
+        }
+        let sql = "SELECT f2.name FROM calls c \
+                   JOIN functions f1 ON c.caller_id = f1.id \
+                   JOIN functions f2 ON c.callee_id = f2.id \
+                   WHERE f1.name = ?1";
+        let mut stmt = db.conn().prepare(sql).ok()?;
+        let callees: Vec<String> = stmt
+            .query_map([func_name], |row| row.get::<_, String>(0))
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+        if callees.len() != 1 {
+            return None;
+        }
+        let callee_base = callees[0].split('@').next().unwrap_or(&callees[0]);
+        if self.entries.iter().any(|e| e.name == callee_base) {
+            Some(callee_base.to_string())
+        } else {
+            None
+        }
+    }
+
     /// Check a set of binary imports for dangerous function usage.
     pub fn check_imports(&self, imports: &[ImportInfo]) -> Vec<DangerousApiHit> {
         imports
@@ -70,6 +97,20 @@ impl DangerousApiDetector {
                         file: String::new(),
                         line: 0,
                     });
+                }
+            } else if let Some(resolved) = self.resolve_wrapper_sink(db, &name) {
+                if let Some(entry) = self.entries.iter().find(|e| e.name == resolved.as_str()) {
+                    if seen.insert(name.clone()) {
+                        hits.push(DangerousApiHit {
+                            function_name: name.clone(),
+                            library: format!("wrapper({})", resolved),
+                            reason: format!("wrapper around {}: {}", resolved, entry.reason),
+                            danger_category: entry.category.clone(),
+                            severity: entry.severity.clone(),
+                            file: String::new(),
+                            line: 0,
+                        });
+                    }
                 }
             }
         }
@@ -357,5 +398,41 @@ mod tests {
                 hits[0].danger_category
             );
         }
+    }
+
+    #[test]
+    fn test_detect_wrapper_around_dangerous_api() {
+        let db = GraphDb::in_memory().unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f1', 'my_sprintf')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f2', 'sprintf')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')",
+            &[],
+        )
+        .unwrap();
+        let detector = DangerousApiDetector::new();
+        let hits = detector.detect(&db).unwrap();
+        assert!(
+            hits.iter().any(|h| h.function_name == "sprintf"),
+            "should detect sprintf"
+        );
+        assert!(
+            hits.iter().any(|h| h.function_name == "my_sprintf"),
+            "should detect wrapper"
+        );
+        let w = hits
+            .iter()
+            .find(|h| h.function_name == "my_sprintf")
+            .unwrap();
+        assert!(w.library.contains("wrapper"));
+        assert_eq!(w.danger_category, DangerCategory::FormatString);
     }
 }

--- a/crates/core/src/analysis/perspective_pattern.rs
+++ b/crates/core/src/analysis/perspective_pattern.rs
@@ -53,6 +53,35 @@ pub fn pattern_perspective(db: &GraphDb, inv_id: &str, cycle: u32) -> Vec<Findin
                             cycle_last_updated: cycle,
                         });
                     }
+                } else if let Some(resolved) = resolve_wrapper_sink(db, &name) {
+                    if let Some((cat, sev, reason)) = dangerous_api_info(&resolved) {
+                        if seen.insert(name.clone()) {
+                            findings.push(Finding {
+                                id: Uuid::new_v4().to_string(),
+                                title: format!("Dangerous API wrapper: {} -> {}", base, resolved),
+                                description: format!("Wrapper around {}: {}", resolved, reason),
+                                severity: sev.to_string(),
+                                category: cat.to_string(),
+                                location: FindingLocation {
+                                    file: String::new(),
+                                    function: name.clone(),
+                                    line: None,
+                                    address: if address.is_empty() {
+                                        None
+                                    } else {
+                                        Some(address.clone())
+                                    },
+                                },
+                                evidence: vec![format!(
+                                    "Function '{}' wraps dangerous API '{}': {}",
+                                    base, resolved, reason
+                                )],
+                                status: FindingStatus::New,
+                                cycle_discovered: cycle,
+                                cycle_last_updated: cycle,
+                            });
+                        }
+                    }
                 }
             }
         }
@@ -133,6 +162,33 @@ pub fn pattern_perspective(db: &GraphDb, inv_id: &str, cycle: u32) -> Vec<Findin
     }
 
     findings
+}
+
+/// If `func_name` wraps exactly one dangerous API, return the wrapped name.
+fn resolve_wrapper_sink(db: &GraphDb, func_name: &str) -> Option<String> {
+    let base = func_name.split('@').next().unwrap_or(func_name);
+    if dangerous_api_info(base).is_some() {
+        return None;
+    }
+    let sql = "SELECT f2.name FROM calls c \
+               JOIN functions f1 ON c.caller_id = f1.id \
+               JOIN functions f2 ON c.callee_id = f2.id \
+               WHERE f1.name = ?1";
+    let mut stmt = db.conn().prepare(sql).ok()?;
+    let callees: Vec<String> = stmt
+        .query_map([func_name], |row| row.get::<_, String>(0))
+        .ok()?
+        .filter_map(|r| r.ok())
+        .collect();
+    if callees.len() != 1 {
+        return None;
+    }
+    let callee_base = callees[0].split('@').next().unwrap_or(&callees[0]);
+    if dangerous_api_info(callee_base).is_some() {
+        Some(callee_base.to_string())
+    } else {
+        None
+    }
 }
 
 /// Look up danger info for a function name. Returns (category, severity, reason).
@@ -270,5 +326,37 @@ mod tests {
         assert!(dangerous_api_info("system").is_some());
         assert!(dangerous_api_info("printf").is_some());
         assert!(dangerous_api_info("malloc").is_none());
+    }
+
+    #[test]
+    fn test_pattern_perspective_detects_wrapper() {
+        let db = GraphDb::in_memory().unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name, investigation_id) VALUES ('f1', 'log_msg', 'inv1')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name, investigation_id) VALUES ('f2', 'sprintf', 'inv1')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')",
+            &[],
+        )
+        .unwrap();
+        let findings = pattern_perspective(&db, "inv1", 1);
+        assert!(
+            findings.iter().any(|f| f.title.contains("sprintf")),
+            "should detect sprintf"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.title.contains("log_msg") && f.title.contains("wrapper")),
+            "should detect log_msg as wrapper: {:?}",
+            findings.iter().map(|f| &f.title).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/core/src/analysis/taint.rs
+++ b/crates/core/src/analysis/taint.rs
@@ -8,6 +8,13 @@ use crate::graph::GraphDb;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+/// Known dangerous sink function names used for wrapper resolution.
+const DANGEROUS_SINK_NAMES: &[&str] = &[
+    "sprintf", "vsprintf", "scanf", "fscanf", "sscanf", "strcpy", "strcat", "gets", "memcpy",
+    "memmove", "system", "popen", "exec", "execl", "execle", "execlp", "execv", "execvp",
+    "execvpe", "wcscpy", "wcscat", "wmemcpy", "wmemmove", "swprintf", "mktemp", "tmpnam",
+];
+
 /// Performs taint analysis over the property graph.
 pub struct TaintAnalyzer<'a> {
     db: &'a GraphDb,
@@ -17,6 +24,33 @@ pub struct TaintAnalyzer<'a> {
 impl<'a> TaintAnalyzer<'a> {
     pub fn new(db: &'a GraphDb, max_depth: u32) -> Self {
         Self { db, max_depth }
+    }
+
+    /// If `func_name` wraps exactly one dangerous sink, return the sink name.
+    fn resolve_wrapper_sink(&self, func_name: &str) -> Option<String> {
+        let base = func_name.split('@').next().unwrap_or(func_name);
+        if DANGEROUS_SINK_NAMES.contains(&base) {
+            return None;
+        }
+        let sql = "SELECT f2.name FROM calls c \
+                   JOIN functions f1 ON c.caller_id = f1.id \
+                   JOIN functions f2 ON c.callee_id = f2.id \
+                   WHERE f1.name = ?1";
+        let mut stmt = self.db.conn().prepare(sql).ok()?;
+        let callees: Vec<String> = stmt
+            .query_map([func_name], |row| row.get::<_, String>(0))
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+        if callees.len() != 1 {
+            return None;
+        }
+        let callee_base = callees[0].split('@').next().unwrap_or(&callees[0]);
+        if DANGEROUS_SINK_NAMES.contains(&callee_base) {
+            Some(callee_base.to_string())
+        } else {
+            None
+        }
     }
 
     /// Find data-flow paths from sources to sinks where no sanitiser
@@ -144,6 +178,13 @@ impl<'a> TaintAnalyzer<'a> {
                                 hops: vec![source.clone(), func_name.to_string()],
                                 sanitized: false,
                             });
+                        } else if let Some(resolved) = self.resolve_wrapper_sink(func_name) {
+                            results.push(TaintPath {
+                                source: source.clone(),
+                                sink: resolved.clone(),
+                                hops: vec![source.clone(), func_name.to_string(), resolved],
+                                sanitized: false,
+                            });
                         }
                     }
                 }
@@ -213,6 +254,16 @@ impl<'a> TaintAnalyzer<'a> {
                             source: source.clone(),
                             sink: func_name,
                             hops: path.split(" -> ").map(|s| s.trim().to_string()).collect(),
+                            sanitized: false,
+                        });
+                    } else if let Some(resolved) = self.resolve_wrapper_sink(&func_name) {
+                        let mut hops: Vec<String> =
+                            path.split(" -> ").map(|s| s.trim().to_string()).collect();
+                        hops.push(resolved.clone());
+                        results.push(TaintPath {
+                            source: source.clone(),
+                            sink: resolved,
+                            hops,
                             sanitized: false,
                         });
                     }
@@ -505,6 +556,94 @@ mod tests {
         let analyzer = TaintAnalyzer::new(&db, 10);
         let paths = analyzer.find_unsanitized_paths().unwrap();
         assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_wrapper_sink_resolution() {
+        let db = GraphDb::in_memory().unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f1', 'recv')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f2', 'my_sprintf')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f3', 'sprintf')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f2', 'f3')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO data_sources (id, name, source_type) VALUES ('src1', 'recv', 'network')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO data_sinks (id, name, sink_type) VALUES ('sink1', 'sprintf', 'format')",
+            &[],
+        )
+        .unwrap();
+
+        let analyzer = TaintAnalyzer::new(&db, 10);
+        assert_eq!(
+            analyzer.resolve_wrapper_sink("my_sprintf"),
+            Some("sprintf".to_string())
+        );
+        assert_eq!(analyzer.resolve_wrapper_sink("sprintf"), None);
+        assert_eq!(analyzer.resolve_wrapper_sink("recv"), None);
+
+        let paths = analyzer.find_unsanitized_paths().unwrap();
+        assert!(!paths.is_empty(), "should find path through wrapper");
+        assert!(
+            paths.iter().any(|p| p.sink == "sprintf"),
+            "should resolve wrapper to sprintf"
+        );
+    }
+
+    #[test]
+    fn test_wrapper_multiple_callees_not_resolved() {
+        let db = GraphDb::in_memory().unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f1', 'multi')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f2', 'sprintf')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f3', 'strlen')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f2')",
+            &[],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO calls (caller_id, callee_id) VALUES ('f1', 'f3')",
+            &[],
+        )
+        .unwrap();
+
+        let analyzer = TaintAnalyzer::new(&db, 10);
+        assert_eq!(analyzer.resolve_wrapper_sink("multi"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds wrapper function resolution to taint analysis, binary pattern detection, and pattern perspective findings
- A "simple wrapper" is a function that calls exactly ONE callee that is a known dangerous sink (e.g., `my_printf` -> `printf`)
- Applied to all three code paths: Cypher traversal, recursive CTE, and direct function scanning
- Includes 4 new tests validating wrapper resolution logic and edge cases (multi-callee rejection)

## Motivation
Format string vulnerabilities (CWE-134) are missed when dangerous APIs like `printf`/`sprintf` are called through wrapper functions. This is the #1 capability improvement identified in the roadmap.

## Changes (~100 lines of new logic + ~200 lines of tests)
- `taint.rs`: `DANGEROUS_SINK_NAMES` const + `resolve_wrapper_sink()` method on `TaintAnalyzer`, integrated into both Cypher and CTE discovery paths
- `patterns_binary.rs`: `resolve_wrapper_sink()` on `DangerousApiDetector`, integrated into `detect()` 
- `perspective_pattern.rs`: Free function `resolve_wrapper_sink()`, integrated into `pattern_perspective()`

## Test plan
- [x] `cargo build --release` compiles cleanly
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] 4 new wrapper-specific tests pass
- [x] All pre-existing analysis tests pass in isolation
- [ ] Run `cargo run --release -- gym run juliet --quick --max-cases 100` to validate CWE-134 improvement

Generated with [Claude Code](https://claude.com/claude-code)