### PR TITLE
Fix #450 #451: Add Info severity + fix gym monitor progress

### DIFF
--- a/crates/cli/src/commands/gym_cmd.rs
+++ b/crates/cli/src/commands/gym_cmd.rs
@@ -827,14 +827,18 @@ pub async fn run(sub: &GymSub) -> anyhow::Result<()> {
                         }
                     }
 
-                    // Count cases from logs
+                    // Count completed cases from stdout logs (CASE_DONE markers)
                     let mut total_cases = 0;
                     let mut total_retries = 0;
                     for i in 0..children.len() {
                         let log = suite_dir.join(format!("shard-{i}.log"));
                         if let Ok(content) = std::fs::read_to_string(&log) {
-                            total_cases += content.matches("Agent").count().saturating_sub(1) / 5;
-                            total_retries += content.matches("Retrying").count();
+                            total_cases += content.matches("CASE_DONE").count();
+                        }
+                        let stderr_log = suite_dir.join(format!("shard-{i}.stderr.log"));
+                        if let Ok(content) = std::fs::read_to_string(&stderr_log) {
+                            total_retries += content.matches("Retrying").count()
+                                + content.matches("requeueing").count();
                         }
                     }
                     let target = suite_cases.get(suite.as_str()).copied().unwrap_or(0);

--- a/crates/core/src/agents/output_schema.rs
+++ b/crates/core/src/agents/output_schema.rs
@@ -12,6 +12,7 @@ pub enum VulnHunterSeverity {
     High,
     Medium,
     Low,
+    Info,
 }
 
 impl fmt::Display for VulnHunterSeverity {
@@ -21,6 +22,7 @@ impl fmt::Display for VulnHunterSeverity {
             Self::High => write!(f, "high"),
             Self::Medium => write!(f, "medium"),
             Self::Low => write!(f, "low"),
+            Self::Info => write!(f, "info"),
         }
     }
 }
@@ -205,7 +207,7 @@ pub fn output_schema_contract(schema_name: &str) -> Option<&'static str> {
                \"findings\": [\n\
                  {\n\
                    \"title\": \"Specific vulnerability title\",\n\
-                   \"severity\": \"critical|high|medium|low\",\n\
+                   \"severity\": \"critical|high|medium|low|info\",\n\
                    \"cwe_id\": \"CWE-XXX\",\n\
                    \"function\": \"function_name\"\n\
                  }\n\
@@ -614,5 +616,37 @@ mod tests {
 
         let error = parse_structured_output(EXPLOIT_ANALYST_V1_SCHEMA, output).unwrap_err();
         assert!(error.to_string().contains("at least one evidence item"));
+    }
+
+    #[test]
+    fn parses_info_severity_finding() {
+        let output = r#"```json
+{
+  "summary": "Informational observation",
+  "findings": [
+    {
+      "title": "Unused import detected",
+      "severity": "info",
+      "cwe_id": "CWE-561",
+      "function": "main"
+    }
+  ]
+}
+```"#;
+
+        let parsed = parse_structured_output(VULN_HUNTER_V1_SCHEMA, output).unwrap();
+        match parsed {
+            ParsedAgentOutput::VulnHunterV1(data) => {
+                assert_eq!(data.findings[0].severity, VulnHunterSeverity::Info);
+                assert_eq!(data.findings[0].severity.to_string(), "info");
+            }
+            other => panic!("expected vuln hunter output, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn output_contract_includes_info_severity() {
+        let contract = output_schema_contract(VULN_HUNTER_V1_SCHEMA).unwrap();
+        assert!(contract.contains("info"));
     }
 }

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -475,6 +475,7 @@ impl Gym {
                             metrics::CASE_DURATION
                                 .with_label_values(&[&suite_name])
                                 .observe(elapsed);
+                            println!("CASE_DONE {}", case.id);
                             let mut outcome = scoring::score_case(case, &findings, &|f| {
                                 adapter.map_finding_to_cwes(f)
                             });
@@ -486,6 +487,7 @@ impl Gym {
                             metrics::CASES_TOTAL
                                 .with_label_values(&[&suite_name, "failed"])
                                 .inc();
+                            println!("CASE_DONE {}", case.id);
                             tracing::warn!("Case {} failed: {}", case.id, e);
                         }
                         Err(_) => {
@@ -493,6 +495,7 @@ impl Gym {
                             metrics::CASES_TOTAL
                                 .with_label_values(&[&suite_name, "timeout"])
                                 .inc();
+                            println!("CASE_DONE {}", case.id);
                             tracing::warn!("Case {} timed out after {}s", case.id, timeout_secs);
                         }
                     }
@@ -601,6 +604,7 @@ impl Gym {
                             metrics::CASES_TOTAL
                                 .with_label_values(&[&suite, "completed"])
                                 .inc();
+                            println!("CASE_DONE {}", case.id);
                             let mut outcome = scoring::score_case(case, &findings, &|f| {
                                 adapter.map_finding_to_cwes(f)
                             });
@@ -645,6 +649,7 @@ impl Gym {
                                 metrics::CASES_TOTAL
                                     .with_label_values(&[&suite, "failed"])
                                     .inc();
+                                println!("CASE_DONE {}", case.id);
                                 tracing::warn!(
                                     "[{}/{}] Case {} failed (not retryable or max retries): {}",
                                     i,
@@ -677,6 +682,7 @@ impl Gym {
                                 metrics::CASES_TOTAL
                                     .with_label_values(&[&suite, "timeout"])
                                     .inc();
+                                println!("CASE_DONE {}", case.id);
                                 tracing::warn!(
                                     "[{}/{}] Case {} timed out after {}s (max retries exhausted)",
                                     i,


### PR DESCRIPTION
## Summary
- **#450**: Add `Info` variant to `VulnHunterSeverity` enum with `Display` impl and updated structured output contract string
- **#451**: Fix gym eval monitor showing 0% progress — the monitor counted "Agent" in stdout logs but progress was logged via tracing to stderr. Added reliable `CASE_DONE` stdout markers per-case and updated the monitor to count them

## Changes
- `crates/core/src/agents/output_schema.rs`: Add `Info` to enum, Display impl, contract string; add 2 tests
- `crates/gym/src/lib.rs`: Emit `CASE_DONE` markers to stdout in both sequential and concurrent paths
- `crates/cli/src/commands/gym_cmd.rs`: Monitor counts `CASE_DONE` markers from stdout + retries from stderr

## Test plan
- [x] All 17 output_schema tests pass (15 existing + 2 new)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] Pre-existing kb_cli test failure confirmed unrelated (fails on main too)

Closes #450, closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)