### PR TITLE
fix: reduce LadybugDB buffer pool for in_memory instances (#437)

### DIFF
--- a/crates/core/src/graph/ladybug_db.rs
+++ b/crates/core/src/graph/ladybug_db.rs
@@ -99,8 +99,13 @@ impl LadybugGraphDb {
         let tmp = tempfile::tempdir()?;
         let db_path = tmp.path().join("ladybug_test");
         let db = Arc::new(
-            lbug::Database::new(&db_path, lbug::SystemConfig::default())
-                .map_err(|e| anyhow::anyhow!("Failed to open LadybugDB: {e}"))?,
+            lbug::Database::new(
+                &db_path,
+                lbug::SystemConfig::default()
+                    .buffer_pool_size(64 * 1024 * 1024)
+                    .max_num_threads(1),
+            )
+            .map_err(|e| anyhow::anyhow!("Failed to open LadybugDB: {e}"))?,
         );
         let gdb = Self { db, path: db_path };
         gdb.ensure_schema()?;


### PR DESCRIPTION
## Summary
- Configure `LadybugGraphDb::in_memory()` with `buffer_pool_size(64 * 1024 * 1024)` (64MB) and `max_num_threads(1)` instead of defaults
- Reduces per-instance virtual address space from ~204GB to ~4GB, allowing 96 concurrent instances within system limits
- Fixes #437 Phase 1

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] Individual LadybugDB tests pass when run in isolation
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)