### PR TITLE
feat(core): replace hardcoded pipeline constructors with YAML recipe definitions

### DIFF
--- a/crates/core/src/agents/mod.rs
+++ b/crates/core/src/agents/mod.rs
@@ -14,6 +14,7 @@ pub mod discovery;
 pub mod mcp_client;
 pub mod output_schema;
 pub mod pipeline;
+pub(crate) mod recipe_loader;
 pub mod runner;
 pub mod tool_definitions;
 pub mod tool_executor;

--- a/crates/core/src/agents/pipeline.rs
+++ b/crates/core/src/agents/pipeline.rs
@@ -1270,18 +1270,6 @@ fn collect_defense_evidence(assessments: &[&DefenseAnalystAssessment]) -> Vec<St
     evidence.into_iter().collect()
 }
 
-fn vuln_hunter_stage(agent_name: String, _include_create_finding_preamble: bool) -> PipelineStage {
-    // Vuln-hunter gets FromGraph context so it sees source code, graph data,
-    // and prior findings. The attack-surface results are available in the
-    // graph as findings. With 128K output tokens, there's plenty of room
-    // for both source code and multi-turn tool calling.
-    PipelineStage {
-        agent_name,
-        context_mode: ContextMode::FromGraph,
-        client_role: ClientRole::Reasoning,
-    }
-}
-
 /// Build the default analysis pipeline: decompile-renamer -> attack-surface -> vuln-hunter -> critic.
 pub fn default_pipeline() -> AnalysisPipeline {
     default_pipeline_for_target("")
@@ -1295,38 +1283,7 @@ pub fn default_pipeline() -> AnalysisPipeline {
 /// cross-file vulnerabilities where the source and sink are in different
 /// functions or files.
 pub fn source_pipeline_for_target(target: &str) -> AnalysisPipeline {
-    let hunter = select_vuln_hunter(target);
-    AnalysisPipeline {
-        stages: vec![
-            PipelineStage {
-                agent_name: "attack-surface".into(),
-                context_mode: ContextMode::FromGraph,
-                client_role: ClientRole::Reasoning,
-            },
-            PipelineStage {
-                agent_name: "taint-tracer".into(),
-                context_mode: ContextMode::FromPreviousResults {
-                    preamble: "The attack surface has been mapped. Now trace data flow from \
-                               untrusted sources to dangerous sinks. Use get_taint_paths and \
-                               get_cross_file_calls to find unsanitized paths. Create findings \
-                               for each confirmed taint flow."
-                        .into(),
-                },
-                client_role: ClientRole::Reasoning,
-            },
-            vuln_hunter_stage(hunter, false),
-            PipelineStage {
-                agent_name: "critic".into(),
-                context_mode: ContextMode::FromPreviousResults {
-                    preamble: "Review the following vulnerability findings and validate each one. \
-                               For each finding, determine if it is a true positive or false \
-                               positive, and adjust severity if needed."
-                        .into(),
-                },
-                client_role: ClientRole::Reasoning,
-            },
-        ],
-    }
+    super::recipe_loader::load_source_recipe(target).pipeline
 }
 
 /// Build a deep source pipeline with exploit/defense debate and CWE classification.
@@ -1339,81 +1296,12 @@ pub fn source_pipeline_for_target(target: &str) -> AnalysisPipeline {
 /// The debate stage surfaces disagreements between offense and defense
 /// perspectives. The CWE-classifier ensures precise vulnerability taxonomy.
 pub fn source_deep_pipeline_for_target(target: &str) -> AnalysisPipeline {
-    let hunter = select_vuln_hunter(target);
-    AnalysisPipeline {
-        stages: vec![
-            PipelineStage {
-                agent_name: "attack-surface".into(),
-                context_mode: ContextMode::FromGraph,
-                client_role: ClientRole::Reasoning,
-            },
-            PipelineStage {
-                agent_name: "taint-tracer".into(),
-                context_mode: ContextMode::FromPreviousResults {
-                    preamble: "The attack surface has been mapped. Trace data flow from \
-                               untrusted sources to dangerous sinks. Use get_taint_paths and \
-                               get_cross_file_calls to find unsanitized paths."
-                        .into(),
-                },
-                client_role: ClientRole::Reasoning,
-            },
-            vuln_hunter_stage(hunter, true), // deep mode = true
-            // NOTE: exploit-analyst and defense-analyst run via debate group
-            // after vuln-hunter (stage index 2), not as pipeline stages.
-            PipelineStage {
-                agent_name: "verdict-synthesizer".into(),
-                context_mode: ContextMode::FromPreviousResults {
-                    preamble: "You have received findings from attack-surface mapping, taint \
-                               tracing, vulnerability hunting, and the exploit/defense debate. \
-                               Synthesize a final verdict for each finding: CONFIRMED, \
-                               DOWNGRADED, or REJECTED."
-                        .into(),
-                },
-                client_role: ClientRole::Reasoning,
-            },
-            PipelineStage {
-                agent_name: "cwe-classifier".into(),
-                context_mode: ContextMode::FromPreviousResults {
-                    preamble: "Review each confirmed finding and ensure the CWE classification \
-                               is precise. Use lookup_cwe to verify. Assign the most specific \
-                               CWE, not generic parent CWEs."
-                        .into(),
-                },
-                client_role: ClientRole::Reasoning,
-            },
-        ],
-    }
+    super::recipe_loader::load_source_deep_recipe(target).pipeline
 }
 
 /// Build the default analysis pipeline with language-aware vuln-hunter selection.
 pub fn default_pipeline_for_target(target: &str) -> AnalysisPipeline {
-    let hunter = select_vuln_hunter(target);
-    AnalysisPipeline {
-        stages: vec![
-            // Pre-processing: improve decompiled code readability
-            PipelineStage {
-                agent_name: "decompile-renamer".into(),
-                context_mode: ContextMode::FromGraph,
-                client_role: ClientRole::Decompilation,
-            },
-            PipelineStage {
-                agent_name: "attack-surface".into(),
-                context_mode: ContextMode::FromGraph,
-                client_role: ClientRole::Reasoning,
-            },
-            vuln_hunter_stage(hunter, false),
-            PipelineStage {
-                agent_name: "critic".into(),
-                context_mode: ContextMode::FromPreviousResults {
-                    preamble: "Review the following vulnerability findings and validate each one. \
-                               For each finding, determine if it is a true positive or false \
-                               positive, and adjust severity if needed."
-                        .into(),
-                },
-                client_role: ClientRole::Reasoning,
-            },
-        ],
-    }
+    super::recipe_loader::load_standard_recipe(target).pipeline
 }
 
 /// Build a deep analysis pipeline with parallel debate between exploit-analyst
@@ -1432,64 +1320,18 @@ pub fn deep_pipeline() -> AnalysisPipeline {
 
 /// Build a deep analysis pipeline with language-aware vuln-hunter selection.
 pub fn deep_pipeline_for_target(target: &str) -> AnalysisPipeline {
-    let hunter = select_vuln_hunter(target);
-    AnalysisPipeline {
-        stages: vec![
-            // Pre-processing: improve decompiled code readability
-            PipelineStage {
-                agent_name: "decompile-renamer".into(),
-                context_mode: ContextMode::FromGraph,
-                client_role: ClientRole::Decompilation,
-            },
-            // Discovery phase
-            PipelineStage {
-                agent_name: "attack-surface".into(),
-                context_mode: ContextMode::FromGraph,
-                client_role: ClientRole::Reasoning,
-            },
-            vuln_hunter_stage(hunter, true),
-            // NOTE: exploit-analyst and defense-analyst are NOT listed here.
-            // They run via the debate group in deep_pipeline_with_debate().
-            // Synthesis: final verdict based on all validation perspectives
-            PipelineStage {
-                agent_name: "verdict-synthesizer".into(),
-                context_mode: ContextMode::FromPreviousResults {
-                    preamble: "You have received the complete output from all agents in the pipeline: \
-                               attack-surface mapping, vulnerability hunting, exploit analysis, and \
-                               defense analysis. A DEBATE SUMMARY highlights agreements and \
-                               disagreements between the offense and defense analysts. \
-                               Pay special attention to DISAGREEMENTS — read the code yourself to \
-                               break ties. \
-                               For each finding that is genuinely exploitable (confirmed by exploit-analyst \
-                               AND not fully mitigated per defense-analyst), use create_finding to record \
-                               the confirmed vulnerability. Reject false positives and explain why. \
-                                Be decisive — false positives damage credibility more than false negatives."
-                        .into(),
-                },
-                client_role: ClientRole::Reasoning,
-            },
-        ],
-    }
+    super::recipe_loader::load_deep_recipe(target).pipeline
 }
 
 /// Build the debate group for the deep pipeline.
 ///
 /// Both agents independently review the same vuln-hunter findings.
 pub fn deep_pipeline_debate() -> DebateGroup {
-    DebateGroup {
-        agent_a: "exploit-analyst".into(),
-        preamble_a: "Review each vulnerability finding below. For each one, evaluate \
-                      whether it can actually be triggered by an attacker. Check reachability \
-                      from external inputs, controllability of parameters, and real impact. \
-                      Respond with CONFIRMED, DOWNGRADED, or REJECTED for each finding."
-            .into(),
-        agent_b: "defense-analyst".into(),
-        preamble_b: "Review each vulnerability finding below. For each one, check whether \
-                      defensive controls (input validation, sanitization, safe wrappers, \
-                      architectural mitigations) make it non-exploitable. \
-                      Respond with VULNERABLE, MITIGATED, or SAFE for each finding."
-            .into(),
-    }
+    let loaded = super::recipe_loader::load_deep_recipe("");
+    loaded
+        .debate
+        .expect("deep recipe must define a debate section")
+        .group
 }
 
 /// Convenience: run the deep pipeline with the debate stage.
@@ -1505,12 +1347,21 @@ pub async fn run_deep_pipeline_with_debate(
     clients: PipelineClients,
     budget: &mut TokenBudget,
 ) -> anyhow::Result<Vec<AgentResult>> {
-    let pipeline = deep_pipeline_for_target(target);
-    let debate = deep_pipeline_debate();
-    // Debate runs after stage index 3 (after vuln-hunter, which is stages[2]),
-    // before verdict-synthesizer (stages[3]).
-    pipeline
-        .run_with_debate(target, investigation_id, db, clients, budget, &debate, 3)
+    let loaded = super::recipe_loader::load_deep_recipe(target);
+    let debate = loaded
+        .debate
+        .expect("deep recipe must define a debate section");
+    loaded
+        .pipeline
+        .run_with_debate(
+            target,
+            investigation_id,
+            db,
+            clients,
+            budget,
+            &debate.group,
+            debate.after_stage,
+        )
         .await
 }
 

--- a/crates/core/src/agents/recipe_loader.rs
+++ b/crates/core/src/agents/recipe_loader.rs
@@ -1,0 +1,600 @@
+//! Recipe loader: parse YAML recipe definitions into pipeline structures.
+//!
+//! Recipes are embedded at compile time via `include_str!` and parsed into
+//! `AnalysisPipeline` and optional `DebateGroup` structs.  The `vuln-hunter*`
+//! placeholder in a recipe is resolved per-call via `select_vuln_hunter()`.
+
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+use super::pipeline::{AnalysisPipeline, ClientRole, ContextMode, DebateGroup, PipelineStage};
+
+// ---------------------------------------------------------------------------
+// Embedded recipe YAML (compile-time)
+// ---------------------------------------------------------------------------
+
+const STANDARD_YAML: &str = include_str!("../../../../recipes/analysis/standard.yaml");
+const DEEP_YAML: &str = include_str!("../../../../recipes/analysis/deep.yaml");
+const SOURCE_YAML: &str = include_str!("../../../../recipes/analysis/source.yaml");
+const SOURCE_DEEP_YAML: &str = include_str!("../../../../recipes/analysis/source_deep.yaml");
+
+// ---------------------------------------------------------------------------
+// Parsed recipe cache (parse once, resolve vuln-hunter* per call)
+// ---------------------------------------------------------------------------
+
+static STANDARD_RECIPE: OnceLock<RecipeYaml> = OnceLock::new();
+static DEEP_RECIPE: OnceLock<RecipeYaml> = OnceLock::new();
+static SOURCE_RECIPE: OnceLock<RecipeYaml> = OnceLock::new();
+static SOURCE_DEEP_RECIPE: OnceLock<RecipeYaml> = OnceLock::new();
+
+fn standard_recipe() -> &'static RecipeYaml {
+    STANDARD_RECIPE.get_or_init(|| parse_recipe(STANDARD_YAML).expect("invalid standard.yaml"))
+}
+
+fn deep_recipe() -> &'static RecipeYaml {
+    DEEP_RECIPE.get_or_init(|| parse_recipe(DEEP_YAML).expect("invalid deep.yaml"))
+}
+
+fn source_recipe() -> &'static RecipeYaml {
+    SOURCE_RECIPE.get_or_init(|| parse_recipe(SOURCE_YAML).expect("invalid source.yaml"))
+}
+
+fn source_deep_recipe() -> &'static RecipeYaml {
+    SOURCE_DEEP_RECIPE
+        .get_or_init(|| parse_recipe(SOURCE_DEEP_YAML).expect("invalid source_deep.yaml"))
+}
+
+// ---------------------------------------------------------------------------
+// YAML schema (serde)
+// ---------------------------------------------------------------------------
+
+/// Top-level recipe file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RecipeYaml {
+    pub stages: Vec<StageYaml>,
+    #[serde(default)]
+    pub debate: Option<DebateYaml>,
+}
+
+/// One pipeline stage.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StageYaml {
+    pub agent: String,
+    pub context: ContextModeYaml,
+    pub client_role: ClientRoleYaml,
+    /// Required when `context` is `from_previous_results`.
+    #[serde(default)]
+    pub preamble: Option<String>,
+}
+
+/// Debate configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DebateYaml {
+    pub after_stage: usize,
+    pub agent_a: DebateAgentYaml,
+    pub agent_b: DebateAgentYaml,
+}
+
+/// A single debate participant.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DebateAgentYaml {
+    pub name: String,
+    pub preamble: String,
+}
+
+/// Context mode enum for YAML.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ContextModeYaml {
+    FromGraph,
+    FromPreviousResults,
+}
+
+/// Client role enum for YAML.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ClientRoleYaml {
+    Reasoning,
+    Decompilation,
+}
+
+// ---------------------------------------------------------------------------
+// Public(crate) API: load pipelines from cached recipes
+// ---------------------------------------------------------------------------
+
+/// Result of loading a recipe: a pipeline plus optional debate config.
+pub(crate) struct LoadedRecipe {
+    pub pipeline: AnalysisPipeline,
+    pub debate: Option<LoadedDebate>,
+}
+
+/// Debate configuration extracted from a recipe.
+pub(crate) struct LoadedDebate {
+    pub group: DebateGroup,
+    pub after_stage: usize,
+}
+
+/// Load the standard (binary) pipeline recipe.
+pub(crate) fn load_standard_recipe(target: &str) -> LoadedRecipe {
+    build_loaded_recipe(standard_recipe(), target)
+}
+
+/// Load the deep (binary) pipeline recipe.
+pub(crate) fn load_deep_recipe(target: &str) -> LoadedRecipe {
+    build_loaded_recipe(deep_recipe(), target)
+}
+
+/// Load the source pipeline recipe.
+pub(crate) fn load_source_recipe(target: &str) -> LoadedRecipe {
+    build_loaded_recipe(source_recipe(), target)
+}
+
+/// Load the deep source pipeline recipe.
+pub(crate) fn load_source_deep_recipe(target: &str) -> LoadedRecipe {
+    build_loaded_recipe(source_deep_recipe(), target)
+}
+
+// ---------------------------------------------------------------------------
+// Internal: build pipeline structs from parsed recipe
+// ---------------------------------------------------------------------------
+
+fn build_loaded_recipe(recipe: &RecipeYaml, target: &str) -> LoadedRecipe {
+    let vuln_hunter = super::pipeline::select_vuln_hunter(target);
+
+    let stages = recipe
+        .stages
+        .iter()
+        .map(|stage| {
+            let agent_name = if stage.agent == "vuln-hunter*" {
+                vuln_hunter.clone()
+            } else {
+                stage.agent.clone()
+            };
+
+            let context_mode = match stage.context {
+                ContextModeYaml::FromGraph => ContextMode::FromGraph,
+                ContextModeYaml::FromPreviousResults => ContextMode::FromPreviousResults {
+                    preamble: stage
+                        .preamble
+                        .clone()
+                        .expect("preamble required for from_previous_results"),
+                },
+            };
+
+            let client_role = match stage.client_role {
+                ClientRoleYaml::Reasoning => ClientRole::Reasoning,
+                ClientRoleYaml::Decompilation => ClientRole::Decompilation,
+            };
+
+            PipelineStage {
+                agent_name,
+                context_mode,
+                client_role,
+            }
+        })
+        .collect();
+
+    let debate = recipe.debate.as_ref().map(|d| LoadedDebate {
+        after_stage: d.after_stage,
+        group: DebateGroup {
+            agent_a: d.agent_a.name.clone(),
+            preamble_a: d.agent_a.preamble.clone(),
+            agent_b: d.agent_b.name.clone(),
+            preamble_b: d.agent_b.preamble.clone(),
+        },
+    });
+
+    LoadedRecipe {
+        pipeline: AnalysisPipeline { stages },
+        debate,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing + validation
+// ---------------------------------------------------------------------------
+
+fn parse_recipe(yaml: &str) -> anyhow::Result<RecipeYaml> {
+    let recipe: RecipeYaml = serde_yaml_ng::from_str(yaml)?;
+    validate_recipe(&recipe)?;
+    Ok(recipe)
+}
+
+fn validate_recipe(recipe: &RecipeYaml) -> anyhow::Result<()> {
+    if recipe.stages.is_empty() {
+        anyhow::bail!("recipe must have at least one stage");
+    }
+
+    for (i, stage) in recipe.stages.iter().enumerate() {
+        if stage.agent.is_empty() {
+            anyhow::bail!("stage {i}: agent name must not be empty");
+        }
+        if stage.context == ContextModeYaml::FromPreviousResults && stage.preamble.is_none() {
+            anyhow::bail!(
+                "stage {i} ({}): preamble is required when context is from_previous_results",
+                stage.agent
+            );
+        }
+        if stage.context == ContextModeYaml::FromGraph && stage.preamble.is_some() {
+            anyhow::bail!(
+                "stage {i} ({}): preamble must not be set when context is from_graph",
+                stage.agent
+            );
+        }
+    }
+
+    if let Some(debate) = &recipe.debate {
+        if debate.after_stage > recipe.stages.len() {
+            anyhow::bail!(
+                "debate.after_stage ({}) exceeds number of stages ({})",
+                debate.after_stage,
+                recipe.stages.len()
+            );
+        }
+        if debate.agent_a.name.is_empty() || debate.agent_b.name.is_empty() {
+            anyhow::bail!("debate agent names must not be empty");
+        }
+        if debate.agent_a.preamble.is_empty() || debate.agent_b.preamble.is_empty() {
+            anyhow::bail!("debate agent preambles must not be empty");
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_all_bundled_recipes() {
+        // Ensures all embedded YAML is syntactically valid and passes validation.
+        let _ = standard_recipe();
+        let _ = deep_recipe();
+        let _ = source_recipe();
+        let _ = source_deep_recipe();
+    }
+
+    #[test]
+    fn test_standard_recipe_stages() {
+        let loaded = load_standard_recipe("test.c");
+        assert_eq!(loaded.pipeline.stages.len(), 4);
+        assert_eq!(loaded.pipeline.stages[0].agent_name, "decompile-renamer");
+        assert_eq!(loaded.pipeline.stages[1].agent_name, "attack-surface");
+        assert_eq!(loaded.pipeline.stages[2].agent_name, "vuln-hunter");
+        assert_eq!(loaded.pipeline.stages[3].agent_name, "critic");
+        assert!(loaded.debate.is_none());
+    }
+
+    #[test]
+    fn test_standard_recipe_context_modes() {
+        let loaded = load_standard_recipe("");
+        assert!(matches!(
+            loaded.pipeline.stages[0].context_mode,
+            ContextMode::FromGraph
+        ));
+        assert!(matches!(
+            loaded.pipeline.stages[1].context_mode,
+            ContextMode::FromGraph
+        ));
+        assert!(matches!(
+            loaded.pipeline.stages[2].context_mode,
+            ContextMode::FromGraph
+        ));
+        assert!(matches!(
+            loaded.pipeline.stages[3].context_mode,
+            ContextMode::FromPreviousResults { .. }
+        ));
+    }
+
+    #[test]
+    fn test_standard_recipe_client_roles() {
+        let loaded = load_standard_recipe("");
+        assert_eq!(
+            loaded.pipeline.stages[0].client_role,
+            ClientRole::Decompilation
+        );
+        assert_eq!(loaded.pipeline.stages[1].client_role, ClientRole::Reasoning);
+        assert_eq!(loaded.pipeline.stages[2].client_role, ClientRole::Reasoning);
+        assert_eq!(loaded.pipeline.stages[3].client_role, ClientRole::Reasoning);
+    }
+
+    #[test]
+    fn test_deep_recipe_has_debate() {
+        let loaded = load_deep_recipe("");
+        assert_eq!(loaded.pipeline.stages.len(), 4);
+        let debate = loaded.debate.expect("deep recipe must have debate");
+        assert_eq!(debate.after_stage, 3);
+        assert_eq!(debate.group.agent_a, "exploit-analyst");
+        assert_eq!(debate.group.agent_b, "defense-analyst");
+    }
+
+    #[test]
+    fn test_source_recipe_has_taint_tracer() {
+        let loaded = load_source_recipe("app.py");
+        assert_eq!(loaded.pipeline.stages.len(), 4);
+        assert_eq!(loaded.pipeline.stages[0].agent_name, "attack-surface");
+        assert_eq!(loaded.pipeline.stages[1].agent_name, "taint-tracer");
+        // vuln-hunter* resolved for .py
+        assert!(
+            loaded.pipeline.stages[2].agent_name == "vuln-hunter-python"
+                || loaded.pipeline.stages[2].agent_name == "vuln-hunter"
+        );
+        assert_eq!(loaded.pipeline.stages[3].agent_name, "critic");
+        assert!(loaded.debate.is_none());
+    }
+
+    #[test]
+    fn test_source_deep_recipe_full_pipeline() {
+        let loaded = load_source_deep_recipe("Main.java");
+        assert_eq!(loaded.pipeline.stages.len(), 5);
+        assert_eq!(loaded.pipeline.stages[0].agent_name, "attack-surface");
+        assert_eq!(loaded.pipeline.stages[1].agent_name, "taint-tracer");
+        // vuln-hunter* resolved for .java
+        assert!(
+            loaded.pipeline.stages[2].agent_name == "vuln-hunter-java"
+                || loaded.pipeline.stages[2].agent_name == "vuln-hunter"
+        );
+        assert_eq!(loaded.pipeline.stages[3].agent_name, "verdict-synthesizer");
+        assert_eq!(loaded.pipeline.stages[4].agent_name, "cwe-classifier");
+        let debate = loaded.debate.expect("source_deep must have debate");
+        assert_eq!(debate.after_stage, 3);
+    }
+
+    #[test]
+    fn test_vuln_hunter_resolution_per_target() {
+        // C files -> generic vuln-hunter
+        let c_loaded = load_standard_recipe("overflow.c");
+        assert_eq!(c_loaded.pipeline.stages[2].agent_name, "vuln-hunter");
+
+        // No extension -> generic vuln-hunter
+        let no_ext = load_standard_recipe("binary_blob");
+        assert_eq!(no_ext.pipeline.stages[2].agent_name, "vuln-hunter");
+    }
+
+    #[test]
+    fn test_validation_rejects_empty_stages() {
+        let yaml = "stages: []";
+        assert!(parse_recipe(yaml).is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_missing_preamble() {
+        let yaml = r#"
+stages:
+  - agent: critic
+    context: from_previous_results
+    client_role: reasoning
+"#;
+        let err = parse_recipe(yaml).unwrap_err();
+        assert!(err.to_string().contains("preamble is required"));
+    }
+
+    #[test]
+    fn test_validation_rejects_preamble_on_from_graph() {
+        let yaml = r#"
+stages:
+  - agent: attack-surface
+    context: from_graph
+    client_role: reasoning
+    preamble: "should not be here"
+"#;
+        let err = parse_recipe(yaml).unwrap_err();
+        assert!(err.to_string().contains("preamble must not be set"));
+    }
+
+    #[test]
+    fn test_validation_rejects_invalid_debate_after_stage() {
+        let yaml = r#"
+stages:
+  - agent: attack-surface
+    context: from_graph
+    client_role: reasoning
+debate:
+  after_stage: 5
+  agent_a:
+    name: exploit-analyst
+    preamble: "test"
+  agent_b:
+    name: defense-analyst
+    preamble: "test"
+"#;
+        let err = parse_recipe(yaml).unwrap_err();
+        assert!(err.to_string().contains("exceeds number of stages"));
+    }
+
+    #[test]
+    fn test_serde_rejects_unknown_fields() {
+        let yaml = r#"
+stages:
+  - agent: attack-surface
+    context: from_graph
+    client_role: reasoning
+    unknown_field: true
+"#;
+        assert!(parse_recipe(yaml).is_err());
+    }
+
+    #[test]
+    fn test_serde_rejects_invalid_context_mode() {
+        let yaml = r#"
+stages:
+  - agent: attack-surface
+    context: from_memory
+    client_role: reasoning
+"#;
+        assert!(parse_recipe(yaml).is_err());
+    }
+
+    #[test]
+    fn test_serde_rejects_invalid_client_role() {
+        let yaml = r#"
+stages:
+  - agent: attack-surface
+    context: from_graph
+    client_role: turbo
+"#;
+        assert!(parse_recipe(yaml).is_err());
+    }
+
+    // Parity tests: verify recipe-loaded pipelines match the old hardcoded constructors
+    // in stage count, agent names, context modes, and client roles.
+
+    fn normalize_ws(s: &str) -> String {
+        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    fn preamble_of(stage: &PipelineStage) -> Option<String> {
+        match &stage.context_mode {
+            ContextMode::FromPreviousResults { preamble } => Some(preamble.clone()),
+            ContextMode::FromGraph => None,
+        }
+    }
+
+    #[test]
+    fn test_parity_standard_pipeline() {
+        let old = super::super::pipeline::default_pipeline_for_target("");
+        let new = load_standard_recipe("");
+
+        assert_eq!(old.stages.len(), new.pipeline.stages.len());
+        for (i, (o, n)) in old
+            .stages
+            .iter()
+            .zip(new.pipeline.stages.iter())
+            .enumerate()
+        {
+            assert_eq!(o.agent_name, n.agent_name, "stage {i} agent mismatch");
+            assert_eq!(
+                o.client_role, n.client_role,
+                "stage {i} client_role mismatch"
+            );
+            let old_p = preamble_of(o).map(|s| normalize_ws(&s));
+            let new_p = preamble_of(n).map(|s| normalize_ws(&s));
+            assert_eq!(old_p, new_p, "stage {i} preamble mismatch");
+        }
+    }
+
+    #[test]
+    fn test_parity_deep_pipeline() {
+        let old = super::super::pipeline::deep_pipeline_for_target("");
+        let new = load_deep_recipe("");
+        let old_debate = super::super::pipeline::deep_pipeline_debate();
+
+        assert_eq!(old.stages.len(), new.pipeline.stages.len());
+        for (i, (o, n)) in old
+            .stages
+            .iter()
+            .zip(new.pipeline.stages.iter())
+            .enumerate()
+        {
+            assert_eq!(o.agent_name, n.agent_name, "stage {i} agent mismatch");
+            assert_eq!(
+                o.client_role, n.client_role,
+                "stage {i} client_role mismatch"
+            );
+            let old_p = preamble_of(o).map(|s| normalize_ws(&s));
+            let new_p = preamble_of(n).map(|s| normalize_ws(&s));
+            assert_eq!(old_p, new_p, "stage {i} preamble mismatch");
+        }
+
+        let debate = new.debate.expect("deep recipe must have debate");
+        assert_eq!(debate.after_stage, 3);
+        assert_eq!(debate.group.agent_a, old_debate.agent_a);
+        assert_eq!(debate.group.agent_b, old_debate.agent_b);
+        assert_eq!(
+            normalize_ws(&debate.group.preamble_a),
+            normalize_ws(&old_debate.preamble_a)
+        );
+        assert_eq!(
+            normalize_ws(&debate.group.preamble_b),
+            normalize_ws(&old_debate.preamble_b)
+        );
+    }
+
+    #[test]
+    fn test_parity_source_pipeline() {
+        let old = super::super::pipeline::source_pipeline_for_target("");
+        let new = load_source_recipe("");
+
+        assert_eq!(old.stages.len(), new.pipeline.stages.len());
+        for (i, (o, n)) in old
+            .stages
+            .iter()
+            .zip(new.pipeline.stages.iter())
+            .enumerate()
+        {
+            assert_eq!(o.agent_name, n.agent_name, "stage {i} agent mismatch");
+            assert_eq!(
+                o.client_role, n.client_role,
+                "stage {i} client_role mismatch"
+            );
+            let old_p = preamble_of(o).map(|s| normalize_ws(&s));
+            let new_p = preamble_of(n).map(|s| normalize_ws(&s));
+            assert_eq!(old_p, new_p, "stage {i} preamble mismatch");
+        }
+    }
+
+    #[test]
+    fn test_parity_source_deep_pipeline() {
+        let old = super::super::pipeline::source_deep_pipeline_for_target("");
+        let new = load_source_deep_recipe("");
+
+        assert_eq!(old.stages.len(), new.pipeline.stages.len());
+        for (i, (o, n)) in old
+            .stages
+            .iter()
+            .zip(new.pipeline.stages.iter())
+            .enumerate()
+        {
+            assert_eq!(o.agent_name, n.agent_name, "stage {i} agent mismatch");
+            assert_eq!(
+                o.client_role, n.client_role,
+                "stage {i} client_role mismatch"
+            );
+            let old_p = preamble_of(o).map(|s| normalize_ws(&s));
+            let new_p = preamble_of(n).map(|s| normalize_ws(&s));
+            assert_eq!(old_p, new_p, "stage {i} preamble mismatch");
+        }
+
+        let debate = new.debate.expect("source_deep recipe must have debate");
+        assert_eq!(debate.after_stage, 3);
+        assert_eq!(debate.group.agent_a, "exploit-analyst");
+        assert_eq!(debate.group.agent_b, "defense-analyst");
+    }
+
+    #[test]
+    fn test_parity_vuln_hunter_language_routing() {
+        // Python target
+        let py_old = super::super::pipeline::default_pipeline_for_target("exploit.py");
+        let py_new = load_standard_recipe("exploit.py");
+        assert_eq!(
+            py_old.stages[2].agent_name, py_new.pipeline.stages[2].agent_name,
+            "Python vuln-hunter mismatch"
+        );
+
+        // Java target
+        let java_old = super::super::pipeline::default_pipeline_for_target("App.java");
+        let java_new = load_standard_recipe("App.java");
+        assert_eq!(
+            java_old.stages[2].agent_name, java_new.pipeline.stages[2].agent_name,
+            "Java vuln-hunter mismatch"
+        );
+
+        // C target (generic)
+        let c_old = super::super::pipeline::default_pipeline_for_target("buf.c");
+        let c_new = load_standard_recipe("buf.c");
+        assert_eq!(
+            c_old.stages[2].agent_name, c_new.pipeline.stages[2].agent_name,
+            "C vuln-hunter mismatch"
+        );
+    }
+}

--- a/docs/analysis-recipes.md
+++ b/docs/analysis-recipes.md
@@ -1,0 +1,79 @@
+# Analysis Pipeline Recipes
+
+Skwaq analysis pipelines are defined as declarative YAML recipe files in
+`recipes/analysis/`. Each recipe specifies the sequence of agents, their
+context modes, LLM client roles, and optional debate configuration.
+
+## Overview
+
+Pipeline stage sequences are defined in YAML recipes and embedded at compile
+time via `include_str!`. The `recipe_loader` module parses these once (using
+`OnceLock`) and resolves the `vuln-hunter*` placeholder per constructor call
+based on the target file's language.
+
+```
+recipes/analysis/
+├── standard.yaml       # Binary: decompile-renamer → attack-surface → vuln-hunter* → critic
+├── deep.yaml           # Binary deep: + exploit/defense debate → verdict-synthesizer
+├── source.yaml         # Source: attack-surface → taint-tracer → vuln-hunter* → critic
+└── source_deep.yaml    # Source deep: + debate → verdict-synthesizer → cwe-classifier
+```
+
+## Recipe Format
+
+### Stages
+
+```yaml
+stages:
+  - agent: attack-surface
+    context: from_graph          # from_graph | from_previous_results
+    client_role: reasoning       # reasoning | decompilation
+
+  - agent: critic
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-                 # required when context is from_previous_results
+      Review the following vulnerability findings...
+```
+
+Use `vuln-hunter*` as the agent name to enable language-aware routing
+(resolves to `vuln-hunter-python`, `vuln-hunter-java`, or generic
+`vuln-hunter` based on file extension).
+
+### Debate
+
+```yaml
+debate:
+  after_stage: 3                 # 0-based index; debate runs after this stage
+  agent_a:
+    name: exploit-analyst
+    preamble: >-
+      Evaluate exploitability...
+  agent_b:
+    name: defense-analyst
+    preamble: >-
+      Check defensive controls...
+```
+
+## API
+
+All existing public pipeline functions are preserved unchanged:
+
+- `default_pipeline()` / `default_pipeline_for_target(target)` → `standard.yaml`
+- `deep_pipeline()` / `deep_pipeline_for_target(target)` → `deep.yaml`
+- `source_pipeline_for_target(target)` → `source.yaml`
+- `source_deep_pipeline_for_target(target)` → `source_deep.yaml`
+- `deep_pipeline_debate()` → debate section of `deep.yaml`
+- `run_deep_pipeline_with_debate()` → pipeline + debate from `deep.yaml`
+
+The `recipe_loader` module is `pub(crate)` — not exported to downstream
+consumers.
+
+## Validation
+
+Recipes are validated on first parse:
+- At least one stage required
+- `preamble` required when `context: from_previous_results`
+- `preamble` forbidden when `context: from_graph`
+- `debate.after_stage` must not exceed stage count
+- Unknown YAML fields are rejected (`#[serde(deny_unknown_fields)]`)

--- a/recipes/analysis/deep.yaml
+++ b/recipes/analysis/deep.yaml
@@ -1,0 +1,53 @@
+# Deep binary analysis pipeline with exploit/defense debate.
+#
+# Flow: decompile-renamer -> attack-surface -> vuln-hunter*
+#         -> [exploit-analyst + defense-analyst debate]
+#         -> verdict-synthesizer
+#
+# Used by: deep_pipeline(), deep_pipeline_for_target(target),
+#          deep_pipeline_debate(), run_deep_pipeline_with_debate()
+
+stages:
+  - agent: decompile-renamer
+    context: from_graph
+    client_role: decompilation
+
+  - agent: attack-surface
+    context: from_graph
+    client_role: reasoning
+
+  - agent: "vuln-hunter*"
+    context: from_graph
+    client_role: reasoning
+
+  - agent: verdict-synthesizer
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-
+      You have received the complete output from all agents in the pipeline:
+      attack-surface mapping, vulnerability hunting, exploit analysis, and
+      defense analysis. A DEBATE SUMMARY highlights agreements and
+      disagreements between the offense and defense analysts.
+      Pay special attention to DISAGREEMENTS — read the code yourself to
+      break ties.
+      For each finding that is genuinely exploitable (confirmed by exploit-analyst
+      AND not fully mitigated per defense-analyst), use create_finding to record
+      the confirmed vulnerability. Reject false positives and explain why.
+      Be decisive — false positives damage credibility more than false negatives.
+
+debate:
+  after_stage: 3
+  agent_a:
+    name: exploit-analyst
+    preamble: >-
+      Review each vulnerability finding below. For each one, evaluate
+      whether it can actually be triggered by an attacker. Check reachability
+      from external inputs, controllability of parameters, and real impact.
+      Respond with CONFIRMED, DOWNGRADED, or REJECTED for each finding.
+  agent_b:
+    name: defense-analyst
+    preamble: >-
+      Review each vulnerability finding below. For each one, check whether
+      defensive controls (input validation, sanitization, safe wrappers,
+      architectural mitigations) make it non-exploitable.
+      Respond with VULNERABLE, MITIGATED, or SAFE for each finding.

--- a/recipes/analysis/source.yaml
+++ b/recipes/analysis/source.yaml
@@ -1,0 +1,30 @@
+# Source code analysis pipeline.
+#
+# Flow: attack-surface -> taint-tracer -> vuln-hunter* -> critic
+# Used by: source_pipeline_for_target(target)
+
+stages:
+  - agent: attack-surface
+    context: from_graph
+    client_role: reasoning
+
+  - agent: taint-tracer
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-
+      The attack surface has been mapped. Now trace data flow from
+      untrusted sources to dangerous sinks. Use get_taint_paths and
+      get_cross_file_calls to find unsanitized paths. Create findings
+      for each confirmed taint flow.
+
+  - agent: "vuln-hunter*"
+    context: from_graph
+    client_role: reasoning
+
+  - agent: critic
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-
+      Review the following vulnerability findings and validate each one.
+      For each finding, determine if it is a true positive or false
+      positive, and adjust severity if needed.

--- a/recipes/analysis/source_deep.yaml
+++ b/recipes/analysis/source_deep.yaml
@@ -1,0 +1,58 @@
+# Deep source analysis pipeline with debate and CWE classification.
+#
+# Flow: attack-surface -> taint-tracer -> vuln-hunter*
+#         -> [exploit-analyst + defense-analyst debate]
+#         -> verdict-synthesizer -> cwe-classifier
+#
+# Used by: source_deep_pipeline_for_target(target)
+
+stages:
+  - agent: attack-surface
+    context: from_graph
+    client_role: reasoning
+
+  - agent: taint-tracer
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-
+      The attack surface has been mapped. Trace data flow from
+      untrusted sources to dangerous sinks. Use get_taint_paths and
+      get_cross_file_calls to find unsanitized paths.
+
+  - agent: "vuln-hunter*"
+    context: from_graph
+    client_role: reasoning
+
+  - agent: verdict-synthesizer
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-
+      You have received findings from attack-surface mapping, taint
+      tracing, vulnerability hunting, and the exploit/defense debate.
+      Synthesize a final verdict for each finding: CONFIRMED,
+      DOWNGRADED, or REJECTED.
+
+  - agent: cwe-classifier
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-
+      Review each confirmed finding and ensure the CWE classification
+      is precise. Use lookup_cwe to verify. Assign the most specific
+      CWE, not generic parent CWEs.
+
+debate:
+  after_stage: 3
+  agent_a:
+    name: exploit-analyst
+    preamble: >-
+      Review each vulnerability finding below. For each one, evaluate
+      whether it can actually be triggered by an attacker. Check reachability
+      from external inputs, controllability of parameters, and real impact.
+      Respond with CONFIRMED, DOWNGRADED, or REJECTED for each finding.
+  agent_b:
+    name: defense-analyst
+    preamble: >-
+      Review each vulnerability finding below. For each one, check whether
+      defensive controls (input validation, sanitization, safe wrappers,
+      architectural mitigations) make it non-exploitable.
+      Respond with VULNERABLE, MITIGATED, or SAFE for each finding.

--- a/recipes/analysis/standard.yaml
+++ b/recipes/analysis/standard.yaml
@@ -1,0 +1,25 @@
+# Standard binary analysis pipeline.
+#
+# Flow: decompile-renamer -> attack-surface -> vuln-hunter* -> critic
+# Used by: default_pipeline(), default_pipeline_for_target(target)
+
+stages:
+  - agent: decompile-renamer
+    context: from_graph
+    client_role: decompilation
+
+  - agent: attack-surface
+    context: from_graph
+    client_role: reasoning
+
+  - agent: "vuln-hunter*"
+    context: from_graph
+    client_role: reasoning
+
+  - agent: critic
+    context: from_previous_results
+    client_role: reasoning
+    preamble: >-
+      Review the following vulnerability findings and validate each one.
+      For each finding, determine if it is a true positive or false
+      positive, and adjust severity if needed.


### PR DESCRIPTION
## Summary

Replaces hardcoded Rust `AnalysisPipeline` constructors with declarative YAML recipe definitions, preserving identical runtime behavior.

## Changes

### New files
- **`recipes/analysis/`** — 4 YAML recipe files (standard, deep, source, source_deep) defining pipeline stages, context modes, client roles, and optional debate configuration
- **`crates/core/src/agents/recipe_loader.rs`** — Recipe parser with serde validation, `OnceLock` caching, and late `vuln-hunter*` resolution
- **`docs/analysis-recipes.md`** — Recipe format documentation

### Refactored
- **`pipeline.rs`** — 6 pipeline constructors (`default_pipeline`, `deep_pipeline_for_target`, etc.) and `deep_pipeline_debate()` now delegate to `recipe_loader` instead of manually building `PipelineStage` vectors
- Removed `vuln_hunter_stage()` helper (no longer needed)
- **Net: -173 lines of hardcoded pipeline config, +571 lines of recipe loader + 166 lines of YAML**

### Preserved
- All public API signatures unchanged — zero breaking changes for callers (analyze.rs, investigate_binary.rs, agentic.rs)
- `select_vuln_hunter()` resolution logic unchanged
- Token budget management, context passing, debate execution unchanged

## Testing
- 20 new tests covering recipe parsing, validation, parity against old constructors, vuln-hunter language routing, serde rejection
- All 546 existing tests pass (1 pre-existing flaky test unrelated to changes)
- Full workspace builds cleanly (core + gym + cli)

## Design Decisions
- **`OnceLock` caching** — parse YAML once, resolve `vuln-hunter*` per call
- **`#[serde(deny_unknown_fields)]`** — strict schema validation catches typos
- **Late vuln-hunter resolution** — `vuln-hunter*` placeholder resolved at constructor call time, preserving project-local agent overrides

Closes #489