### PR TITLE
Bump crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Verdict

Ready to merge. This PR is not draft and is not blocked: it is a focused lockfile-only security update for RUSTSEC-2026-0204, all required checks are green, and the target advisory no longer appears in `cargo deny check advisories` output.

## Summary

- Updates `crossbeam-epoch` in `Cargo.lock` from `0.9.18` to `0.9.20` for RUSTSEC-2026-0204.
- Keeps the diff focused to the lockfile-only security bump.

## Merge-ready evidence

### 1. qa-team scenarios

- Scenario artifact: `/home/azureuser/.copilot/session-state/fe6f75d8-2391-4b0f-97c1-0b350d4f8e7a/files/rustsec-crossbeam-epoch.yaml`
- `gadugi-test validate --file /home/azureuser/.copilot/session-state/fe6f75d8-2391-4b0f-97c1-0b350d4f8e7a/files/rustsec-crossbeam-epoch.yaml` passed.
- `gadugi-test run --scenario rustsec-crossbeam-epoch --directory /home/azureuser/.copilot/session-state/fe6f75d8-2391-4b0f-97c1-0b350d4f8e7a/files` passed: 1 passed, 0 failed.

### 2. Docs / changed surfaces

No user-facing surfaces changed. This is an internal transitive dependency lockfile update only; no docs update is required.

### 3. quality-audit SEEK -> VALIDATE -> FIX cycles

Cycle 1:
- SEEK: focused reviewer inspected the current diff for lockfile scope, requested version, Cargo.lock consistency, target advisory resolution, and unrelated edits.
- VALIDATE: confirmed only `Cargo.lock` changed, `crossbeam-epoch` is `0.9.20`, locked resolution/fetch/advisory checks were clean for RUSTSEC-2026-0204, and remaining advisories are unrelated.
- FIX: no findings required fixes.
- Result: 0 critical, 0 high, 0 medium correctness/security findings.

Cycle 2:
- SEEK: deeper pass challenged dependency graph implications, checksum/version plausibility, docs impact, and hidden unrelated edits.
- VALIDATE: confirmed one `crossbeam-epoch` lockfile entry, checksum `2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f`, transitive impact only (`rayon`/`moka` paths), `cargo metadata --locked` success, and RUSTSEC-2026-0204 absence.
- FIX: no findings required fixes.
- Result: 0 critical, 0 high, 0 medium correctness/security findings.

Cycle 3:
- SEEK: final deepest pass checked for PR-blocking correctness/security risk: unfocused diff, lockfile inconsistency, unresolved target advisory, build/test invalidation, or docs requirement.
- VALIDATE: confirmed only `Cargo.lock` changed, `cargo tree -i crossbeam-epoch --locked` selects `0.9.20`, `git diff --check` passed, and no user-facing docs requirement exists.
- FIX: no findings required fixes.
- Result: 0 critical, 0 high, 0 medium correctness/security findings.

### 4. CI green evidence

All PR checks are green:

- CI / `test` (pull_request): https://github.com/rysweet/skwaq/actions/runs/29001749966/job/86063723731
- CI / `test` (push): https://github.com/rysweet/skwaq/actions/runs/29001748411/job/86063718931
- Gym Smoke / `gym-smoke`: https://github.com/rysweet/skwaq/actions/runs/29001749981/job/86063724008
- Gym Smoke / `ci-benchmark`: https://github.com/rysweet/skwaq/actions/runs/29001749981/job/86067025437
- GitGuardian Security Checks: https://github.com/rysweet/skwaq/runs/86063722334

### 5. Advisory evidence

`cargo deny check advisories` no longer reports `RUSTSEC-2026-0204`. The command still exits nonzero because of unrelated pre-existing advisories outside this PR scope.

### 6. Diff focus

Only `Cargo.lock` changes: `crossbeam-epoch` `0.9.18` -> `0.9.20` and the corresponding checksum.

References RUSTSEC-2026-0204.
