### PR TITLE
docs: purge 'fallback' terminology from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Create `skwaq.toml` in your project directory:
 ```toml
 [llm]
 reasoning = "copilot"       # default; or "anthropic" (requires ANTHROPIC_API_KEY)
-decompilation = "copilot"   # backend for decompile-* stages; no hidden fallback
+decompilation = "copilot"   # backend for decompile-* stages; no silent backend substitution
 
 [llm.copilot]
 model = "claude-opus-4.6"   # default model for Copilot backend

--- a/Specifications/SKWAQ_V2_DESIGN.md
+++ b/Specifications/SKWAQ_V2_DESIGN.md
@@ -773,7 +773,7 @@ impl VulnHunterAgent {
     }
 
     fn load_prompt(&self, filename: &str) -> anyhow::Result<String> {
-        // Try user-customized prompt, fall back to bundled default
+        // Try user-customized prompt, otherwise use the bundled default
         let user_path = dirs::home_dir()
             .unwrap_or_default()
             .join(".skwaq/prompts")

--- a/Specifications/SKWAQ_V2_SPEC.md
+++ b/Specifications/SKWAQ_V2_SPEC.md
@@ -212,7 +212,7 @@ Agents use a simple tool-loop pattern (LLM requests tool calls, Skwaq executes t
 
 **Token budget management**: Agents receive a configurable token budget. Large binaries are analyzed in chunks, prioritized by attack surface proximity. The orchestrator tracks spend and stops when budget is exhausted.
 
-**Prompts loaded from disk** (not compiled in): `~/.skwaq/prompts/vuln_hunter.md`. Editable without recompilation. Bundled defaults as fallback.
+**Prompts loaded from disk** (not compiled in): `~/.skwaq/prompts/vuln_hunter.md`. Editable without recompilation. Bundled defaults used when no on-disk override exists.
 
 ### 8. LLM Provider Flexibility
 

--- a/agents/results-skeptic.md
+++ b/agents/results-skeptic.md
@@ -77,5 +77,5 @@ Reason: <explanation>
 1. Never approve results where > 20% of cases were silently skipped.
 2. Never approve F1 > 95% without verifying coverage.
 3. Always report the ACTUAL number of cases evaluated, not just TP+FP+FN+TN.
-4. Flag any "fallback" or "skip" behavior in adapters — these hide real performance.
+4. Flag any silent-degradation or "skip" behavior in adapters — these hide real performance.
 5. Compare to previous checkpoint results — unexplained improvements are suspicious.

--- a/agents/vuln-hunter.md
+++ b/agents/vuln-hunter.md
@@ -159,7 +159,7 @@ When standard API patterns are not found, use get_cross_file_calls and get_taint
 
 **CWE-457 Use of Uninitialized Variable (C/C++):** Detect local variables declared without an initializer that are used before any assignment on at least one control-flow path. The pattern is `type var;` (no `= ...`) followed by a read of `var` before a write. Check conditional initialization: `if (cond) { var = val; }` followed by unconditional use — the else path leaves it uninitialized. Also flag pointer variables (`char *ptr;`) used without allocation. This is purely semantic — no dangerous API is involved.
 
-**Deep Analysis Fallback:** When standard API pattern matching yields no findings, escalate to cross-file call graph traversal and taint flow tracing:
+**Deep Analysis Escalation:** When standard API pattern matching yields no findings, escalate to cross-file call graph traversal and taint flow tracing:
 1. Use `get_cross_file_calls` to trace data flow through wrapper functions and indirect call chains.
 2. Use `get_taint_paths` to check if any taint source flows to dangerous sinks through intermediaries.
 3. Apply this broadly to all vulnerability classes, especially: buffer overflow (CWE-119 family), injection (CWE-78/89/134), input validation (CWE-20), information exposure (CWE-200/201/209), uninitialized variables (CWE-457/665), and path traversal (CWE-22).

--- a/docs/detection-coverage.md
+++ b/docs/detection-coverage.md
@@ -179,7 +179,7 @@ For each detected finding, CWEs are inferred using a three-level cascade:
 
 ```
 Explicit CWEs on finding  →  Semantic class CWEs  →  Category CWEs
-     (highest priority)         (if no explicit)       (fallback)
+     (highest priority)         (if no explicit)       (last resort)
 ```
 
 This is implemented in `inferred_finding_cwes()`:

--- a/docs/graph-agent-architecture.md
+++ b/docs/graph-agent-architecture.md
@@ -411,7 +411,7 @@ back to regex-based analysis:
 | Sparse call graph | Function has < 2 callers/callees in a multi-file project | `AgentPrompt` — improve cross-file tracing |
 | No data sources | Investigation has zero `data_sources` entries | `TaintRule` — add data source entries |
 | Unmapped CWE family | Expected CWE has no `cwe_family()` mapping | `CweMapping` — add family mapping |
-| Missing regex (fallback) | No pattern matches and graph analysis is complete | `NewPattern` — add detection pattern |
+| Missing regex (default) | No pattern matches and graph analysis is complete | `NewPattern` — add detection pattern |
 
 ## Context Budget Management
 

--- a/docs/graph-agent-gym-cycle.md
+++ b/docs/graph-agent-gym-cycle.md
@@ -76,11 +76,11 @@ cargo run -p skwaq -- gym eval --suites fixtures
 # Compile check (important after merging refactoring PRs)
 cargo build -p skwaq
 
-# LLM readiness (optional — heuristic fallback exists)
+# LLM readiness (optional — heuristic analyzer runs without LLM)
 cargo run -p skwaq -- gym preflight
 ```
 
-If the LLM backend is unavailable, the improvement engine falls back to
+If the LLM backend is unavailable, the improvement engine uses
 heuristic gap detection, which still produces AgentPrompt and TaintRule
 proposals based on graph context analysis.
 
@@ -265,7 +265,7 @@ A well-functioning graph-agent cycle shows:
 | TaintRule proposals skipped with "no database" | `db=None` in quick mode | Expected — TaintRule inserts need DB connection |
 | Quick-mode regression after AgentPrompt patches | Agent .md file syntax broken | Check for malformed Markdown in agents/ |
 
-## Heuristic Fallback
+## Heuristic Analyzer
 
 When the LLM backend is unavailable, the improvement engine uses a heuristic
 analyzer that checks for graph context gaps:
@@ -276,10 +276,10 @@ analyzer that checks for graph context gaps:
 | Function has < 2 callers/callees in multi-file project | `AgentPrompt` — improve cross-file tracing |
 | Investigation has zero `data_sources` entries | `TaintRule` — add data source entries |
 | Expected CWE has no `cwe_family()` mapping | `CweMapping` — add family mapping |
-| No graph gap found | `NewPattern` — add detection pattern (fallback) |
+| No graph gap found | `NewPattern` — add detection pattern (default) |
 
 The heuristic analyzer runs in parallel with the LLM failure-analyst. If the
-LLM is available, its proposals take precedence. If not, heuristic proposals
+LLM is available, its proposals take precedence. Otherwise, heuristic proposals
 are used.
 
 ## Configuration

--- a/docs/graph-migration-plan.md
+++ b/docs/graph-migration-plan.md
@@ -152,7 +152,7 @@ Key templates:
 | Tool | SQL Summary |
 |------|-------------|
 | `query_graph` | Delegates to `translate_to_sql()` → `execute_read_query()` |
-| `read_function` | `SELECT … FROM functions WHERE name = ?` (fallback by address) |
+| `read_function` | `SELECT … FROM functions WHERE name = ?` (lookup by address if name lookup misses) |
 | `get_callers` | `JOIN calls → functions` filtering by callee name |
 | `get_callees` | `JOIN calls → functions` filtering by caller name |
 | `get_taint_paths` | `JOIN taint_flows → data_sources → data_sinks`, optional location prefix filter |
@@ -571,7 +571,7 @@ safety net.
    - Keep the read-only and injection-prevention checks.
 4. Rewrite `queries.rs` helper functions to use Cypher.
 5. **Tests:** All existing tests pass. Add Cypher-specific query tests.
-   Optionally add a feature flag `--features sqlite-fallback` to toggle the
+   Optionally add a feature flag `--features sqlite-readback` to toggle the
    read backend during the transition.
 
 ### Phase 3 — Remove SQLite  *(estimated: 1–2 PRs)*
@@ -668,7 +668,7 @@ string collation).
 **Mitigation:** Phase 1 adds comparison tests that assert both backends
 return identical results for a representative workload. Phase 2 runs the
 full test suite against Kuzu reads. Any divergence is caught before Phase 3
-removes the fallback.
+removes the SQLite read path.
 
 ### 7.8  Agent-Generated Cypher
 

--- a/docs/gym-agents.md
+++ b/docs/gym-agents.md
@@ -72,7 +72,7 @@ You are [Agent], a [specialist]. Your job is to [task].
 
 The graph-query tools (`get_taint_paths`, `get_cross_file_calls`,
 `get_data_sources`, `get_imports`) are the primary discovery mechanism.
-Agents should use these tools first, then fall back to `query_graph` for
+Agents should use these tools first, then use `query_graph` for
 custom queries and `read_function` for source-level confirmation. See
 [Graph-Agent Architecture](graph-agent-architecture.md) for details.
 
@@ -118,12 +118,12 @@ knowledge base context.
 3. `CweMapping` — fix CWE family mapping gaps
 4. `NewPattern` — add regex patterns only when graph detection is insufficient
 
-**Graph gap detection** (heuristic fallback):
+**Graph gap detection** (heuristic classification):
 - Missing taint flows for functions handling external data → `TaintRule`
 - Sparse cross-file call graph → `AgentPrompt`
 - No data sources in investigation → `TaintRule`
 - Unmapped CWE family → `CweMapping`
-- No graph gap found → `NewPattern` (fallback)
+- No graph gap found → `NewPattern` (default)
 
 **Anti-overfitting rules** (built into the prompt):
 - Reject patterns that match benchmark-specific naming (e.g., `test_case_*`)

--- a/docs/gym-api-reference.md
+++ b/docs/gym-api-reference.md
@@ -531,7 +531,7 @@ The synthesis layer routes findings through one of six paths, tracked by
 | Expert routed | Sent to specialized agent (exploit/defense) |
 | LLM synthesis | Full multi-agent debate then synthesizer verdict |
 | Consensus early exit | All agents agree — accept without synthesis |
-| Fallback | Synthesis failed — keep all findings |
+| Retained-all | Synthesis failed — keep all findings (counter `retained_all_count`) |
 
 ---
 

--- a/docs/gym-configuration.md
+++ b/docs/gym-configuration.md
@@ -24,7 +24,7 @@ Supported backends:
 | Anthropic API | `"anthropic"` | `ANTHROPIC_API_KEY` env var |
 
 Run `skwaq gym preflight` to verify connectivity, model availability, and
-no-fallback readiness before starting an improvement cycle.
+no-silent-degradation readiness before starting an improvement cycle.
 
 ## BenchmarkConfig Fields
 

--- a/docs/gym-tutorial.md
+++ b/docs/gym-tutorial.md
@@ -21,7 +21,7 @@ Expected output:
 ```
 [OK] Copilot backend reachable
 [OK] Model: claude-opus-4.6
-[OK] No fallback model configured
+[OK] No-silent-degradation check (reasoning=copilot, decompilation=copilot)
 [OK] Token budget: 3,000,000 per cycle
 ```
 

--- a/docs/investigation-copilot-lm-api.md
+++ b/docs/investigation-copilot-lm-api.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-RustyClawd already has a production-ready Copilot backend. Only skwaqr-side configuration and model name changes are needed. No upstream RustyClawd code changes are required for the primary Copilot endpoint, but the GitHub Models fallback endpoint has a model prefix bug for non-OpenAI models.
+RustyClawd already has a production-ready Copilot backend. Only skwaqr-side configuration and model name changes are needed. No upstream RustyClawd code changes are required for the primary Copilot endpoint, but the GitHub Models secondary endpoint has a model prefix bug for non-OpenAI models.
 
 ## Architecture: Current State
 
@@ -14,7 +14,7 @@ RustyClawd already has a production-ready Copilot backend. Only skwaqr-side conf
 Skwaqr Agents → skwaq_core::llm::create_client() → RustyClawd Client
                                                         ├── Backend::Anthropic → api.anthropic.com (default)
                                                         └── Backend::Copilot   → api.githubcopilot.com (primary)
-                                                                               → models.github.ai (fallback)
+                                                                               → models.github.ai (secondary)
 ```
 
 RustyClawd's Copilot backend (`copilot.rs`, ~1120 lines) translates between Anthropic Messages API and OpenAI Chat Completions API format. The translation covers:
@@ -64,9 +64,9 @@ RustyClawd's `CopilotAuth::qualify_model()` method:
 - **Copilot endpoint** (`api.githubcopilot.com`): Model names pass through as-is — works correctly
 - **GitHub Models endpoint** (`models.github.ai`): Hardcodes `openai/` prefix for non-namespaced models
 
-This means `claude-opus-4.6` would incorrectly become `openai/claude-opus-4.6` on the fallback endpoint. It should be `anthropic/claude-opus-4.6`.
+This means `claude-opus-4.6` would incorrectly become `openai/claude-opus-4.6` on the secondary endpoint. It should be `anthropic/claude-opus-4.6`.
 
-**Mitigation**: The primary Copilot endpoint is tried first. Since Claude models are confirmed in the Copilot catalog, the fallback should rarely trigger.
+**Mitigation**: The primary Copilot endpoint is tried first. Since Claude models are confirmed in the Copilot catalog, the secondary endpoint should rarely be reached.
 
 ## Required Changes
 
@@ -96,7 +96,7 @@ This means `claude-opus-4.6` would incorrectly become `openai/claude-opus-4.6` o
 - Update associated test assertions
 
 ### 4. Auto-detect logic — `crates/core/src/llm/mod.rs` (OPTIONAL)
-- Consider flipping fallback priority (Copilot first, Anthropic second)
+- Consider flipping endpoint priority (Copilot first, Anthropic second)
 
 ## Authentication Migration
 
@@ -109,7 +109,7 @@ This means `claude-opus-4.6` would incorrectly become `openai/claude-opus-4.6` o
 
 ## No Upstream RustyClawd Changes Needed
 
-For the primary Copilot endpoint, RustyClawd works as-is. The `qualify_model()` prefix issue only affects the GitHub Models fallback endpoint and could be addressed separately if needed.
+For the primary Copilot endpoint, RustyClawd works as-is. The `qualify_model()` prefix issue only affects the GitHub Models secondary endpoint and could be addressed separately if needed.
 
 ## Implementation Status
 

--- a/docs/tool-translate-cypher-migration.md
+++ b/docs/tool-translate-cypher-migration.md
@@ -1,13 +1,13 @@
 # Tool Execution: Cypher-Native Query Layer
 
-> **Status:** Complete (SQL fallbacks removed)
+> **Status:** Complete (legacy SQL paths removed)
 > **Relates to:** [Graph Migration Plan](graph-migration-plan.md), [Graph Agent Architecture](graph-agent-architecture.md)
 > **Files:** `crates/core/src/agents/tool_translate.rs`, `crates/core/src/agents/tool_executor.rs`
 
 ## Overview
 
 The agent tool execution layer runs all graph queries as native Cypher against
-LadybugDB. The SQL fallback paths that existed during the migration window have
+LadybugDB. The legacy SQL paths that existed during the migration window have
 been removed. SQLite is retained **only** for the `lookup_cwe` tool, which
 queries a static reference table (`cwes`) that has no graph equivalent.
 
@@ -36,7 +36,7 @@ LLM query string
 ```
 
 Both steps use `db.cypher_query()` which routes through LadybugDB's C++ FFI
-bridge. There is no SQL fallback — if both steps fail, the tool returns an
+bridge. There is no SQL retry path — if both steps fail, the tool returns an
 error to the agent.
 
 ### Backend Routing
@@ -53,7 +53,7 @@ All tool handlers route to a single backend:
 | `get_callers` / `get_callees` | Cypher | `investigation_id`-scoped call graph |
 | `get_data_sources` / `get_imports` | Cypher | `investigation_id`-scoped |
 | `create_finding` | Cypher | Single-write (no dual-write) |
-| `search_similar` | Cypher | Single-read (no SQL fallback) |
+| `search_similar` | Cypher | Single-read (no SQL retry) |
 | `lookup_cwe` | **SQLite** | Static reference table, parameterized queries |
 | `store_memory` / `recall_memory` | LadybugDB (via MemoryStore) | — |
 


### PR DESCRIPTION
## Summary

Companion to merged PR #496 (which purged the word \"fallback\" from `crates/*.rs`). This PR finishes the job by removing it from the markdown documentation, agent prompts, README, and Specifications.

## Replacements applied

| Old phrasing | New phrasing | Rationale |
|---|---|---|
| \"hidden fallback\" | \"silent backend substitution\" | matches `crates/core/src/llm/mod.rs` error message |
| \"no-fallback readiness\" | \"no-silent-degradation readiness\" | matches `gym preflight` actual output |
| \"Heuristic Fallback\" (section) | \"Heuristic Analyzer\" | concrete, accurate |
| \"Fallback by address\" (in tool table) | \"lookup by address if name lookup misses\" | describes actual control flow |
| \"models.github.ai (fallback)\" | \"models.github.ai (secondary)\" | secondary endpoint, not silent retry |
| \"NewPattern (fallback)\" | \"NewPattern (default)\" | accurate — last classifier in cascade |
| \"\`Fallback\` synthesis result\" | \"\`Retained-all\` synthesis result\" (counter `retained_all_count`) | matches code |
| \"fall back to bundled default\" | \"otherwise use the bundled default\" | concrete |
| \"Deep Analysis Fallback\" (in agent prompt) | \"Deep Analysis Escalation\" | escalates, not degrades |
| \"sqlite-fallback\" feature flag (in design doc) | \"sqlite-readback\" | accurate |

## Files touched (15)

- `docs/gym-agents.md`, `docs/gym-api-reference.md`, `docs/gym-configuration.md`, `docs/gym-tutorial.md`
- `docs/graph-agent-architecture.md`, `docs/graph-agent-gym-cycle.md`, `docs/graph-migration-plan.md`
- `docs/detection-coverage.md`
- `docs/investigation-copilot-lm-api.md`, `docs/tool-translate-cypher-migration.md`
- `Specifications/SKWAQ_V2_SPEC.md`, `Specifications/SKWAQ_V2_DESIGN.md`
- `agents/vuln-hunter.md`, `agents/results-skeptic.md`
- `README.md`

## Validation

\`\`\`bash
$ grep -rln -i 'fallback\\|fall back' . --include='*.md' \\
    --exclude-dir=target --exclude-dir=worktrees --exclude-dir=.git \\
    --exclude-dir=outputs --exclude-dir=logs
./data/knowledge/fn-insights.md
\`\`\`

Only `data/knowledge/fn-insights.md` remains. That file is **auto-generated** content — recorded LLM reviewer reasoning from past gym cycles. Rewriting historical agent output would falsify the record. Future improvement cycles enforce the new vocabulary via the overfitting-reviewer prompt updated in PR #495, so new entries will not contain \"fallback\".

## Diff scope

- **15 files**, 31/-31 lines, prose-only
- **Zero code changes** — `cargo build`/`cargo test` not affected
- One agent prompt edit (`agents/vuln-hunter.md` line 162) renames a section header from \"Fallback\" → \"Escalation\". The instructions below it are unchanged. The vuln-hunter agent reads this file at runtime; the rename does not change its tool-calling behavior.

## Merge-ready checklist

- [x] **QA team**: not applicable (docs-only, no behavior change)
- [x] **Docs updated**: this **is** the docs update
- [x] **Quality audit**: pure mechanical rename of prose; no logic to audit
- [x] **CI**: docs-only diff; no test impact (will verify on PR)
- [x] **Diff scope**: clean — single concern (terminology)
- [x] **Evidence**: above

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>