### PR TITLE
feat: add taint-tracer to source analysis pipeline (4-agent)

### DIFF
--- a/agents/taint-tracer.md
+++ b/agents/taint-tracer.md
@@ -7,6 +7,16 @@ tools:
   - read_function
   - get_callers
   - get_callees
+  - get_taint_paths
+  - get_cross_file_calls
+  - get_data_sources
+  - get_imports
+  - search_similar
+  - lookup_knowledge
+  - lookup_cwe
+  - create_finding
+  - store_memory
+  - recall_memory
 max_turns: 25
 ---
 

--- a/crates/core/src/agents/pipeline.rs
+++ b/crates/core/src/agents/pipeline.rs
@@ -1287,7 +1287,13 @@ pub fn default_pipeline() -> AnalysisPipeline {
     default_pipeline_for_target("")
 }
 
-/// Build the default source-analysis pipeline: attack-surface -> vuln-hunter -> critic.
+/// Build the default source-analysis pipeline:
+/// attack-surface -> taint-tracer -> vuln-hunter -> critic.
+///
+/// The taint-tracer stage runs between attack-surface and vuln-hunter to
+/// enrich the context with data flow paths. This helps vuln-hunter detect
+/// cross-file vulnerabilities where the source and sink are in different
+/// functions or files.
 pub fn source_pipeline_for_target(target: &str) -> AnalysisPipeline {
     let hunter = select_vuln_hunter(target);
     AnalysisPipeline {
@@ -1295,6 +1301,17 @@ pub fn source_pipeline_for_target(target: &str) -> AnalysisPipeline {
             PipelineStage {
                 agent_name: "attack-surface".into(),
                 context_mode: ContextMode::FromGraph,
+                client_role: ClientRole::Reasoning,
+            },
+            PipelineStage {
+                agent_name: "taint-tracer".into(),
+                context_mode: ContextMode::FromPreviousResults {
+                    preamble: "The attack surface has been mapped. Now trace data flow from \
+                               untrusted sources to dangerous sinks. Use get_taint_paths and \
+                               get_cross_file_calls to find unsanitized paths. Create findings \
+                               for each confirmed taint flow."
+                        .into(),
+                },
                 client_role: ClientRole::Reasoning,
             },
             vuln_hunter_stage(hunter, false),


### PR DESCRIPTION
## Summary
Source pipeline expands from 3 to 4 agents:
`attack-surface → taint-tracer → vuln-hunter → critic`

The taint-tracer enriches context with cross-file data flow paths before
vuln-hunter runs, enabling detection of vulnerabilities spanning files.

## Changes
- Add taint-tracer as pipeline stage between attack-surface and vuln-hunter
- Add missing tools to taint-tracer: get_taint_paths, get_cross_file_calls, etc.

## Test
5-case OWASP: 3/3 TP, 2 TN, 0 FP — pipeline works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)