### PR TITLE
feat: content filter classification + RustyClawd 43ebaa1 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,7 +1075,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1841,7 +1841,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2672,7 +2672,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3368,7 +3368,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3406,9 +3406,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3852,7 +3852,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3911,7 +3911,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3940,8 +3940,8 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyclawd-core"
-version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=856bdf8#856bdf81d2404fb57b16ef6a9836c6da9655651b"
+version = "0.1.1"
+source = "git+https://github.com/rysweet/RustyClawd?rev=43ebaa1#43ebaa1c1b18a5630c53f0519989a2bacd42ef62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3962,8 +3962,8 @@ dependencies = [
 
 [[package]]
 name = "rustyclawd-tools"
-version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd?rev=856bdf8#856bdf81d2404fb57b16ef6a9836c6da9655651b"
+version = "0.1.1"
+source = "git+https://github.com/rysweet/RustyClawd?rev=43ebaa1#43ebaa1c1b18a5630c53f0519989a2bacd42ef62"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4660,7 +4660,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5669,7 +5669,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5777,15 +5777,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5817,28 +5808,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5854,12 +5828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5870,12 +5838,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5890,22 +5852,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5920,12 +5870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,12 +5880,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5956,12 +5894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5972,12 +5904,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/rysweet/skwaq"
 [workspace.dependencies]
 # RustyClawd agent framework — pinned to a known-good main commit for reproducible builds.
 # To update: run `cargo update -p rustyclawd-core -p rustyclawd-tools --precise <commit>`
-rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "856bdf8" }
-rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "856bdf8" }
+rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd", rev = "43ebaa1" }
+rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd", rev = "43ebaa1" }
 
 # Async
 tokio = { version = "1", features = ["full"] }

--- a/crates/gym/src/lib.rs
+++ b/crates/gym/src/lib.rs
@@ -442,6 +442,7 @@ impl Gym {
             // Each case creates its own in-memory GraphDb, so no shared state.
             // Concurrency > 1 lets multiple LLM API calls overlap (network I/O).
             let mut outcomes = Vec::with_capacity(total);
+            let mut content_filtered: u32 = 0;
             let timeout_secs = config.timeout_secs;
 
             if concurrency <= 1 {
@@ -484,11 +485,23 @@ impl Gym {
                         }
                         Ok(Err(e)) => {
                             metrics::CASES_IN_PROGRESS.dec();
-                            metrics::CASES_TOTAL
-                                .with_label_values(&[&suite_name, "failed"])
-                                .inc();
-                            println!("CASE_DONE {}", case.id);
-                            tracing::warn!("Case {} failed: {}", case.id, e);
+                            if is_content_filter_error(&e) {
+                                content_filtered += 1;
+                                metrics::CASES_TOTAL
+                                    .with_label_values(&[&suite_name, "content_filtered"])
+                                    .inc();
+                                println!("CASE_DONE {}", case.id);
+                                tracing::info!(
+                                    "Case {} content-filtered (excluded from scoring)",
+                                    case.id
+                                );
+                            } else {
+                                metrics::CASES_TOTAL
+                                    .with_label_values(&[&suite_name, "failed"])
+                                    .inc();
+                                println!("CASE_DONE {}", case.id);
+                                tracing::warn!("Case {} failed: {}", case.id, e);
+                            }
                         }
                         Err(_) => {
                             metrics::CASES_IN_PROGRESS.dec();
@@ -612,52 +625,68 @@ impl Gym {
                             outcomes.push(outcome);
                         }
                         Ok(Err(e)) => {
-                            let msg = e.to_string();
-                            let is_retryable = msg.contains("429")
-                                || msg.contains("529")
-                                || msg.contains("overloaded")
-                                || msg.contains("rate")
-                                || msg.contains("Rate")
-                                || msg.contains("Timeout")
-                                || msg.contains("timed out")
-                                || msg.contains("throttl")
-                                || msg.contains("error sending request");
-                            // Signal cross-process backoff on rate limit errors
-                            if is_retryable
-                                && (msg.contains("429")
-                                    || msg.contains("529")
-                                    || msg.contains("overloaded"))
-                            {
-                                crate::throttle::CrossProcessBackoff::new().signal_rate_limited(30);
-                            }
-                            // Extract retry count from the case index (stored as i)
-                            let retry_count = retry_queue
-                                .iter()
-                                .filter(|(idx, _, _)| *idx == i)
-                                .map(|(_, _, r)| *r)
-                                .next()
-                                .unwrap_or(0);
-                            if is_retryable && retry_count < MAX_RETRIES {
+                            // Content filter errors are deterministic — never retry.
+                            if is_content_filter_error(&e) {
+                                content_filtered += 1;
+                                metrics::CASES_TOTAL
+                                    .with_label_values(&[&suite, "content_filtered"])
+                                    .inc();
+                                println!("CASE_DONE {}", case.id);
                                 tracing::info!(
+                                    "[{}/{}] Case {} content-filtered (excluded from scoring)",
+                                    i,
+                                    total,
+                                    case.id
+                                );
+                            } else {
+                                let msg = e.to_string();
+                                let is_retryable = msg.contains("429")
+                                    || msg.contains("529")
+                                    || msg.contains("overloaded")
+                                    || msg.contains("rate")
+                                    || msg.contains("Rate")
+                                    || msg.contains("Timeout")
+                                    || msg.contains("timed out")
+                                    || msg.contains("throttl")
+                                    || msg.contains("error sending request");
+                                // Signal cross-process backoff on rate limit errors
+                                if is_retryable
+                                    && (msg.contains("429")
+                                        || msg.contains("529")
+                                        || msg.contains("overloaded"))
+                                {
+                                    crate::throttle::CrossProcessBackoff::new()
+                                        .signal_rate_limited(30);
+                                }
+                                // Extract retry count from the case index (stored as i)
+                                let retry_count = retry_queue
+                                    .iter()
+                                    .filter(|(idx, _, _)| *idx == i)
+                                    .map(|(_, _, r)| *r)
+                                    .next()
+                                    .unwrap_or(0);
+                                if is_retryable && retry_count < MAX_RETRIES {
+                                    tracing::info!(
                                     "[{}/{}] Case {} failed (retryable), requeueing (attempt {}/{}): {}",
                                     i, total, case.id, retry_count + 1, MAX_RETRIES, msg.chars().take(80).collect::<String>()
                                 );
-                                metrics::RETRIES_TOTAL.with_label_values(&[&suite]).inc();
-                                retry_queue.push((i, case, retry_count + 1));
-                                total_retries += 1;
-                            } else {
-                                metrics::CASES_TOTAL
-                                    .with_label_values(&[&suite, "failed"])
-                                    .inc();
-                                println!("CASE_DONE {}", case.id);
-                                tracing::warn!(
-                                    "[{}/{}] Case {} failed (not retryable or max retries): {}",
-                                    i,
-                                    total,
-                                    case.id,
-                                    e
-                                );
-                            }
+                                    metrics::RETRIES_TOTAL.with_label_values(&[&suite]).inc();
+                                    retry_queue.push((i, case, retry_count + 1));
+                                    total_retries += 1;
+                                } else {
+                                    metrics::CASES_TOTAL
+                                        .with_label_values(&[&suite, "failed"])
+                                        .inc();
+                                    println!("CASE_DONE {}", case.id);
+                                    tracing::warn!(
+                                        "[{}/{}] Case {} failed (not retryable or max retries): {}",
+                                        i,
+                                        total,
+                                        case.id,
+                                        e
+                                    );
+                                }
+                            } // end else (not content-filtered)
                         }
                         Err(_) => {
                             let retry_count = retry_queue
@@ -908,7 +937,11 @@ impl Gym {
             };
             self.history_db.finish_run(&run)?;
 
-            reporting::terminal::print_summary(&score, &suite_name);
+            reporting::terminal::print_summary_with_content_filtered(
+                &score,
+                &suite_name,
+                content_filtered,
+            );
         }
 
         // Report synthesis usage across the entire run
@@ -1074,6 +1107,17 @@ fn build_run_metadata(
     }
 }
 
+/// Detect Azure content filter errors (HTTP 400 with ResponsibleAIPolicyViolation).
+///
+/// These are deterministic rejections for specific content — not transient failures.
+/// Cases blocked by content filters are unevaluated, not false negatives.
+fn is_content_filter_error(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("content_filter")
+        || msg.contains("ResponsibleAIPolicyViolation")
+        || msg.contains("content_filter_result")
+}
+
 fn classify_case_result(outcome: &scoring::CaseOutcome) -> &'static str {
     if outcome.expected_cwes.is_empty() {
         if outcome.detected_cwes.is_empty() {
@@ -1179,7 +1223,10 @@ fn reconstruct_score(
 
 #[cfg(test)]
 mod tests {
-    use super::{case_outcomes_for_history, classify_case_result, reconstruct_score, Gym};
+    use super::{
+        case_outcomes_for_history, classify_case_result, is_content_filter_error,
+        reconstruct_score, Gym,
+    };
     use crate::history;
     use crate::scoring;
 
@@ -1350,5 +1397,32 @@ language = "c"
         assert!(negative_rows
             .iter()
             .all(|row| { row.outcome == history::CaseOutcomeKind::FalsePositive }));
+    }
+
+    #[test]
+    fn content_filter_error_detected() {
+        let err = anyhow::anyhow!(
+            "Bad Request: innererror.code=ResponsibleAIPolicyViolation, \
+             content_filter_result: violence filtered=true"
+        );
+        assert!(is_content_filter_error(&err));
+    }
+
+    #[test]
+    fn content_filter_detects_content_filter_keyword() {
+        let err = anyhow::anyhow!("HTTP 400: content_filter block on input");
+        assert!(is_content_filter_error(&err));
+    }
+
+    #[test]
+    fn content_filter_ignores_unrelated_errors() {
+        let err = anyhow::anyhow!("HTTP 429: rate limit exceeded");
+        assert!(!is_content_filter_error(&err));
+
+        let err = anyhow::anyhow!("connection timed out after 120s");
+        assert!(!is_content_filter_error(&err));
+
+        let err = anyhow::anyhow!("internal server error");
+        assert!(!is_content_filter_error(&err));
     }
 }

--- a/crates/gym/src/reporting/terminal.rs
+++ b/crates/gym/src/reporting/terminal.rs
@@ -4,7 +4,19 @@ use crate::history::{BenchmarkRun, CaseRegression};
 use crate::scoring::{self, AggregateScore};
 
 /// Print a summary of benchmark results.
+///
+/// `content_filtered` is the number of cases blocked by Azure content filters
+/// and excluded from scoring. Pass 0 when not applicable (e.g. historical runs).
 pub fn print_summary(score: &AggregateScore, suite: &str) {
+    print_summary_with_content_filtered(score, suite, 0);
+}
+
+/// Print a summary with explicit content-filtered count.
+pub fn print_summary_with_content_filtered(
+    score: &AggregateScore,
+    suite: &str,
+    content_filtered: u32,
+) {
     println!("\n{}", "=".repeat(70));
     println!("  SKWAQ GYM RESULTS: {}", suite.to_uppercase());
     println!("{}", "=".repeat(70));
@@ -13,10 +25,24 @@ pub fn print_summary(score: &AggregateScore, suite: &str) {
     println!("  Recall:     {:.1}%", score.recall * 100.0);
     println!("  F1 Score:   {:.1}%", score.f1 * 100.0);
     println!();
-    println!(
-        "  TP: {}  FP: {}  FN: {}  TN: {}",
-        score.true_positives, score.false_positives, score.false_negatives, score.true_negatives
-    );
+    if content_filtered > 0 {
+        println!(
+            "  TP: {}  FP: {}  FN: {}  TN: {}  Content-Filtered: {}",
+            score.true_positives,
+            score.false_positives,
+            score.false_negatives,
+            score.true_negatives,
+            content_filtered
+        );
+    } else {
+        println!(
+            "  TP: {}  FP: {}  FN: {}  TN: {}",
+            score.true_positives,
+            score.false_positives,
+            score.false_negatives,
+            score.true_negatives
+        );
+    }
     println!();
 
     let mut cwes: Vec<_> = score.per_cwe.values().collect();

--- a/docs/investigations/456-azure-retry-metrics-codebase-analysis.md
+++ b/docs/investigations/456-azure-retry-metrics-codebase-analysis.md
@@ -1,0 +1,79 @@
+# Issue #456: Azure Retry Metrics — Codebase Analysis
+
+**Date**: 2026-04-03
+**Status**: Analysis complete, ready for design phase
+
+## Problem Statement
+
+Azure API retries (429 rate limit, 401 auth) happen inside RustyClawd's `with_retry()` but are invisible to monitoring. Need to surface retry count, wait time, and reason in OTEL spans and Prometheus counters.
+
+## Relevant Existing Code
+
+### RustyClawd (External Dependency, rev `43ebaa1`)
+
+| File | Key Code | Notes |
+|------|----------|-------|
+| `crates/core/src/client/mod.rs:194-224` | `Client::with_retry()` — private method with `retries` counter, exponential backoff, `tracing::warn!` per retry | Returns only `ClientResult<T>`, discards retry metadata |
+| `crates/core/src/client/retry.rs` | `RetryConfig { max_retries: 3, initial_delay: 1s, max_delay: 30s }` | Configurable but not exposed to callers |
+| `crates/core/src/client/error.rs` | `is_retryable()` — matches `RateLimited`(429), `ServiceUnavailable`(503), `ServerError`(5xx), `Timeout`, `NetworkError`, `DnsError`, `ConnectionError` | **`Unauthorized`(401) is NOT retried** |
+| `crates/core/src/client/tool_loop.rs:71-158` | `execute_with_tools()` calls `create_message()` in a loop per tool-use turn; each call retries independently via `with_retry()` | Retries accumulate across turns but are invisible |
+
+### Skwaq LLM Layer
+
+| File | Key Code | Notes |
+|------|----------|-------|
+| `crates/core/src/llm/traits.rs:90-96` | `llm.request` span with `model`, `tools_count`, `input_tokens`, `output_tokens` | Target for adding `retries` and `retry_wait_ms` fields |
+| `crates/core/src/llm/traits.rs:112-122` | Calls `client.execute_with_tools()` — opaque to retry info | Must propagate metadata through here |
+| `crates/core/src/agents/runner.rs:131-144` | Agent runner calls `execute_with_tools` with `gym.agent` span | Consumers of the wrapper |
+| `crates/gym/src/agentic.rs:1716-1726` | `execute_synthesis_completion()` calls `execute_with_tools` | Another consumer |
+
+### Gym Metrics & Telemetry
+
+| File | Key Code | Notes |
+|------|----------|-------|
+| `crates/gym/src/metrics.rs:36-40` | `RETRIES_TOTAL` counter `["suite"]` — **case-level** retries only | Different from per-request API retries |
+| `crates/gym/src/telemetry.rs` | OTEL TracerProvider with JSONL exporter + optional OTLP | Spans auto-exported |
+| `crates/gym/src/tui.rs:263-265` | TUI reads `retry` span attribute | Will pick up new fields automatically |
+
+## Files Requiring Modification
+
+| # | File | Change | Complexity |
+|---|------|--------|------------|
+| 1 | RustyClawd `crates/core/src/client/mod.rs` | `with_retry()` returns `(T, RetryStats)` where `RetryStats { count: u32, total_wait_ms: u64 }` | HIGH (separate repo) |
+| 2 | RustyClawd `crates/core/src/client/tool_loop.rs` | Accumulate `RetryStats` across tool-loop turns in `execute_with_tools()` | MEDIUM |
+| 3 | `crates/core/src/llm/traits.rs` | Add `retries` (u32) and `retry_wait_ms` (u64) Empty fields to `llm.request` span; record after response | LOW |
+| 4 | `crates/gym/src/metrics.rs` | Add `AZURE_RETRIES_TOTAL` CounterVec with `["reason"]` labels | LOW |
+| 5 | `crates/gym/src/agentic.rs` | Record retry metrics after `run_llm_pipeline` | LOW-MEDIUM |
+
+## Key Design Considerations
+
+### 1. Cross-Repo Dependency
+RustyClawd must be modified first, then its rev pin updated in skwaq's workspace `Cargo.toml` (line 15).
+
+### 2. Aggregation Across Tool-Loop Turns
+A single `execute_with_tools` call makes 1-N `create_message` calls (one per tool-use turn). Each can independently retry. Total retries = sum across all turns.
+
+### 3. 401 Auth Retries Don't Exist Yet
+`Unauthorized` is not in `is_retryable()`. If the goal includes tracking auth retries, RustyClawd's retry policy must also change. This should be clarified.
+
+### 4. Retry Reason Classification
+`ClientError` variants map to Prometheus label values:
+- `RateLimited` → `"rate_limit"`
+- `Timeout` → `"timeout"`
+- `ServerError` → `"server_error"`
+- `ServiceUnavailable` → `"service_unavailable"`
+- `NetworkError`/`DnsError`/`ConnectionError` → `"network"`
+
+### 5. Recommended Approach
+Modify `with_retry()` to return `(T, RetryStats)`. Propagate through `create_message()` → `execute_with_tools()` → skwaq's `execute_with_tools` wrapper. Clean, traceable, minimal API surface change.
+
+Alternative: Emit structured tracing spans inside `with_retry()` and capture via subscriber. Less invasive to RustyClawd API but harder to get exact counts into parent span fields.
+
+## Consumers of Modified APIs
+
+These files call `execute_with_tools` and will need updating if the return type changes:
+- `crates/core/src/llm/traits.rs` (primary wrapper)
+- `crates/core/src/agents/runner.rs` (agent pipeline)
+- `crates/core/src/skills/mod.rs` (skill execution)
+- `crates/gym/src/agentic.rs` (gym synthesis)
+- `crates/gym/src/improve.rs` (self-improvement)


### PR DESCRIPTION
## Changes

- **Content filter classification**: Azure content filter errors (`ResponsibleAIPolicyViolation`) are now classified as deterministic rejections, not transient failures. Content-filtered cases are excluded from scoring instead of counted as failures/FNs.
- **Terminal output**: Adds content-filtered count to gym eval summary.
- **RustyClawd bump**: Pin updated from `856bdf8` to `43ebaa1` (includes 401 Unauthorized retry with token refresh, RustyClawd PR #653).
- **Investigation doc**: Adds codebase analysis for issue #456 (Azure retry OTEL metrics).
- **Test fix**: Adds missing import for `is_content_filter_error` in test module.

## Testing

- 3 new unit tests for content filter detection (positive + negative cases)
- All 281 existing gym tests pass (1 pre-existing failure in `improve.rs` unrelated to this PR)
- `cargo clippy` clean

Closes: n/a (incremental improvement from benchmark session)