### PR TITLE
fix(core): propagate database errors from agent tools (#507)

### DIFF
--- a/crates/core/src/agents/tool_executor.rs
+++ b/crates/core/src/agents/tool_executor.rs
@@ -164,7 +164,11 @@ fn execute_read_function(
              RETURN f.id, f.name, f.address, f.decompiled, f.confidence LIMIT 1"
         );
 
-        if let Some(val) = read_function_from_rows(db.cypher_query(&cypher).ok()) {
+        let rows = db.cypher_query(&cypher).map_err(|e| {
+            tracing::error!("read_function name lookup failed: {e}");
+            anyhow::anyhow!("read_function name lookup failed: {e}")
+        })?;
+        if let Some(val) = read_function_from_rows(Some(rows)) {
             return Ok(val);
         }
 
@@ -175,13 +179,17 @@ fn execute_read_function(
              RETURN f.id, f.name, f.address, f.decompiled, f.confidence LIMIT 1"
         );
 
-        if let Some(val) = read_function_from_rows(db.cypher_query(&cypher).ok()) {
+        let rows = db.cypher_query(&cypher).map_err(|e| {
+            tracing::error!("read_function address lookup failed: {e}");
+            anyhow::anyhow!("read_function address lookup failed: {e}")
+        })?;
+        if let Some(val) = read_function_from_rows(Some(rows)) {
             return Ok(val);
         }
     }
 
     // SQL path — always works (SQLite-only mode or LadybugDB miss)
-    if let Ok(row) = db.conn().query_row(
+    let row_result = db.conn().query_row(
         "SELECT id, name, address, decompiled, confidence FROM functions \
          WHERE investigation_id = ?1 AND (name = ?2 OR address = ?2) LIMIT 1",
         rusqlite::params![investigation_id, func_name],
@@ -194,16 +202,26 @@ fn execute_read_function(
                 row.get::<_, f64>(4)?,
             ))
         },
-    ) {
-        let safe_decompiled = format!("<code_data>\n{}\n</code_data>", row.3);
-        return Ok(serde_json::json!({
-            "status": "ok",
-            "function_id": row.0,
-            "function": row.1,
-            "address": row.2,
-            "decompiled": safe_decompiled,
-            "confidence": row.4
-        }));
+    );
+    match row_result {
+        Ok(row) => {
+            let safe_decompiled = format!("<code_data>\n{}\n</code_data>", row.3);
+            return Ok(serde_json::json!({
+                "status": "ok",
+                "function_id": row.0,
+                "function": row.1,
+                "address": row.2,
+                "decompiled": safe_decompiled,
+                "confidence": row.4
+            }));
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            // Genuine not-found — fall through to not_found response.
+        }
+        Err(e) => {
+            tracing::error!("read_function sql query failed: {e}");
+            anyhow::bail!("read_function sql query failed: {e}");
+        }
     }
 
     Ok(serde_json::json!({
@@ -760,22 +778,23 @@ fn execute_get_taint_paths(
     let func_esc = esc(&function);
 
     // Get the function's file prefix to match taint sources/sinks in the same file
-    let file_prefix: Option<String> = db
+    let prefix_rows = db
         .cypher_query(&format!(
             "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.name = '{func_esc}' \
-             RETURN f.address LIMIT 1"
+         RETURN f.address LIMIT 1"
         ))
-        .ok()
-        .and_then(|rows| {
-            rows.first().and_then(|row| {
-                LadybugGraphDb::as_str(&row[0]).and_then(|addr| {
-                    addr.split(':')
-                        .next()
-                        .filter(|s| !s.is_empty())
-                        .map(|s| s.to_string())
-                })
-            })
-        });
+        .map_err(|e| {
+            tracing::error!("get_taint_paths prefix lookup failed: {e}");
+            anyhow::anyhow!("get_taint_paths prefix lookup failed: {e}")
+        })?;
+    let file_prefix: Option<String> = prefix_rows.first().and_then(|row| {
+        LadybugGraphDb::as_str(&row[0]).and_then(|addr| {
+            addr.split(':')
+                .next()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        })
+    });
 
     let cypher = if let Some(ref prefix) = file_prefix {
         let pfx = esc(prefix);
@@ -835,18 +854,18 @@ fn execute_get_cross_file_calls(
     let func_esc = esc(&function);
 
     // Get the function's file prefix from its address
-    let file_prefix: Option<String> = db
+    let prefix_rows = db
         .cypher_query(&format!(
             "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.name = '{func_esc}' \
-             RETURN f.address LIMIT 1"
+         RETURN f.address LIMIT 1"
         ))
-        .ok()
-        .and_then(|rows| {
-            rows.first().and_then(|row| {
-                LadybugGraphDb::as_str(&row[0])
-                    .map(|addr| addr.split(':').next().unwrap_or("").to_string())
-            })
-        });
+        .map_err(|e| {
+            tracing::error!("get_cross_file_calls prefix lookup failed: {e}");
+            anyhow::anyhow!("get_cross_file_calls prefix lookup failed: {e}")
+        })?;
+    let file_prefix: Option<String> = prefix_rows.first().and_then(|row| {
+        LadybugGraphDb::as_str(&row[0]).map(|addr| addr.split(':').next().unwrap_or("").to_string())
+    });
 
     let mut results = Vec::new();
 
@@ -857,18 +876,20 @@ fn execute_get_cross_file_calls(
              WHERE f1.investigation_id = '{inv}' AND f1.name = '{func_esc}' \
              RETURN f2.name, f2.address LIMIT 50"
         );
-        if let Ok(rows) = db.cypher_query(&cypher) {
-            for row in &rows {
-                let name = LadybugGraphDb::as_str(&row[0]).unwrap_or("").to_string();
-                let address = LadybugGraphDb::as_str(&row[1]).unwrap_or("").to_string();
-                let callee_prefix = address.split(':').next().unwrap_or("");
-                if callee_prefix != prefix {
-                    results.push(serde_json::json!({
-                        "name": name,
-                        "address": address,
-                        "direction": "callee",
-                    }));
-                }
+        let rows = db.cypher_query(&cypher).map_err(|e| {
+            tracing::error!("get_cross_file_calls callee query failed: {e}");
+            anyhow::anyhow!("get_cross_file_calls callee query failed: {e}")
+        })?;
+        for row in &rows {
+            let name = LadybugGraphDb::as_str(&row[0]).unwrap_or("").to_string();
+            let address = LadybugGraphDb::as_str(&row[1]).unwrap_or("").to_string();
+            let callee_prefix = address.split(':').next().unwrap_or("");
+            if callee_prefix != prefix {
+                results.push(serde_json::json!({
+                    "name": name,
+                    "address": address,
+                    "direction": "callee",
+                }));
             }
         }
 
@@ -878,18 +899,20 @@ fn execute_get_cross_file_calls(
              WHERE f2.investigation_id = '{inv}' AND f2.name = '{func_esc}' \
              RETURN f1.name, f1.address LIMIT 50"
         );
-        if let Ok(rows) = db.cypher_query(&cypher) {
-            for row in &rows {
-                let name = LadybugGraphDb::as_str(&row[0]).unwrap_or("").to_string();
-                let address = LadybugGraphDb::as_str(&row[1]).unwrap_or("").to_string();
-                let caller_prefix = address.split(':').next().unwrap_or("");
-                if caller_prefix != prefix {
-                    results.push(serde_json::json!({
-                        "name": name,
-                        "address": address,
-                        "direction": "caller",
-                    }));
-                }
+        let rows = db.cypher_query(&cypher).map_err(|e| {
+            tracing::error!("get_cross_file_calls caller query failed: {e}");
+            anyhow::anyhow!("get_cross_file_calls caller query failed: {e}")
+        })?;
+        for row in &rows {
+            let name = LadybugGraphDb::as_str(&row[0]).unwrap_or("").to_string();
+            let address = LadybugGraphDb::as_str(&row[1]).unwrap_or("").to_string();
+            let caller_prefix = address.split(':').next().unwrap_or("");
+            if caller_prefix != prefix {
+                results.push(serde_json::json!({
+                    "name": name,
+                    "address": address,
+                    "direction": "caller",
+                }));
             }
         }
     }

--- a/crates/core/src/agents/tool_executor.rs
+++ b/crates/core/src/agents/tool_executor.rs
@@ -278,8 +278,8 @@ fn execute_get_call_neighbors(
                 })
                 .collect(),
             Err(e) => {
-                tracing::debug!("get_{direction} query failed: {e}");
-                Vec::new()
+                tracing::error!("get_{direction} cypher query failed: {e}");
+                anyhow::bail!("get_{direction} cypher query failed: {e}");
             }
         }
     } else {
@@ -295,18 +295,33 @@ fn execute_get_call_neighbors(
              JOIN functions f2 ON c.callee_id = f2.id \
              WHERE f1.name = ?1 AND f1.investigation_id = ?2 LIMIT 50"
         };
-        let mut stmt = db
-            .conn()
-            .prepare(sql)
-            .unwrap_or_else(|_| db.conn().prepare("SELECT '' WHERE 0").unwrap());
-        stmt.query_map(rusqlite::params![func_name, investigation_id], |row| {
-            Ok(serde_json::json!({
-                "name": row.get::<_, String>(0)?,
-                "address": row.get::<_, String>(1)?
-            }))
-        })
-        .map(|rows| rows.filter_map(|r| r.ok()).collect())
-        .unwrap_or_default()
+        let conn = db.conn();
+        let mut stmt = conn.prepare(sql).map_err(|e| {
+            tracing::error!("get_{direction} sql prepare failed: {e}");
+            anyhow::anyhow!("get_{direction} sql prepare failed: {e}")
+        })?;
+        let rows = stmt
+            .query_map(rusqlite::params![func_name, investigation_id], |row| {
+                Ok(serde_json::json!({
+                    "name": row.get::<_, String>(0)?,
+                    "address": row.get::<_, String>(1)?
+                }))
+            })
+            .map_err(|e| {
+                tracing::error!("get_{direction} sql query failed: {e}");
+                anyhow::anyhow!("get_{direction} sql query failed: {e}")
+            })?;
+        let mut out = Vec::new();
+        for r in rows {
+            match r {
+                Ok(v) => out.push(v),
+                Err(e) => {
+                    tracing::error!("get_{direction} sql row read failed: {e}");
+                    anyhow::bail!("get_{direction} sql row read failed: {e}");
+                }
+            }
+        }
+        out
     };
 
     Ok(serde_json::json!({
@@ -541,11 +556,14 @@ fn execute_rename_function(
             "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.name = '{name_esc}' \
              RETURN f.name LIMIT 1"
         );
-        if db
-            .cypher_query(&check)
-            .map(|r| !r.is_empty())
-            .unwrap_or(false)
-        {
+        let exists_by_name = match db.cypher_query(&check) {
+            Ok(rows) => !rows.is_empty(),
+            Err(e) => {
+                tracing::error!("rename_function existence-by-name check failed: {e}");
+                anyhow::bail!("rename_function existence-by-name check failed: {e}");
+            }
+        };
+        if exists_by_name {
             let update = format!(
                 "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.name = '{name_esc}' \
                  SET f.decompiled = '{code}'"
@@ -563,11 +581,14 @@ fn execute_rename_function(
             "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.address = '{name_esc}' \
              RETURN f.name LIMIT 1"
         );
-        if db
-            .cypher_query(&check)
-            .map(|r| !r.is_empty())
-            .unwrap_or(false)
-        {
+        let exists_by_addr = match db.cypher_query(&check) {
+            Ok(rows) => !rows.is_empty(),
+            Err(e) => {
+                tracing::error!("rename_function existence-by-address check failed: {e}");
+                anyhow::bail!("rename_function existence-by-address check failed: {e}");
+            }
+        };
+        if exists_by_addr {
             let update = format!(
                 "MATCH (f:Function) WHERE f.investigation_id = '{inv}' AND f.address = '{name_esc}' \
                  SET f.decompiled = '{code}'"
@@ -592,7 +613,10 @@ fn execute_rename_function(
                 &func_name,
             ],
         )
-        .unwrap_or(0);
+        .map_err(|e| {
+            tracing::error!("rename_function sql update failed: {e}");
+            anyhow::anyhow!("rename_function sql update failed: {e}")
+        })?;
 
     if updated > 0 {
         return Ok(serde_json::json!({
@@ -784,8 +808,8 @@ fn execute_get_taint_paths(
             })
             .collect(),
         Err(e) => {
-            tracing::debug!("get_taint_paths query failed: {e}");
-            Vec::new()
+            tracing::error!("get_taint_paths query failed: {e}");
+            anyhow::bail!("get_taint_paths query failed: {e}");
         }
     };
 
@@ -907,8 +931,8 @@ fn execute_get_data_sources(
             })
             .collect(),
         Err(e) => {
-            tracing::debug!("get_data_sources query failed: {e}");
-            Vec::new()
+            tracing::error!("get_data_sources query failed: {e}");
+            anyhow::bail!("get_data_sources query failed: {e}");
         }
     };
 
@@ -947,8 +971,8 @@ fn execute_get_imports(
             })
             .collect(),
         Err(e) => {
-            tracing::debug!("get_imports query failed: {e}");
-            Vec::new()
+            tracing::error!("get_imports query failed: {e}");
+            anyhow::bail!("get_imports query failed: {e}");
         }
     };
 
@@ -1899,4 +1923,26 @@ mod tests {
             assert!(!insight.is_empty(), "fn_insight should be non-empty");
         }
     }
+
+    // ===== #507: Tool error propagation =====
+    //
+    // The fixes in this file replace silent-error patterns
+    // (`.unwrap_or(false)`, `.unwrap_or(0)`, `_ => Vec::new()` swallowing
+    // `Err(e)`) with explicit `bail!` / `?` propagation in five tools:
+    //   - get_callers / get_callees
+    //   - get_taint_paths
+    //   - get_data_sources
+    //   - get_imports
+    //   - rename_function
+    //
+    // Direct unit tests for the Err path are impractical: LadybugDB does not
+    // return Err for "label has no nodes" — it returns an empty result set,
+    // which is the correct happy-path behavior already exercised by the
+    // existing `_empty` and `_isolation` tests above. To meaningfully exercise
+    // the Err path we would need to inject a corrupted/closed DB handle, which
+    // would require refactoring `GraphDb` for dependency injection (out of
+    // scope for this fix). The change is therefore covered by:
+    //   1. Existing happy-path tests (no regression on Ok results)
+    //   2. Code review of the bail!/`?` patterns
+    //   3. Integration-level testing via `cargo run -- gym run fixtures --quick`
 }

--- a/docs/tool-error-propagation.md
+++ b/docs/tool-error-propagation.md
@@ -1,0 +1,181 @@
+# Tool Error Propagation
+
+Agent tool functions in `tool_executor.rs` propagate database errors to callers
+instead of swallowing them. When a graph query fails, the tool returns an
+`Err(anyhow::Error)` that flows through the agent runner and surfaces as a
+tool-use error in the LLM conversation. Agents receive an explicit failure
+signal and can retry or adjust their strategy.
+
+This applies to six tool entry points: `get_callers`, `get_callees`,
+`get_taint_paths`, `get_data_sources`, `get_imports`, and `rename_function`.
+`get_callers` and `get_callees` share the `execute_get_call_neighbors`
+implementation, so five internal functions are modified.
+
+## Why This Matters
+
+Silent tool failures corrupt agent analysis. When `get_data_sources` returns
+an empty list due to a query error, the agent concludes "no external inputs
+exist" and skips taint analysis entirely. The vulnerability goes unreported —
+not because the code is safe, but because the tool lied about it.
+
+With error propagation, the agent sees a tool error and knows the data is
+missing. It can retry, use alternative tools, or report that analysis was
+incomplete.
+
+## Error Behavior
+
+Every tool function returns `anyhow::Result<serde_json::Value>`. On database
+failure, the function:
+
+1. Logs the error at `tracing::error!` level (not `debug!`)
+2. Returns `Err(anyhow::anyhow!("descriptive message: {original_error}"))`
+
+The caller chain handles the rest:
+
+| Layer | File | Behavior |
+|-------|------|----------|
+| Tool executor | `tool_executor.rs` | Returns `Err` with context |
+| Agent runner | `runner.rs` | Converts to tool-use error message in LLM conversation |
+| Agent traits | `traits.rs` | Wraps as `ClientError::ToolExecution` |
+| Gym agentic | `gym/agentic.rs` | Logs error, continues pipeline with reduced context |
+
+Agents already handle tool errors in the LLM protocol — the tool-use error
+appears as a message the agent can read and react to. No changes to agent
+markdown definitions or runner logic are needed.
+
+## Affected Tools
+
+### get_callers / get_callees
+
+Returns functions that call (or are called by) a target function.
+
+**Before:** Cypher query failure logged at `debug!` level, returned empty list.
+SQL prepare failure replaced with a dummy query that returned no rows.
+
+**After:** Cypher query failure returns `Err` with the query error. SQL prepare
+failure propagates via `anyhow::Context`. SQL row-read errors propagate instead
+of being filtered out with `.filter_map(|r| r.ok())`.
+
+```
+// Agent sees this on success:
+{"status": "ok", "callers": [{"name": "handle_request", "address": "server.c:42"}]}
+
+// Agent sees this on failure:
+Tool error: get_callers cypher query failed: LadybugDB: no such table: ladybug_nodes
+```
+
+### get_taint_paths
+
+Returns taint flow paths (source → function → sink) for a target function.
+
+**Before:** Query failure logged at `debug!`, returned empty path list.
+
+**After:** Query failure returns `Err` with the original error message.
+
+```
+// Agent sees this on success:
+{"status": "ok", "taint_paths": [{"source": "getenv", "sink": "sprintf", "path": "getenv → parse_input → sprintf"}]}
+
+// Agent sees this on failure:
+Tool error: get_taint_paths query failed: LadybugDB: connection closed
+```
+
+### get_data_sources
+
+Returns all external data inputs (network, file, env, stdin) for the
+investigation.
+
+**Before:** Query failure logged at `debug!`, returned empty source list.
+
+**After:** Query failure returns `Err`.
+
+```
+// Agent sees this on failure:
+Tool error: get_data_sources query failed: LadybugDB: disk I/O error
+```
+
+### get_imports
+
+Returns all imported symbols for the investigation.
+
+**Before:** Query failure logged at `debug!`, returned empty import list.
+
+**After:** Query failure returns `Err`.
+
+```
+// Agent sees this on failure:
+Tool error: get_imports query failed: LadybugDB: table ladybug_edges does not exist
+```
+
+### rename_function
+
+Updates a function's display name and decompiled code after variable renaming.
+
+**Before:** Cypher existence checks used `.unwrap_or(false)`, collapsing errors
+into "function not found." SQL UPDATE used `.unwrap_or(0)`, collapsing errors
+into "0 rows updated."
+
+**After:** All three database operations propagate errors. A failed existence
+check returns `Err` instead of falling through to the "not found" branch. A
+failed SQL UPDATE returns `Err` instead of reporting zero rows affected.
+
+```
+// Agent sees this on failure:
+Tool error: rename_function existence check failed: LadybugDB: database is locked
+```
+
+## Error Logging
+
+All database errors in the six tool entry points log at `tracing::error!` level.
+This makes tool failures visible in production logs and monitoring dashboards.
+
+Previous behavior logged at `tracing::debug!`, which was invisible in default
+log configurations and made production diagnosis impossible.
+
+## Testing
+
+Direct unit tests for the `Err` path turned out to be impractical with the
+current `GraphDb` design:
+
+- LadybugDB does **not** return `Err` for "label has no nodes" — it returns
+  an empty result set, which is the correct happy-path behavior already
+  exercised by existing `_empty` and `_isolation` tests.
+- Dropping the underlying SQLite tables (`ladybug_nodes`, `ladybug_edges`)
+  does not corrupt the embedded LadybugDB store either — LadybugDB owns its
+  own in-process state and does not rely on those SQLite tables for the
+  tool query paths exercised here.
+- Injecting a corrupted/closed DB handle would require refactoring `GraphDb`
+  to support dependency injection of the underlying `LadybugGraphDb`, which
+  is out of scope for a surgical correctness fix.
+
+The change is therefore covered by:
+
+1. **Existing happy-path unit tests** — verify no regression on `Ok` results
+   (e.g., `test_execute_tool_get_callers_empty`, `test_callers_scoped_to_investigation`).
+2. **Code review** of the `bail!` / `?` patterns at the five sites.
+3. **Integration testing** via `cargo run -- gym run fixtures --quick` before
+   the PR is merged, which exercises the full pipeline against real corpora.
+
+A future refactor could parameterize `GraphDb` over its graph backend to
+enable mock-based `Err`-path coverage without touching the production code.
+
+## Compatibility
+
+This change is backward-compatible at the agent level. The tool-use protocol
+already defines error responses — agents have always been capable of receiving
+tool errors. The only behavior change is that tools that previously returned
+`{"status": "ok", "callers": []}` on failure now return an error. Agents that
+assumed empty results meant "no data" continue to work correctly for the
+genuine empty-data case, which still returns `{"status": "ok", ...}` with an
+empty list.
+
+The gym benchmark scores are unaffected because the graph database does not
+fail during normal benchmark execution. The error paths only trigger on actual
+database corruption or connection issues.
+
+## Related Documentation
+
+- [Graph-Agent Architecture](graph-agent-architecture.md) — Tool definitions
+  and agent methodology
+- [Tool Translate: Cypher Migration](tool-translate-cypher-migration.md) —
+  Cypher query pipeline and error handling in `query_graph`


### PR DESCRIPTION
Closes #507

## What

Five agent tools previously swallowed database errors via `.unwrap_or(false)`, `.unwrap_or(0)`, and `Err(_) => Vec::new()` patterns, returning `{status:'ok', ...:[]}` on failure. Agents could not distinguish 'no data' from 'query failed'.

## Sites fixed in `crates/core/src/agents/tool_executor.rs`

- `get_callers` / `get_callees` (`execute_get_call_neighbors`, ~line 262)
- `get_taint_paths` (~line 787)
- `get_data_sources` (~line 910)
- `get_imports` (~line 952)
- `rename_function` (cypher existence checks + sql update, ~line 553)


## Validation

- `cargo run -- gym run fixtures --quick` passes with identical results to main (E2E smoke)
- All 43 tool_executor unit tests pass
- `cargo clippy --lib -p skwaq-core -- -D warnings` clean

## Testing rationale

Direct Err-path unit tests proved impractical without refactoring `GraphDb` for dependency injection (LadybugDB returns empty results, not Err, for missing labels; dropping SQLite tables doesn't corrupt the embedded LadybugDB store). Coverage relies on existing happy-path tests + code review + E2E smoke. Full rationale in `docs/tool-error-propagation.md`.

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — internal tool-error-propagation hardening; tools are agent-only, not user-facing.
- Equivalent E2E coverage: `cargo run -- gym run fixtures --quick` validated by `gym-smoke` CI (passed 1m16s on `deeb4307`).
- Unit-test command: `cargo test -p skwaq-core --lib agents::tool_executor` → 43 passed, 0 failed.

### Documentation

- User-facing docs impact: no
- Updated docs: `docs/tool-error-propagation.md` (this PR)
- Rationale: tool internals; agent runner already converts `Err` → `ClientError::ToolExecution`.

### Quality-audit

- Cycle 1 (`audit-pr-511`): HIGH findings — three additional silent-failure sites: `execute_read_function`, `execute_get_cross_file_calls`, `execute_get_taint_paths` prefix query. **Fix:** commit `deeb4307` propagated `Err` from all three (8 sites total fixed across the PR).
- Cycle 2 (`audit2-pr-511`): **CLEAN** — `lookup_cwe_children` and `execute_query_graph` log-level were intentionally left out of scope (helper / fallback by design).
- Cycle 3 (`audit3-pr-511`): **CLEAN** — all 8 agent-facing tools verified to propagate cypher errors via `?`/`bail!` + `tracing::error!`. SQL not-found correctly distinguished from query-failed via `QueryReturnedNoRows`.

### CI

- `gh pr checks 511`: test ✅ (25m12s + 23m47s), gym-smoke ✅ (1m16s), ci-benchmark ✅ (1m54s).
- Skipped checks: GitGuardian (non-code).
- Real failures fixed: none.

### Scope

- Files changed: `crates/core/src/agents/tool_executor.rs`, `docs/tool-error-propagation.md`.
- Unrelated changes: none.

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none.
