### PR TITLE
fix(core): agent name mismatch in taint-tracer and create_finding attribution

### DIFF
--- a/agents/attack-surface.md
+++ b/agents/attack-surface.md
@@ -53,7 +53,7 @@ Your analysis process — USE GRAPH TOOLS FOR EVERY STEP:
 6. **Query the graph** for additional data flow and findings:
    ```
    query_graph("MATCH (n)-[:FLOWS_TO]->(m) RETURN n, m")
-   query_graph("MATCH (f:Finding) WHERE f.agent = 'taint-analyzer' RETURN f")
+   query_graph("MATCH (f:Finding) WHERE f.agent = 'taint-tracer' RETURN f")
    ```
 
 Focus on identifying:

--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -67,7 +67,7 @@ You MUST call read_function for every function you investigate. Do not analyze f
 
 STEP 4 — QUERY THE GRAPH FOR TAINT PATHS and data flow edges:
 ```
-query_graph("MATCH (f:Finding) WHERE f.agent = 'taint-analyzer' RETURN f")
+query_graph("MATCH (f:Finding) WHERE f.agent = 'taint-tracer' RETURN f")
 query_graph("MATCH (n)-[:FLOWS_TO]->(m) RETURN n, m")
 ```
 These edges trace variable assignments: recv→buffer, atoi→index, etc.

--- a/crates/core/src/agents/runner.rs
+++ b/crates/core/src/agents/runner.rs
@@ -593,7 +593,7 @@ pub fn build_analysis_context_with_limit(
     // Include findings from taint analyzer and orchestrator
     if let Ok(mut stmt) = db.conn().prepare(
         "SELECT title, evidence, severity, category FROM findings \
-         WHERE investigation_id = ?1 AND agent IN ('taint-analyzer', 'orchestrator') \
+         WHERE investigation_id = ?1 AND agent IN ('taint-tracer', 'taint-analyzer', 'orchestrator') \
          AND status != 'invalidated' LIMIT 15",
     ) {
         if let Ok(rows) = stmt.query_map([investigation_id], |row| {
@@ -979,6 +979,73 @@ mod tests {
         assert!(
             !ctx.contains("sym_59"),
             "Should respect 50-row limit on symbols"
+        );
+    }
+
+    // ===== P1: taint-tracer findings appear in context builder =====
+
+    #[test]
+    fn test_build_analysis_context_includes_taint_tracer_findings() {
+        let db = GraphDb::in_memory().unwrap();
+        let inv_id = "test-inv-taint";
+
+        // Insert a finding with agent='taint-tracer' (the pipeline agent name)
+        db.conn()
+            .execute(
+                "INSERT INTO findings (id, title, evidence, agent, timestamp, \
+                 investigation_id, status, severity, category) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                rusqlite::params![
+                    "f-taint-1",
+                    "SQL injection via taint flow",
+                    "unsanitized input reaches query()",
+                    "taint-tracer",
+                    "2026-01-01T00:00:00Z",
+                    inv_id,
+                    "new",
+                    "high",
+                    "CWE-89"
+                ],
+            )
+            .unwrap();
+
+        let ctx = build_analysis_context("target.c", inv_id, &db);
+        assert!(
+            ctx.contains("SQL injection via taint flow"),
+            "Context should include taint-tracer findings. Got:\n{}",
+            &ctx[..ctx.len().min(2000)]
+        );
+    }
+
+    #[test]
+    fn test_build_analysis_context_includes_taint_analyzer_findings() {
+        let db = GraphDb::in_memory().unwrap();
+        let inv_id = "test-inv-analyzer";
+
+        // Insert a finding with agent='taint-analyzer' (the gym static analysis name)
+        db.conn()
+            .execute(
+                "INSERT INTO findings (id, title, evidence, agent, timestamp, \
+                 investigation_id, status, severity, category) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                rusqlite::params![
+                    "f-analyzer-1",
+                    "Unsafe memcpy via static taint",
+                    "static analysis: buffer flows to memcpy",
+                    "taint-analyzer",
+                    "2026-01-01T00:00:00Z",
+                    inv_id,
+                    "new",
+                    "critical",
+                    "CWE-120"
+                ],
+            )
+            .unwrap();
+
+        let ctx = build_analysis_context("target.c", inv_id, &db);
+        assert!(
+            ctx.contains("Unsafe memcpy via static taint"),
+            "Context should still include taint-analyzer findings for backward compat"
         );
     }
 }

--- a/crates/core/src/agents/tool_executor.rs
+++ b/crates/core/src/agents/tool_executor.rs
@@ -42,7 +42,7 @@ pub fn execute_tool_with_memory(
         "get_callees" => execute_get_call_neighbors(db, investigation_id, args, false),
         "lookup_cwe" => execute_lookup_cwe(db, args),
         "create_finding" => {
-            super::tool_translate::execute_create_finding(db, investigation_id, args)
+            super::tool_translate::execute_create_finding(db, investigation_id, args, agent_name)
         }
         "rename_function" => execute_rename_function(db, investigation_id, args),
         "search_similar" => {

--- a/crates/core/src/agents/tool_translate.rs
+++ b/crates/core/src/agents/tool_translate.rs
@@ -354,6 +354,7 @@ pub(super) fn execute_create_finding(
     db: &GraphDb,
     investigation_id: &str,
     args: &serde_json::Value,
+    agent_name: Option<&str>,
 ) -> anyhow::Result<serde_json::Value> {
     let title = args
         .get("title")
@@ -378,13 +379,16 @@ pub(super) fn execute_create_finding(
         "description": description, "function": function, "cwe_id": cwe_id,
     });
 
+    let agent = agent_name.unwrap_or("vuln_hunter");
+
     let cypher = format!(
         "CREATE (f:Finding {{id: '{id}', title: '{title}', evidence: '{ev}', \
-         agent: 'vuln_hunter', timestamp: '{ts}', investigation_id: '{inv}', \
+         agent: '{agent}', timestamp: '{ts}', investigation_id: '{inv}', \
          status: 'new', severity: '{sev}', category: '{cat}'}})",
         id = esc(&finding_id),
         title = esc(title),
         ev = esc(&evidence.to_string()),
+        agent = esc(agent),
         ts = esc(&timestamp),
         inv = esc(investigation_id),
         sev = esc(severity),
@@ -585,7 +589,7 @@ mod tests {
             "cwe_id": "CWE-120"
         });
 
-        let result = execute_create_finding(&db, inv_id, &args).unwrap();
+        let result = execute_create_finding(&db, inv_id, &args, None).unwrap();
         assert_eq!(result["status"], "ok");
         assert_eq!(result["title"], "Buffer Overflow");
         assert_eq!(result["severity"], "critical");
@@ -920,7 +924,7 @@ mod tests {
         let db = GraphDb::in_memory().unwrap();
         // Only required field missing — should use defaults
         let args = serde_json::json!({});
-        let result = execute_create_finding(&db, "inv1", &args).unwrap();
+        let result = execute_create_finding(&db, "inv1", &args, None).unwrap();
         assert_eq!(result["status"], "ok");
         assert_eq!(result["title"], "Untitled");
         assert_eq!(result["severity"], "medium");
@@ -933,7 +937,7 @@ mod tests {
             "title": "Buffer overflow in func('user_input')",
             "severity": "high"
         });
-        let result = execute_create_finding(&db, "inv1", &args).unwrap();
+        let result = execute_create_finding(&db, "inv1", &args, None).unwrap();
         assert_eq!(result["status"], "ok");
         // Verify the finding can be retrieved (escaping worked)
         let finding_id = result["finding_id"].as_str().unwrap();
@@ -1167,7 +1171,7 @@ mod tests {
             "description": "File path: C:\\Windows\\System32\\cmd.exe",
             "severity": "high"
         });
-        let result = execute_create_finding(&db, "inv1", &args).unwrap();
+        let result = execute_create_finding(&db, "inv1", &args, None).unwrap();
         assert_eq!(result["status"], "ok");
 
         // Verify finding was stored (backslashes escaped correctly for Cypher)
@@ -1179,6 +1183,61 @@ mod tests {
             ))
             .unwrap();
         assert_eq!(rows.len(), 1, "Finding must be retrievable after storage");
+    }
+
+    // ===== P2: create_finding uses parameterized agent name =====
+
+    #[test]
+    fn test_create_finding_uses_explicit_agent_name() {
+        let db = GraphDb::in_memory().unwrap();
+        let args = serde_json::json!({
+            "title": "Taint flow detected",
+            "severity": "high",
+            "description": "Unsanitized input flows to sink",
+            "function": "process_request",
+            "cwe_id": "CWE-89"
+        });
+        let result = execute_create_finding(&db, "inv1", &args, Some("taint-tracer")).unwrap();
+        assert_eq!(result["status"], "ok");
+
+        let finding_id = result["finding_id"].as_str().unwrap();
+        let rows = db
+            .cypher_query(&format!(
+                "MATCH (f:Finding {{id: '{}'}}) RETURN f.agent",
+                finding_id
+            ))
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            LadybugGraphDb::as_str(&rows[0][0]),
+            Some("taint-tracer"),
+            "Finding agent should match the explicit agent_name parameter"
+        );
+    }
+
+    #[test]
+    fn test_create_finding_defaults_to_vuln_hunter_when_no_agent() {
+        let db = GraphDb::in_memory().unwrap();
+        let args = serde_json::json!({
+            "title": "Buffer overflow",
+            "severity": "critical"
+        });
+        let result = execute_create_finding(&db, "inv1", &args, None).unwrap();
+        assert_eq!(result["status"], "ok");
+
+        let finding_id = result["finding_id"].as_str().unwrap();
+        let rows = db
+            .cypher_query(&format!(
+                "MATCH (f:Finding {{id: '{}'}}) RETURN f.agent",
+                finding_id
+            ))
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            LadybugGraphDb::as_str(&rows[0][0]),
+            Some("vuln_hunter"),
+            "Finding agent should default to vuln_hunter when agent_name is None"
+        );
     }
 
     // ===== TDD: search_similar with Cypher injection =====

--- a/crates/core/src/analysis/orchestrator.rs
+++ b/crates/core/src/analysis/orchestrator.rs
@@ -159,7 +159,7 @@ impl<'a> AnalysisOrchestrator<'a> {
             }
 
             let agent = match finding.category.as_str() {
-                "taint" => "taint-analyzer",
+                "taint" => "taint-tracer",
                 "indirect" => "context-validator",
                 _ => "pattern-detector",
             };


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in the core analysis pipeline found during PoC quality audit.

### Bug P1 (HIGH): Agent name mismatch — taint-tracer vs taint-analyzer

**Problem:** `runner.rs` queries for findings from `'taint-analyzer'` in the context builder, but the pipeline agent is registered as `'taint-tracer'` in `pipeline.rs`. This means vuln-hunter **never** sees taint-tracer's LLM findings.

**Fix:**
- `runner.rs:596`: Add `'taint-tracer'` to the agent IN clause (keeping `'taint-analyzer'` for backward compat with gym static analysis)
- `orchestrator.rs:162`: Map `'taint'` category to `'taint-tracer'` instead of `'taint-analyzer'`
- `vuln-hunter.md`, `attack-surface.md`: Update example queries to use `'taint-tracer'`

### Bug P2 (MED): create_finding hardcodes 'vuln_hunter' agent name

**Problem:** `execute_create_finding` in `tool_translate.rs` hardcodes `agent: 'vuln_hunter'`. When taint-tracer (or any other agent) calls `create_finding`, the finding is misattributed to vuln_hunter.

**Fix:**
- `tool_translate.rs`: Accept `agent_name: Option<&str>` parameter, default to `'vuln_hunter'`
- `tool_executor.rs`: Thread `agent_name` from `execute_tool_with_memory` to `execute_create_finding`

### Tests
- 4 new tests covering both fixes
- All 526 core tests pass
- Zero clippy warnings

### Design Notes
- **Two separate taint subsystems exist**: pipeline LLM agent (`taint-tracer`) vs gym static analysis (`taint-analyzer` in `agentic.rs`). Both are intentionally different names. The runner now catches findings from both.
- `agentic.rs` references are NOT changed — that's the gym static analysis subsystem.