### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Targeted, lockfile-only bump of **crossbeam-epoch `0.9.18` → `0.9.20`** to remediate **[RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204)** — *Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid*.

Applied with:

```
cargo update -p crossbeam-epoch --precise 0.9.20
```

This is a semver-compatible patch bump of a transitive dependency; only the single `crossbeam-epoch` entry in `Cargo.lock` changed.

### Diff (entire change)

```diff
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
   "crossbeam-utils",
 ]
```

### Verification

Before (on `main`): `cargo deny check advisories` reports `RUSTSEC-2026-0204` for `crossbeam-epoch v0.9.18` with `Solution: Upgrade to >=0.9.20`.

After (this branch):
- `crossbeam-epoch` resolves to `0.9.20` (>=0.9.20 as required).
- `cargo deny check advisories 2>&1 | grep -c RUSTSEC-2026-0204` -> `0` (advisory no longer fires).
- `cargo audit` reports no `crossbeam-epoch` / `RUSTSEC-2026-0204` finding.

## Out of scope

Other pre-existing, unrelated advisories on the default branch (lopdf, protobuf, rsa, webpki, anyhow, memmap2, etc.) are intentionally **left untouched** — they are separate issues and outside the scope of this focused security bump.

## Merge-ready criteria

### 1. qa-team scenarios — N/A (justified)
Lockfile-only, semver-compatible transitive-dependency security bump; there is no new/changed user-facing behavior or code surface to author gadugi scenarios against. The affected code paths (crossbeam-epoch via rayon/moka) are exercised by the existing `cargo test --all` suite, which passed green (see criterion 4).

### 2. Docs — N/A (internal-only justification)
No user-facing surface changed. The only change is a single `Cargo.lock` version+checksum line for a transitive dependency; there is no CLI, API, config, or behavioral surface to document.

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, ended clean
Adapted to a lockfile-only security bump. Each cycle SEEKs a class of defect this change could introduce, VALIDATEs with a concrete command, and FIXes if needed.

**Cycle 1 — Scope creep / unintended lockfile churn**
- SEEK: Did `cargo update` touch anything beyond the crossbeam-epoch entry (wholesale re-resolution, sibling bumps)?
- VALIDATE: `git diff --stat origin/main...HEAD` → `Cargo.lock | 4 ++--, 1 file changed, 2 insertions(+), 2 deletions(-)`. Diff lines excluding crossbeam-epoch name/version/checksum → `0`. Files touched → `Cargo.lock` only.
- FIX: none required. **Result: clean.**

**Cycle 2 — Security remediation actually effective / no regression**
- SEEK: Is RUSTSEC-2026-0204 truly cleared and crossbeam-epoch at the required floor (no accidental downgrade)?
- VALIDATE: `grep -A2 'name = "crossbeam-epoch"' Cargo.lock` → `version = "0.9.20"`; `cargo deny check advisories 2>&1 | grep -c RUSTSEC-2026-0204` → `0`; `cargo audit` → no crossbeam-epoch/2026-0204 finding.
- FIX: none required. **Result: clean.**

**Cycle 3 — Dependency-resolution / build integrity**
- SEEK: Does 0.9.20 remain semver-compatible for all consumers and keep the lockfile self-consistent (no hidden breakage)?
- VALIDATE: `cargo metadata --locked` → OK (lockfile consistent, no re-resolution needed). `cargo tree -i crossbeam-epoch` → 0.9.20 accepted by all consumers (crossbeam-deque→rayon→skwaq-gym; moka→rustyclawd-tools). CI `test` job (fmt/clippy/`cargo test --all`/build) passed green.
- FIX: none required. **Result: clean.**

Final cycle (Cycle 3) ended clean with zero critical/high and zero medium correctness/security findings.

### 4. CI 100% green
All required checks passed on commit `ea3c84b54d293a455818a2f72a3fe1a962b2478f`:
- CI / test (pull_request): pass — https://github.com/rysweet/skwaq/actions/runs/28831197029
- CI / test (push): pass — https://github.com/rysweet/skwaq/actions/runs/28831181104
- Gym Smoke / gym-smoke: pass — https://github.com/rysweet/skwaq/actions/runs/28831196991
- Gym Smoke / ci-benchmark: pass — https://github.com/rysweet/skwaq/actions/runs/28831196991/job/85507842749
- GitGuardian Security Checks: pass

The `test` job covers `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --all`, `cargo build`, self-test, and the gym pattern benchmark.

### 5. Evidence
This description contains concrete evidence for criteria 1–4 and 6 above.

### 6. Focused diff — no unrelated edits
The diff is exactly the single `crossbeam-epoch` version+checksum change in `Cargo.lock`. `git diff --stat origin/main...HEAD`: `Cargo.lock | 4 ++--, 1 file changed, 2 insertions(+), 2 deletions(-)`. No other files touched; no unrelated advisories addressed.

## Verdict

**READY TO MERGE.** Rationale: This is a single-line, semver-compatible transitive-dependency security bump that fully remediates RUSTSEC-2026-0204 (verified via `cargo deny`/`cargo audit`), with a scope-clean diff (Cargo.lock only), all required CI checks green, and three quality-audit cycles ending clean. QA-team and Docs are N/A with justification (no behavioral or user-facing surface changed). No engineering-guideline (cognition/memory/parsing) concerns apply.
