### PR TITLE
fix: cap LadybugDB mmap VA to 256MB and revert SQLite-only mode

### DIFF
--- a/crates/core/src/graph/db.rs
+++ b/crates/core/src/graph/db.rs
@@ -11,12 +11,10 @@ use super::ladybug_db::LadybugGraphDb;
 /// Wrapper around the graph database.
 ///
 /// Backed by LadybugDB for native Cypher graph queries and SQLite for
-/// legacy schema compatibility. LadybugDB is optional — gym eval uses
-/// SQLite-only mode to avoid mmap overhead on per-case databases.
+/// legacy schema compatibility. New graph queries should use `cypher()`.
 pub struct GraphDb {
     conn: rusqlite::Connection,
-    /// LadybugDB backend for native Cypher queries (None in SQLite-only mode).
-    ladybug: Option<LadybugGraphDb>,
+    ladybug: LadybugGraphDb,
 }
 
 impl GraphDb {
@@ -27,10 +25,7 @@ impl GraphDb {
         let conn = rusqlite::Connection::open(&db_file)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
         let ladybug = LadybugGraphDb::open(path)?;
-        let gdb = Self {
-            conn,
-            ladybug: Some(ladybug),
-        };
+        let gdb = Self { conn, ladybug };
         gdb.ensure_schema()?;
         Ok(gdb)
     }
@@ -39,25 +34,7 @@ impl GraphDb {
     pub fn in_memory() -> anyhow::Result<Self> {
         let conn = rusqlite::Connection::open_in_memory()?;
         let ladybug = LadybugGraphDb::in_memory()?;
-        let gdb = Self {
-            conn,
-            ladybug: Some(ladybug),
-        };
-        gdb.ensure_schema()?;
-        Ok(gdb)
-    }
-
-    /// Open an in-memory SQLite-only database (no LadybugDB).
-    ///
-    /// Used by gym eval where per-case LadybugDB is dead weight —
-    /// GraphBuilder writes only to SQLite, and agent queries fall through
-    /// to the SQL-based path in tool_executor. Eliminates mmap overhead.
-    pub fn in_memory_sqlite_only() -> anyhow::Result<Self> {
-        let conn = rusqlite::Connection::open_in_memory()?;
-        let gdb = Self {
-            conn,
-            ladybug: None,
-        };
+        let gdb = Self { conn, ladybug };
         gdb.ensure_schema()?;
         Ok(gdb)
     }
@@ -84,38 +61,27 @@ impl GraphDb {
     }
 
     /// Execute a Cypher query via LadybugDB.
-    /// Returns empty results when in SQLite-only mode.
     #[allow(dead_code)]
     pub fn cypher_query(&self, cypher: &str) -> anyhow::Result<Vec<Vec<lbug::Value>>> {
-        match &self.ladybug {
-            Some(lg) => lg.query(cypher),
-            None => Ok(Vec::new()),
-        }
+        self.ladybug.query(cypher)
     }
 
     /// Execute a Cypher statement (no results expected).
-    /// No-op when in SQLite-only mode.
     #[allow(dead_code)]
     pub fn cypher_execute(&self, cypher: &str) -> anyhow::Result<()> {
-        match &self.ladybug {
-            Some(lg) => lg.execute(cypher),
-            None => {
-                let _ = cypher;
-                Ok(())
-            }
-        }
+        self.ladybug.execute(cypher)
     }
 
-    /// Whether LadybugDB is available.
+    /// Whether LadybugDB is available (always true now).
     #[allow(dead_code)]
     pub fn has_ladybug(&self) -> bool {
-        self.ladybug.is_some()
+        true
     }
 
-    /// Get the LadybugDB handle (if available).
+    /// Get the LadybugDB handle.
     #[allow(dead_code)]
-    pub fn ladybug(&self) -> Option<&LadybugGraphDb> {
-        self.ladybug.as_ref()
+    pub fn ladybug(&self) -> &LadybugGraphDb {
+        &self.ladybug
     }
 
     fn ensure_schema(&self) -> anyhow::Result<()> {
@@ -345,37 +311,6 @@ mod tests {
             .query_row("SELECT count(*) FROM functions", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
-    }
-
-    #[test]
-    fn test_open_in_memory_sqlite_only() {
-        let db = GraphDb::in_memory_sqlite_only().unwrap();
-        // Schema should exist (SQLite tables work)
-        let count: i64 = db
-            .conn()
-            .query_row("SELECT count(*) FROM functions", [], |row| row.get(0))
-            .unwrap();
-        assert_eq!(count, 0);
-        // LadybugDB not available
-        assert!(!db.has_ladybug());
-        // cypher_query returns empty (not error)
-        let rows = db.cypher_query("MATCH (n) RETURN n").unwrap();
-        assert!(rows.is_empty());
-        // cypher_execute is a no-op
-        assert!(db.cypher_execute("CREATE (n:Test {id: '1'})").is_ok());
-        // SQLite operations still work
-        db.execute(
-            "INSERT INTO functions (id, name) VALUES ('f1', 'test')",
-            &[],
-        )
-        .unwrap();
-        let name: String = db
-            .conn()
-            .query_row("SELECT name FROM functions WHERE id = 'f1'", [], |row| {
-                row.get(0)
-            })
-            .unwrap();
-        assert_eq!(name, "test");
     }
 
     #[test]

--- a/crates/core/src/graph/ladybug_db.rs
+++ b/crates/core/src/graph/ladybug_db.rs
@@ -103,6 +103,7 @@ impl LadybugGraphDb {
                 &db_path,
                 lbug::SystemConfig::default()
                     .buffer_pool_size(64 * 1024 * 1024)
+                    .max_db_size(1 << 28)
                     .max_num_threads(1),
             )
             .map_err(|e| anyhow::anyhow!("Failed to open LadybugDB: {e}"))?,

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -226,7 +226,7 @@ pub async fn run_agentic_multi_file_source_analysis(
     // Ingest all files into a shared graph, then run the agent pipeline
     // on the primary file with cross-file context available.
     // SQLite-only: skip LadybugDB mmap overhead for per-case gym databases.
-    let db = GraphDb::in_memory_sqlite_only()?;
+    let db = GraphDb::in_memory()?;
     let inv_id = format!("gym-mf-{}", &uuid::Uuid::new_v4().to_string()[..8]);
     let now = chrono::Utc::now().to_rfc3339();
     let file_str = primary.to_string_lossy().to_string();
@@ -354,7 +354,7 @@ pub fn run_multi_file_pattern_analysis(paths: &[PathBuf]) -> anyhow::Result<Vec<
         return Ok(vec![]);
     }
 
-    let db = GraphDb::in_memory_sqlite_only()?;
+    let db = GraphDb::in_memory()?;
     let inv_id = format!("gym-mf-{}", &uuid::Uuid::new_v4().to_string()[..8]);
     let now = chrono::Utc::now().to_rfc3339();
     let target = paths
@@ -466,7 +466,7 @@ pub async fn run_agentic_source_analysis_with_hints(
     timeout_secs: u64,
     hints: &AnalysisHints,
 ) -> anyhow::Result<Vec<DetectedFinding>> {
-    let db = GraphDb::in_memory_sqlite_only()?;
+    let db = GraphDb::in_memory()?;
     let parsed = parse_file(path)?;
 
     let inv_id = format!("gym-{}", &uuid::Uuid::new_v4().to_string()[..8]);
@@ -724,7 +724,7 @@ pub async fn run_agentic_binary_analysis(
 ) -> anyhow::Result<Vec<DetectedFinding>> {
     use skwaq_core::binary::native::parse_binary;
 
-    let db = GraphDb::in_memory_sqlite_only()?;
+    let db = GraphDb::in_memory()?;
     let binary_info = parse_binary(path)?;
 
     let inv_id = format!("gym-bin-{}", &uuid::Uuid::new_v4().to_string()[..8]);
@@ -834,7 +834,7 @@ pub async fn run_llm_only_source_analysis(
     path: &Path,
     timeout_secs: u64,
 ) -> anyhow::Result<Vec<DetectedFinding>> {
-    let db = GraphDb::in_memory_sqlite_only()?;
+    let db = GraphDb::in_memory()?;
     let parsed = parse_file(path)?;
 
     let inv_id = format!("gym-llm-{}", &uuid::Uuid::new_v4().to_string()[..8]);
@@ -876,7 +876,7 @@ pub async fn run_llm_only_binary_analysis(
 ) -> anyhow::Result<Vec<DetectedFinding>> {
     use skwaq_core::binary::native::parse_binary;
 
-    let db = GraphDb::in_memory_sqlite_only()?;
+    let db = GraphDb::in_memory()?;
     let binary_info = parse_binary(path)?;
 
     let inv_id = format!("gym-llm-bin-{}", &uuid::Uuid::new_v4().to_string()[..8]);


### PR DESCRIPTION
## Summary

- **Root cause**: Each LadybugDB `in_memory()` instance mmaps 8TB (`DEFAULT_VM_REGION_MAX_SIZE = 1<<43`). At 64 concurrent instances, that's 512TB — exceeding the 128TB Linux virtual address space limit.
- Add `.max_db_size(1 << 28)` to `SystemConfig` in `LadybugGraphDb::in_memory()`, capping per-instance VA at 256MB (64 instances = 16GB total, trivial)
- Revert PR #443 SQLite-only `GraphDb` mode — agents need LadybugDB for Cypher queries, and the mmap fix makes SQLite-only unnecessary
- Restore `ladybug` field to non-Optional `LadybugGraphDb`

Closes #437

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test -p skwaq-core graph` — 26/26 pass
- [x] `cargo test` — all pass (1 pre-existing KB test failure unrelated to this change)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)