### PR TITLE
feat: SQLite-only mode for GraphDb in gym eval

### DIFF
--- a/crates/core/src/agents/tool_executor.rs
+++ b/crates/core/src/agents/tool_executor.rs
@@ -156,26 +156,54 @@ fn execute_read_function(
     let inv = esc(investigation_id);
     let name_esc = esc(func_name);
 
-    // Try by name first
-    let cypher = format!(
-        "MATCH (f:Function) WHERE f.investigation_id = '{inv}' \
-         AND f.name = '{name_esc}' \
-         RETURN f.id, f.name, f.address, f.decompiled, f.confidence LIMIT 1"
-    );
+    // Try Cypher first (when LadybugDB is available)
+    if db.has_ladybug() {
+        let cypher = format!(
+            "MATCH (f:Function) WHERE f.investigation_id = '{inv}' \
+             AND f.name = '{name_esc}' \
+             RETURN f.id, f.name, f.address, f.decompiled, f.confidence LIMIT 1"
+        );
 
-    if let Some(val) = read_function_from_rows(db.cypher_query(&cypher).ok()) {
-        return Ok(val);
+        if let Some(val) = read_function_from_rows(db.cypher_query(&cypher).ok()) {
+            return Ok(val);
+        }
+
+        // Try by address
+        let cypher = format!(
+            "MATCH (f:Function) WHERE f.investigation_id = '{inv}' \
+             AND f.address = '{name_esc}' \
+             RETURN f.id, f.name, f.address, f.decompiled, f.confidence LIMIT 1"
+        );
+
+        if let Some(val) = read_function_from_rows(db.cypher_query(&cypher).ok()) {
+            return Ok(val);
+        }
     }
 
-    // Try by address
-    let cypher = format!(
-        "MATCH (f:Function) WHERE f.investigation_id = '{inv}' \
-         AND f.address = '{name_esc}' \
-         RETURN f.id, f.name, f.address, f.decompiled, f.confidence LIMIT 1"
-    );
-
-    if let Some(val) = read_function_from_rows(db.cypher_query(&cypher).ok()) {
-        return Ok(val);
+    // SQL fallback — always works (SQLite-only mode or LadybugDB miss)
+    if let Ok(row) = db.conn().query_row(
+        "SELECT id, name, address, decompiled, confidence FROM functions \
+         WHERE investigation_id = ?1 AND (name = ?2 OR address = ?2) LIMIT 1",
+        rusqlite::params![investigation_id, func_name],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, f64>(4)?,
+            ))
+        },
+    ) {
+        let safe_decompiled = format!("<code_data>\n{}\n</code_data>", row.3);
+        return Ok(serde_json::json!({
+            "status": "ok",
+            "function_id": row.0,
+            "function": row.1,
+            "address": row.2,
+            "decompiled": safe_decompiled,
+            "confidence": row.4
+        }));
     }
 
     Ok(serde_json::json!({
@@ -231,27 +259,54 @@ fn execute_get_call_neighbors(
         ("caller", "callee")
     };
 
-    let cypher = format!(
-        "MATCH (caller:Function)-[:CALLS]->(callee:Function) \
-         WHERE {match_side}.name = '{}' AND {match_side}.investigation_id = '{}' \
-         RETURN {return_side}.name, {return_side}.address LIMIT 50",
-        esc(func_name),
-        esc(investigation_id)
-    );
+    let results: Vec<serde_json::Value> = if db.has_ladybug() {
+        let cypher = format!(
+            "MATCH (caller:Function)-[:CALLS]->(callee:Function) \
+             WHERE {match_side}.name = '{}' AND {match_side}.investigation_id = '{}' \
+             RETURN {return_side}.name, {return_side}.address LIMIT 50",
+            esc(func_name),
+            esc(investigation_id)
+        );
 
-    let results: Vec<serde_json::Value> = match db.cypher_query(&cypher) {
-        Ok(rows) => rows
-            .iter()
-            .filter_map(|r| {
-                let name = LadybugGraphDb::as_str(&r[0])?.to_string();
-                let addr = LadybugGraphDb::as_str(&r[1]).unwrap_or("").to_string();
-                Some(serde_json::json!({"name": name, "address": addr}))
-            })
-            .collect(),
-        Err(e) => {
-            tracing::debug!("get_{direction} query failed: {e}");
-            Vec::new()
+        match db.cypher_query(&cypher) {
+            Ok(rows) => rows
+                .iter()
+                .filter_map(|r| {
+                    let name = LadybugGraphDb::as_str(&r[0])?.to_string();
+                    let addr = LadybugGraphDb::as_str(&r[1]).unwrap_or("").to_string();
+                    Some(serde_json::json!({"name": name, "address": addr}))
+                })
+                .collect(),
+            Err(e) => {
+                tracing::debug!("get_{direction} query failed: {e}");
+                Vec::new()
+            }
         }
+    } else {
+        // SQL fallback for SQLite-only mode
+        let sql = if callers {
+            "SELECT f1.name, f1.address FROM calls c \
+             JOIN functions f2 ON c.callee_id = f2.id \
+             JOIN functions f1 ON c.caller_id = f1.id \
+             WHERE f2.name = ?1 AND f2.investigation_id = ?2 LIMIT 50"
+        } else {
+            "SELECT f2.name, f2.address FROM calls c \
+             JOIN functions f1 ON c.caller_id = f1.id \
+             JOIN functions f2 ON c.callee_id = f2.id \
+             WHERE f1.name = ?1 AND f1.investigation_id = ?2 LIMIT 50"
+        };
+        let mut stmt = db
+            .conn()
+            .prepare(sql)
+            .unwrap_or_else(|_| db.conn().prepare("SELECT '' WHERE 0").unwrap());
+        stmt.query_map(rusqlite::params![func_name, investigation_id], |row| {
+            Ok(serde_json::json!({
+                "name": row.get::<_, String>(0)?,
+                "address": row.get::<_, String>(1)?
+            }))
+        })
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
     };
 
     Ok(serde_json::json!({
@@ -480,43 +535,66 @@ fn execute_rename_function(
     let name_esc = esc(func_name);
     let code = esc(renamed_code);
 
-    // Try by name — check existence then update
-    let check = format!(
-        "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.name = '{name_esc}' \
-         RETURN f.name LIMIT 1"
-    );
-    if db
-        .cypher_query(&check)
-        .map(|r| !r.is_empty())
-        .unwrap_or(false)
-    {
-        let update = format!(
+    if db.has_ladybug() {
+        // Try by name — check existence then update via Cypher
+        let check = format!(
             "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.name = '{name_esc}' \
-             SET f.decompiled = '{code}'"
+             RETURN f.name LIMIT 1"
         );
-        db.cypher_execute(&update)?;
-        return Ok(serde_json::json!({
-            "status": "ok",
-            "function": func_name,
-            "message": format!("Updated decompiled code for '{}'", func_name)
-        }));
+        if db
+            .cypher_query(&check)
+            .map(|r| !r.is_empty())
+            .unwrap_or(false)
+        {
+            let update = format!(
+                "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.name = '{name_esc}' \
+                 SET f.decompiled = '{code}'"
+            );
+            db.cypher_execute(&update)?;
+            return Ok(serde_json::json!({
+                "status": "ok",
+                "function": func_name,
+                "message": format!("Updated decompiled code for '{}'", func_name)
+            }));
+        }
+
+        // Try by address
+        let check = format!(
+            "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.address = '{name_esc}' \
+             RETURN f.name LIMIT 1"
+        );
+        if db
+            .cypher_query(&check)
+            .map(|r| !r.is_empty())
+            .unwrap_or(false)
+        {
+            let update = format!(
+                "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.address = '{name_esc}' \
+                 SET f.decompiled = '{code}'"
+            );
+            db.cypher_execute(&update)?;
+            return Ok(serde_json::json!({
+                "status": "ok",
+                "function": func_name,
+                "message": format!("Updated decompiled code for '{}'", func_name)
+            }));
+        }
     }
 
-    // Try by address
-    let check = format!(
-        "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.address = '{name_esc}' \
-         RETURN f.name LIMIT 1"
-    );
-    if db
-        .cypher_query(&check)
-        .map(|r| !r.is_empty())
-        .unwrap_or(false)
-    {
-        let update = format!(
-            "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.address = '{name_esc}' \
-             SET f.decompiled = '{code}'"
-        );
-        db.cypher_execute(&update)?;
+    // SQL fallback — works in SQLite-only mode
+    let updated = db
+        .execute(
+            "UPDATE functions SET decompiled = ?1 \
+             WHERE investigation_id = ?2 AND (name = ?3 OR address = ?3)",
+            &[
+                &renamed_code as &dyn rusqlite::types::ToSql,
+                &investigation_id,
+                &func_name,
+            ],
+        )
+        .unwrap_or(0);
+
+    if updated > 0 {
         return Ok(serde_json::json!({
             "status": "ok",
             "function": func_name,

--- a/crates/core/src/graph/db.rs
+++ b/crates/core/src/graph/db.rs
@@ -11,11 +11,12 @@ use super::ladybug_db::LadybugGraphDb;
 /// Wrapper around the graph database.
 ///
 /// Backed by LadybugDB for native Cypher graph queries and SQLite for
-/// legacy schema compatibility. LadybugDB is REQUIRED — not optional.
+/// legacy schema compatibility. LadybugDB is optional — gym eval uses
+/// SQLite-only mode to avoid mmap overhead on per-case databases.
 pub struct GraphDb {
     conn: rusqlite::Connection,
-    /// LadybugDB backend for native Cypher queries.
-    ladybug: LadybugGraphDb,
+    /// LadybugDB backend for native Cypher queries (None in SQLite-only mode).
+    ladybug: Option<LadybugGraphDb>,
 }
 
 impl GraphDb {
@@ -26,7 +27,10 @@ impl GraphDb {
         let conn = rusqlite::Connection::open(&db_file)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
         let ladybug = LadybugGraphDb::open(path)?;
-        let gdb = Self { conn, ladybug };
+        let gdb = Self {
+            conn,
+            ladybug: Some(ladybug),
+        };
         gdb.ensure_schema()?;
         Ok(gdb)
     }
@@ -35,7 +39,25 @@ impl GraphDb {
     pub fn in_memory() -> anyhow::Result<Self> {
         let conn = rusqlite::Connection::open_in_memory()?;
         let ladybug = LadybugGraphDb::in_memory()?;
-        let gdb = Self { conn, ladybug };
+        let gdb = Self {
+            conn,
+            ladybug: Some(ladybug),
+        };
+        gdb.ensure_schema()?;
+        Ok(gdb)
+    }
+
+    /// Open an in-memory SQLite-only database (no LadybugDB).
+    ///
+    /// Used by gym eval where per-case LadybugDB is dead weight —
+    /// GraphBuilder writes only to SQLite, and agent queries fall through
+    /// to the SQL-based path in tool_executor. Eliminates mmap overhead.
+    pub fn in_memory_sqlite_only() -> anyhow::Result<Self> {
+        let conn = rusqlite::Connection::open_in_memory()?;
+        let gdb = Self {
+            conn,
+            ladybug: None,
+        };
         gdb.ensure_schema()?;
         Ok(gdb)
     }
@@ -62,27 +84,38 @@ impl GraphDb {
     }
 
     /// Execute a Cypher query via LadybugDB.
+    /// Returns empty results when in SQLite-only mode.
     #[allow(dead_code)]
     pub fn cypher_query(&self, cypher: &str) -> anyhow::Result<Vec<Vec<lbug::Value>>> {
-        self.ladybug.query(cypher)
+        match &self.ladybug {
+            Some(lg) => lg.query(cypher),
+            None => Ok(Vec::new()),
+        }
     }
 
     /// Execute a Cypher statement (no results expected).
+    /// No-op when in SQLite-only mode.
     #[allow(dead_code)]
     pub fn cypher_execute(&self, cypher: &str) -> anyhow::Result<()> {
-        self.ladybug.execute(cypher)
+        match &self.ladybug {
+            Some(lg) => lg.execute(cypher),
+            None => {
+                let _ = cypher;
+                Ok(())
+            }
+        }
     }
 
-    /// LadybugDB is always available.
+    /// Whether LadybugDB is available.
     #[allow(dead_code)]
     pub fn has_ladybug(&self) -> bool {
-        true
+        self.ladybug.is_some()
     }
 
-    /// Get the LadybugDB handle.
+    /// Get the LadybugDB handle (if available).
     #[allow(dead_code)]
-    pub fn ladybug(&self) -> &LadybugGraphDb {
-        &self.ladybug
+    pub fn ladybug(&self) -> Option<&LadybugGraphDb> {
+        self.ladybug.as_ref()
     }
 
     fn ensure_schema(&self) -> anyhow::Result<()> {
@@ -312,6 +345,37 @@ mod tests {
             .query_row("SELECT count(*) FROM functions", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_open_in_memory_sqlite_only() {
+        let db = GraphDb::in_memory_sqlite_only().unwrap();
+        // Schema should exist (SQLite tables work)
+        let count: i64 = db
+            .conn()
+            .query_row("SELECT count(*) FROM functions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+        // LadybugDB not available
+        assert!(!db.has_ladybug());
+        // cypher_query returns empty (not error)
+        let rows = db.cypher_query("MATCH (n) RETURN n").unwrap();
+        assert!(rows.is_empty());
+        // cypher_execute is a no-op
+        assert!(db.cypher_execute("CREATE (n:Test {id: '1'})").is_ok());
+        // SQLite operations still work
+        db.execute(
+            "INSERT INTO functions (id, name) VALUES ('f1', 'test')",
+            &[],
+        )
+        .unwrap();
+        let name: String = db
+            .conn()
+            .query_row("SELECT name FROM functions WHERE id = 'f1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(name, "test");
     }
 
     #[test]

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -225,7 +225,8 @@ pub async fn run_agentic_multi_file_source_analysis(
 
     // Ingest all files into a shared graph, then run the agent pipeline
     // on the primary file with cross-file context available.
-    let db = GraphDb::in_memory()?;
+    // SQLite-only: skip LadybugDB mmap overhead for per-case gym databases.
+    let db = GraphDb::in_memory_sqlite_only()?;
     let inv_id = format!("gym-mf-{}", &uuid::Uuid::new_v4().to_string()[..8]);
     let now = chrono::Utc::now().to_rfc3339();
     let file_str = primary.to_string_lossy().to_string();
@@ -353,7 +354,7 @@ pub fn run_multi_file_pattern_analysis(paths: &[PathBuf]) -> anyhow::Result<Vec<
         return Ok(vec![]);
     }
 
-    let db = GraphDb::in_memory()?;
+    let db = GraphDb::in_memory_sqlite_only()?;
     let inv_id = format!("gym-mf-{}", &uuid::Uuid::new_v4().to_string()[..8]);
     let now = chrono::Utc::now().to_rfc3339();
     let target = paths
@@ -465,7 +466,7 @@ pub async fn run_agentic_source_analysis_with_hints(
     timeout_secs: u64,
     hints: &AnalysisHints,
 ) -> anyhow::Result<Vec<DetectedFinding>> {
-    let db = GraphDb::in_memory()?;
+    let db = GraphDb::in_memory_sqlite_only()?;
     let parsed = parse_file(path)?;
 
     let inv_id = format!("gym-{}", &uuid::Uuid::new_v4().to_string()[..8]);
@@ -723,7 +724,7 @@ pub async fn run_agentic_binary_analysis(
 ) -> anyhow::Result<Vec<DetectedFinding>> {
     use skwaq_core::binary::native::parse_binary;
 
-    let db = GraphDb::in_memory()?;
+    let db = GraphDb::in_memory_sqlite_only()?;
     let binary_info = parse_binary(path)?;
 
     let inv_id = format!("gym-bin-{}", &uuid::Uuid::new_v4().to_string()[..8]);
@@ -833,7 +834,7 @@ pub async fn run_llm_only_source_analysis(
     path: &Path,
     timeout_secs: u64,
 ) -> anyhow::Result<Vec<DetectedFinding>> {
-    let db = GraphDb::in_memory()?;
+    let db = GraphDb::in_memory_sqlite_only()?;
     let parsed = parse_file(path)?;
 
     let inv_id = format!("gym-llm-{}", &uuid::Uuid::new_v4().to_string()[..8]);
@@ -875,7 +876,7 @@ pub async fn run_llm_only_binary_analysis(
 ) -> anyhow::Result<Vec<DetectedFinding>> {
     use skwaq_core::binary::native::parse_binary;
 
-    let db = GraphDb::in_memory()?;
+    let db = GraphDb::in_memory_sqlite_only()?;
     let binary_info = parse_binary(path)?;
 
     let inv_id = format!("gym-llm-bin-{}", &uuid::Uuid::new_v4().to_string()[..8]);


### PR DESCRIPTION
## Summary

- Add `GraphDb::in_memory_sqlite_only()` constructor that creates SQLite in-memory with `ladybug` set to `None`, eliminating all LadybugDB mmap overhead for per-case gym databases
- Make `GraphDb.ladybug` field `Option<LadybugGraphDb>` — `cypher_query` returns empty vec, `cypher_execute` is no-op when None
- Replace all 6 `GraphDb::in_memory()` call sites in `crates/gym/src/agentic.rs` with `in_memory_sqlite_only()`
- Add SQL fallbacks in `tool_executor.rs` for `read_function`, `get_call_neighbors`, and `rename_function` so agents still get data from SQLite when LadybugDB is absent

This eliminates all LadybugDB mmap overhead for gym cases, enabling j=48+ without mmap errors.

## Test plan

- [x] `cargo check --tests` passes for all crates (core, gym, cli)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -p skwaq-core -p skwaq-gym -- -D warnings` clean
- [x] `cargo test -p skwaq-core graph::db::tests` — all 7 tests pass including new `test_open_in_memory_sqlite_only`
- [ ] CI checks pass
- [ ] Gym fixtures benchmark still passes (no regression)

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)