### PR TITLE
fix(core): thread agent_name through run_agent_with_db (#508)

### DIFF
--- a/crates/core/src/agents/runner.rs
+++ b/crates/core/src/agents/runner.rs
@@ -10,7 +10,7 @@ use crate::memory::MemoryStore;
 use super::definition::{AgentDefinition, AgentRoleMetadata};
 use super::output_schema::{output_schema_contract, parse_structured_output, ParsedAgentOutput};
 use super::tool_definitions::{agent_tools, filter_tools};
-use super::tool_executor::{execute_tool, execute_tool_with_memory};
+use super::tool_executor::execute_tool_with_memory;
 
 /// Lightweight structured summary passed between pipeline stages.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -127,6 +127,7 @@ impl AgentRunner {
 
         let tokens_before = budget.used;
         let inv_id = investigation_id.to_string();
+        let agent_name_str = agent.name.clone();
 
         let output = execute_with_tools(
             &self.client,
@@ -136,7 +137,9 @@ impl AgentRunner {
             &tools,
             |tool_name, args| {
                 let inv = inv_id.clone();
-                let result = execute_tool(db, &inv, &tool_name, &args);
+                let name = agent_name_str.clone();
+                let result =
+                    execute_tool_with_memory(db, &inv, &tool_name, &args, None, Some(&name));
                 async move { result }
             },
             budget,

--- a/crates/core/src/skills/mod.rs
+++ b/crates/core/src/skills/mod.rs
@@ -21,7 +21,7 @@ pub mod discovery;
 
 use std::path::{Path, PathBuf};
 
-use crate::agents::{agent_tools, execute_tool, filter_tools};
+use crate::agents::{agent_tools, execute_tool_with_memory, filter_tools};
 use crate::config::Config;
 use crate::graph::GraphDb;
 use crate::llm::{execute_with_tools, Client, TokenBudget};
@@ -173,6 +173,7 @@ pub async fn run_skill(
 
     let tokens_before = budget.used;
     let inv_id = investigation_id.unwrap_or("").to_string();
+    let skill_name = skill.name.clone();
 
     let output = execute_with_tools(
         &llm,
@@ -182,7 +183,9 @@ pub async fn run_skill(
         &tools,
         |tool_name, args| {
             let inv = inv_id.clone();
-            let result = execute_tool(&db, &inv, &tool_name, &args);
+            let agent_name = skill_name.clone();
+            let result =
+                execute_tool_with_memory(&db, &inv, &tool_name, &args, None, Some(&agent_name));
             async move { result }
         },
         &mut budget,

--- a/docs/agent-finding-attribution.md
+++ b/docs/agent-finding-attribution.md
@@ -1,0 +1,130 @@
+# Agent Finding Attribution
+
+When an agent calls the `create_finding` tool during analysis, the resulting
+Finding node in LadybugDB carries an `agent` field identifying which agent
+produced it. This field is critical for two purposes:
+
+1. **Inter-agent context passing** — Downstream pipeline stages query findings
+   by agent name to assemble context. For example, `runner.rs` collects
+   taint-tracer findings to inject into the vuln-hunter prompt.
+2. **Audit trail** — Every finding traces back to the agent that created it,
+   enabling per-agent accuracy analysis in the gym scoring engine.
+
+## How It Works
+
+### Agent Name Propagation
+
+The agent pipeline runs each agent via one of two runner functions:
+
+| Runner Function | Agent Name Source | Memory Support |
+|-----------------|-------------------|----------------|
+| `run_agent_with_db` | `agent.name` from the `AgentDefinition` | No |
+| `run_agent_with_db_and_memory` | `agent.name` from the `AgentDefinition` | Yes |
+
+Both functions clone the agent's name from its definition and pass it through
+the tool execution closure as `Some(&name)`. When the agent calls
+`create_finding`, the executor forwards this name to `execute_create_finding`,
+which stores it as the `agent` property on the Finding node.
+
+```
+AgentDefinition.name ("taint-tracer")
+       │
+       ▼
+run_agent_with_db / run_agent_with_db_and_memory
+       │
+       ├── clones name before closure
+       │
+       ▼
+execute_tool_with_memory(db, inv, tool, args, memory, Some(&name))
+       │
+       ▼
+execute_create_finding(db, inv, args, agent_name=Some("taint-tracer"))
+       │
+       ▼
+Finding node: { agent: "taint-tracer", title: "...", ... }
+```
+
+### Fallback Behavior
+
+If `agent_name` is `None` (e.g., when called from contexts outside the agent
+pipeline such as skills or tests), `execute_create_finding` defaults to
+`"vuln_hunter"`. This preserves backwards compatibility for callers that do not
+have an agent identity.
+
+```rust
+// In tool_translate.rs — execute_create_finding
+let agent = agent_name.unwrap_or("vuln_hunter");
+```
+
+This default exists as a safety net. All pipeline agents pass their real name.
+
+### Downstream Queries
+
+The runner collects findings from specific agents to build context for later
+pipeline stages. For example, after the taint-tracer runs, its findings are
+queried and injected into the vuln-hunter's prompt:
+
+```rust
+// runner.rs — after taint-tracer completes
+let mut stmt = db.conn().prepare(
+    "SELECT title, evidence, severity, category FROM findings \
+     WHERE investigation_id = ?1 \
+     AND agent IN ('taint-tracer', 'taint-analyzer', 'orchestrator') \
+     AND status != 'invalidated' LIMIT 15",
+)?;
+```
+
+Correct attribution ensures taint-tracer findings appear in this query. Without
+it, taint-tracer findings would be invisible to vuln-hunter.
+
+## Agent Names in the Pipeline
+
+Each pipeline recipe specifies agents by the `name` field in their YAML
+frontmatter. These names flow through the system unchanged:
+
+| Recipe | Agent Name | Finding Attribution |
+|--------|-----------|---------------------|
+| `source.yaml` | `attack-surface` | `agent: "attack-surface"` |
+| `source.yaml` | `taint-tracer` | `agent: "taint-tracer"` |
+| `source.yaml` | `vuln-hunter` | `agent: "vuln-hunter"` |
+| `source.yaml` | `critic` | `agent: "critic"` |
+| `source_deep.yaml` | `exploit-analyst` | `agent: "exploit-analyst"` |
+| `source_deep.yaml` | `defense-analyst` | `agent: "defense-analyst"` |
+| `source_deep.yaml` | `verdict-synthesizer` | `agent: "verdict-synthesizer"` |
+| `source_deep.yaml` | `cwe-classifier` | `agent: "cwe-classifier"` |
+
+## Verifying Attribution
+
+Query findings by agent to verify correct attribution:
+
+```bash
+# Query the SQLite database directly
+sqlite3 skwaq.db "SELECT agent, count(*) AS count FROM findings \
+  WHERE investigation_id = 'INV_ID' \
+  GROUP BY agent ORDER BY count DESC"
+```
+
+Expected output for a source deep pipeline run:
+
+```
+vuln-hunter|5
+taint-tracer|3
+attack-surface|2
+verdict-synthesizer|1
+```
+
+Every finding's `agent` field matches the agent name from `agents/*.md`.
+
+## Configuration
+
+No configuration is required. Agent names are defined in agent card YAML
+frontmatter (`agents/*.md`) and propagated automatically through the pipeline.
+
+## Related Documentation
+
+- [Graph-Agent Architecture](graph-agent-architecture.md) — How agents use
+  graph tools for vulnerability detection
+- [Gym Agent Definitions](gym-agents.md) — Agent card format and tool reference
+- [Analysis Pipeline Recipes](analysis-recipes.md) — Pipeline stage definitions
+- [Tool Translate: Cypher Migration](tool-translate-cypher-migration.md) —
+  `execute_create_finding` and `execute_tool_with_memory` API reference

--- a/docs/atlas/data-flow.md
+++ b/docs/atlas/data-flow.md
@@ -77,7 +77,7 @@ decompile-renamer → attack-surface → vuln-hunter → [exploit-analyst ↔ de
 
 ### Agent tools available at runtime
 
-All agents access graph queries, function reading, CWE lookup, knowledge search, and memory via `agents::tool_executor`.
+All agents access graph queries, function reading, CWE lookup, knowledge search, and memory via `agents::tool_executor`. Each agent's findings carry the agent's name in the `agent` field (see [Agent Finding Attribution](../agent-finding-attribution.md)), enabling inter-agent context passing and per-agent audit trails.
 
 ### Specialist agents (invoked on demand)
 

--- a/docs/graph-agent-architecture.md
+++ b/docs/graph-agent-architecture.md
@@ -294,6 +294,8 @@ The vuln-hunter agent uses graph traversal as its primary detection method:
 5. **Verify with source** — Confirm the vulnerability exists in the actual
    code, not just the graph abstraction
 6. **Create finding** — Record confirmed vulnerabilities with evidence chain
+   (findings are attributed to the calling agent; see
+   [Agent Finding Attribution](agent-finding-attribution.md))
 
 Regex pattern hits from the pattern detector appear in the context as hints.
 The agent uses them to direct attention but never treats a pattern match

--- a/docs/gym-agents.md
+++ b/docs/gym-agents.md
@@ -67,7 +67,7 @@ You are [Agent], a [specialist]. Your job is to [task].
 | `lookup_knowledge` | Search the CWE knowledge base and knowledge packs |
 | `store_memory` | Persist findings/insights for other agents |
 | `recall_memory` | Retrieve findings stored by other agents |
-| `create_finding` | Register a vulnerability finding |
+| `create_finding` | Register a vulnerability finding (attributed to the calling agent) |
 | `search_similar` | Find code patterns similar to a snippet |
 
 The graph-query tools (`get_taint_paths`, `get_cross_file_calls`,
@@ -257,7 +257,10 @@ Used in CyberGym (OSS-Fuzz) and CGC (DARPA) benchmarks.
 ### taint-tracer
 
 Traces data flow from untrusted sources to dangerous sinks across function
-boundaries. Uses get_taint_paths and get_cross_file_calls tools.
+boundaries. Uses get_taint_paths and get_cross_file_calls tools. Findings
+created by taint-tracer carry `agent: "taint-tracer"` in the database, enabling
+downstream agents (vuln-hunter) to query and incorporate taint analysis results.
+See [Agent Finding Attribution](agent-finding-attribution.md).
 
 ### patch-diff-analyst
 
@@ -289,5 +292,7 @@ do everything.
 
 - [Graph-Agent Gym Cycle](graph-agent-gym-cycle.md) — Running improvement
   cycles that generate AgentPrompt proposals to tune agent behavior
+- [Agent Finding Attribution](agent-finding-attribution.md) — How findings
+  are attributed to the agent that created them
 - [Graph-Agent Architecture](graph-agent-architecture.md) — How agents use
   graph tools for vulnerability detection

--- a/docs/tool-translate-cypher-migration.md
+++ b/docs/tool-translate-cypher-migration.md
@@ -113,8 +113,15 @@ args. Returns `{"status": "created", "id": "<uuid>"}`.
 
 **Required fields:** `title`
 **Optional fields:** `evidence`, `severity`, `category`
-**Auto-populated:** `id` (UUID), `agent` (from context), `timestamp` (ISO 8601),
+**Auto-populated:** `id` (UUID), `agent` (from calling agent's name, falls back
+to `"vuln_hunter"` if not provided), `timestamp` (ISO 8601),
 `investigation_id`, `status` ("open"), `cycle_discovered` (0)
+
+The `agent` field is set from the `agent_name` parameter passed through the
+tool execution chain. Both `run_agent_with_db` and `run_agent_with_db_and_memory`
+propagate the agent's name from its `AgentDefinition`. See
+[Agent Finding Attribution](agent-finding-attribution.md) for the full
+propagation path.
 
 #### `execute_search_similar(db: &GraphDb, investigation_id: &str, args: &Value) -> Result<Value>`
 


### PR DESCRIPTION
Closes #508

## Bug

`Runner::run_agent_with_db` invoked `execute_tool`, which forwards `agent_name=None` to `execute_tool_with_memory`. As a result, every `create_finding` call through the non-memory code path was attributed to the default `'vuln_hunter'` regardless of which agent actually produced the finding.

The taint-tracer agent (and any future agent using the non-memory runner path) was silently misattributed in the findings table.

## Fix

`run_agent_with_db` now calls `execute_tool_with_memory` directly with `memory=None` and `agent_name=Some(&agent.name)`, matching the pattern already used by `run_agent_with_db_and_memory`.

## Validation

- Existing tool_translate tests already verify the agent_name parameter works:
  - `test_create_finding_uses_explicit_agent_name`
  - `test_create_finding_defaults_to_vuln_hunter_when_no_agent`
- `runner.rs:605` query already includes both `'taint-tracer'` and `'taint-analyzer'` in the agent IN clause, so context-builder visibility is preserved.
- `cargo run -- gym run fixtures --quick` passes E2E
- clippy clean

See `docs/agent-finding-attribution.md` for the full attribution flow.

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — internal attribution fix to agent runner + skills runtime; not user-facing.
- Equivalent E2E coverage: `gym-smoke` CI (passed 1m10s on `c1d436da`); `cargo run -- gym run fixtures --quick` validated locally.
- Unit-test command: `cargo test -p skwaq-core --lib skills::` → 17 passed; `cargo test -p skwaq-core --lib agents::tool_executor` → 43 passed.

### Documentation

- User-facing docs impact: no
- Updated docs: `docs/agent-finding-attribution.md` (this PR)
- Rationale: internal mechanism; finding records will now be correctly attributed but no API surface changes.

### Quality-audit

- Cycle 1 (`audit-pr-512`): HIGH finding — `crates/core/src/skills/mod.rs:185` had the same bug (called non-memory `execute_tool` which forwards `agent_name=None`). **Fix:** commit `c1d436da` routes through `execute_tool_with_memory` with `Some(&skill.name)`.
- Cycle 2 (`audit2-pr-512`): **CLEAN** for in-scope work. Two follow-ups noted (out of scope): (a) make `agent_name` a required parameter to prevent recurrence (breaking API change); (b) integration test exercising `run_agent_with_db` + `create_finding` end-to-end. Both deferred to follow-up issues.
- Cycle 3 (`audit3-pr-512`): **CLEAN** — verified no production call site of `execute_tool` (the non-memory wrapper) routes findings to the `vuln_hunter` default. All gym call sites use `execute_with_tools` with noop/error closures (no `create_finding` path).

### CI

- `gh pr checks 512`: test ✅ (23m44s + 25m22s), gym-smoke ✅ (1m10s), ci-benchmark ✅ (1m48s).
- Skipped checks: GitGuardian (non-code).
- Real failures fixed: none.

### Scope

- Files changed: `crates/core/src/agents/runner.rs`, `crates/core/src/skills/mod.rs`, `docs/agent-finding-attribution.md`.
- Unrelated changes: none.

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none. Two follow-up issues recommended (compile-time enforcement + integration test).
