### PR TITLE
chore: purge remaining fallback terminology and fix silent degradations

### DIFF
--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -35,7 +35,7 @@ pub fn most_recent_investigation(db: &GraphDb) -> anyhow::Result<String> {
 /// Resolve an investigation ID from an optional user-provided value.
 ///
 /// If `explicit_id` is `Some`, validates it exists in the database.
-/// If `None`, falls back to the most recent investigation.
+/// If `None`, uses the most recent investigation.
 /// Returns a clear error message in either failure case.
 pub fn resolve_investigation(db: &GraphDb, explicit_id: Option<&str>) -> anyhow::Result<String> {
     match explicit_id {

--- a/crates/core/src/agents/pipeline.rs
+++ b/crates/core/src/agents/pipeline.rs
@@ -1368,7 +1368,7 @@ pub async fn run_deep_pipeline_with_debate(
 /// Select the best vuln-hunter agent for the given target file.
 ///
 /// Returns a language-specialized agent name if one exists for the file's
-/// language, otherwise falls back to the generic `vuln-hunter`.
+/// language, otherwise returns the generic `vuln-hunter`.
 pub fn select_vuln_hunter(target: &str) -> String {
     let ext = target.rsplit('.').next().unwrap_or("").to_lowercase();
 

--- a/crates/core/src/analysis/taint.rs
+++ b/crates/core/src/analysis/taint.rs
@@ -2,7 +2,7 @@
 //!
 //! `TaintAnalyzer` queries the graph for data-flow paths from sources to
 //! sinks that lack sanitisation. Uses native Cypher via LadybugDB when
-//! available, falling back to SQLite recursive CTEs.
+//! available, with a SQLite recursive-CTE path for pre-migration databases.
 
 use crate::graph::GraphDb;
 use regex::Regex;

--- a/crates/core/src/binary/ghidra.rs
+++ b/crates/core/src/binary/ghidra.rs
@@ -17,7 +17,7 @@ pub struct GhidraRunner {
 /// Result of attempting to load Ghidra analysis for a binary.
 ///
 /// The loader prefers a validated cached analysis when available, otherwise it
-/// falls back to a fresh Ghidra run if Ghidra is installed.
+/// triggers a fresh Ghidra run if Ghidra is installed.
 #[derive(Debug)]
 pub enum GhidraLoadOutcome {
     NotAvailable,

--- a/crates/core/src/reporting/sarif.rs
+++ b/crates/core/src/reporting/sarif.rs
@@ -227,7 +227,7 @@ pub fn generate_sarif(findings: &[Value]) -> anyhow::Result<String> {
 /// Parse a severity string from finding evidence text.
 ///
 /// Looks for patterns like "severity=critical" or "severity=high" in the
-/// evidence string. Falls back to "medium" if no severity is found.
+/// evidence string. Defaults to "medium" if no severity is found.
 fn parse_severity_from_evidence(evidence: &str) -> &str {
     let lower = evidence.to_lowercase();
     if lower.contains("severity=critical") || lower.contains("critical") {

--- a/crates/gym/src/adapters/cybergym.rs
+++ b/crates/gym/src/adapters/cybergym.rs
@@ -156,8 +156,8 @@ impl BenchmarkAdapter for CyberGymAdapter {
             .or_else(|| paired_case_affected_files(case, data_dir, &case_dir))
             .unwrap_or_else(|| {
                 tracing::warn!(
-                    "CyberGym case {}: patch path resolution failed, \
-                     falling back to shallow source scan (≤25 files from {})",
+                    "CyberGym case {}: patch path resolution failed; \
+                     scanning at most 25 source files from {} (analysis is incomplete)",
                     case.id,
                     case_dir.display()
                 );

--- a/crates/gym/src/agentic.rs
+++ b/crates/gym/src/agentic.rs
@@ -731,20 +731,27 @@ pub async fn run_agentic_source_analysis_with_hints_and_runtime_config(
             file_str,
         );
     } else {
-        let agent_results =
-            match run_llm_pipeline(&db, &inv_id, &file_str, timeout_secs, runtime_config).await {
-                Ok(results) => results,
-                Err(e) => {
-                    tracing::warn!(
-                        "LLM pipeline failed for {}, falling back to pattern-only findings: {}",
+        let agent_results = match run_llm_pipeline(
+            &db,
+            &inv_id,
+            &file_str,
+            timeout_secs,
+            runtime_config,
+        )
+        .await
+        {
+            Ok(results) => results,
+            Err(e) => {
+                tracing::error!(
+                        "LLM pipeline failed for {}: {} — surfacing as case failure (no silent degradation to pattern-only)",
                         file_str,
                         e
                     );
-                    // Gracefully degrade to pattern-detected findings already in the graph.
-                    let all_findings = collect_all_findings_from_db(&db, &inv_id)?;
-                    return Ok(dedup_findings_by_best_severity(all_findings));
-                }
-            };
+                return Err(e).with_context(|| {
+                    format!("LLM pipeline failed during agentic source analysis of {file_str}")
+                });
+            }
+        };
 
         // Extract confidence from structured agent outputs and enrich findings.
         let confidence_map = extract_confidence_from_agent_results(&agent_results);
@@ -893,13 +900,14 @@ pub async fn run_agentic_binary_analysis_with_runtime_config(
     } else if let Err(e) =
         run_llm_pipeline(&db, &inv_id, &file_str, timeout_secs, runtime_config).await
     {
-        tracing::warn!(
-            "LLM pipeline failed for binary {}, falling back to pattern-only findings: {}",
+        tracing::error!(
+            "LLM pipeline failed for binary {}: {} — surfacing as case failure (no silent degradation to pattern-only)",
             file_str,
             e
         );
-        let all_findings = collect_all_findings_from_db(&db, &inv_id)?;
-        return Ok(dedup_findings_by_best_severity(all_findings));
+        return Err(e).with_context(|| {
+            format!("LLM pipeline failed during agentic binary analysis of {file_str}")
+        });
     }
 
     // Synthesis — weigh all evidence

--- a/crates/gym/src/improve.rs
+++ b/crates/gym/src/improve.rs
@@ -2110,7 +2110,7 @@ fn parse_review_rating(
 
 /// Heuristic analysis of false negatives (no LLM needed).
 /// Checks for graph context gaps first (missing taint rules, agent prompt gaps),
-/// then falls back to missing regex patterns.
+/// then proposes missing regex patterns as a last resort.
 #[cfg(not(feature = "test-heuristic-api"))]
 fn heuristic_failure_analysis(false_negatives: &[FalseNegativeCase]) -> Vec<Improvement> {
     heuristic_failure_analysis_impl(false_negatives)


### PR DESCRIPTION
## Summary

Continues the no-silent-degradation invariant work from PR #496/#497 by eliminating remaining `fallback` / `falls back` / `falling back` forms that were missed (gerund/conjugation variants), and **fixing two real silent-degradation behaviors** in the gym agentic analyzer.

## Wording-only changes (no behavior change)

| File | Change |
|---|---|
| `crates/cli/src/commands/common.rs` | "falls back to" → "uses" |
| `crates/core/src/agents/pipeline.rs` | "falls back to" → "returns" |
| `crates/core/src/analysis/taint.rs` | doc reword (CTE path is a documented mechanism, not a fallback) |
| `crates/core/src/binary/ghidra.rs` | "falls back" → "triggers" |
| `crates/core/src/reporting/sarif.rs` | "Falls back to" → "Defaults to" |
| `crates/gym/src/adapters/cybergym.rs` | warn log wording (kept the 25-file scan budget — that limit is intentional) |
| `crates/gym/src/improve.rs` | "then falls back to" → "then proposes ... as a last resort" |

## Behavior changes (loud failure replaces silent degradation)

`crates/gym/src/agentic.rs`:

- `run_agentic_source_analysis_with_hints_and_runtime_config`: when the LLM pipeline returns `Err`, we previously logged a warning and silently returned pattern-only findings. Now we log `ERROR` and propagate the `Err` with context up to the case runner.
- `run_agentic_binary_analysis_with_runtime_config`: same change for the binary analysis path.

The gym case runner (`crates/gym/src/lib.rs:486-518`) already handles `Ok(Err(e))` from `adapter.run_case` as a per-case failure (logs warn, increments `metrics::CASES_TOTAL` `"failed"`, continues to the next case), so error propagation is the right shape. Previously hidden LLM-pipeline breakages will now surface as failed cases instead of being silently hidden behind pattern-only results.

## Validation

- `cargo build --quiet`: OK
- `cargo clippy --quiet --all-targets -- -D warnings`: OK
- `cargo fmt --all --check`: OK
- `cargo test --quiet`: 1 pre-existing flaky test (env-var ordering in `tool_executor::test_lookup_cwe_feature_flag_legacy`) — passes in isolation on main without these changes too; unrelated to this PR
- `cargo run --release -- gym run fixtures --quick`: **Precision 98.2%, Recall 92.2%, F1 95.1%** — baseline preserved (pattern-only mode does not exercise `run_llm_pipeline`)

## Impact

Pattern-only paths (used by gym smoke and CI gym-smoke) are unaffected. Full hybrid runs may now show more "failed" cases — **that is the desired loud-failure behavior** per the no-silent-degradation invariant.

## Test plan

- [x] Builds clean
- [x] Clippy clean (`-D warnings`)
- [x] Fmt clean
- [x] `gym run fixtures --quick` matches baseline F1=95.1%
- [ ] CI green