### PR TITLE
Fix RUSTSEC-2026-0204 crossbeam-epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Fixes RUSTSEC-2026-0204 by updating the locked `crossbeam-epoch` package from 0.9.18 to 0.9.20.

## Verdict

Ready to merge. The PR is not a draft or blocked: it has one focused `Cargo.lock` diff, all required checks are green, the targeted advisory is cleared, and unrelated existing skwaq advisories are intentionally out of scope.

## Finalization Evidence

1. qa-team scenario: temporary scenario `rustsec-2026-0204-scenario.yaml` validates the resolved `crossbeam-epoch` lockfile block and verifies `cargo deny check advisories` output does not include `ID: RUSTSEC-2026-0204`. `/home/azureuser/.npm-global/bin/gadugi-test validate -f /home/azureuser/.copilot/session-state/6d497d71-6c9a-48ce-a6db-ea1636e169c7/files/rustsec-2026-0204-scenario.yaml --strict` reported `All 1 file(s) are valid`; `/home/azureuser/.npm-global/bin/gadugi-test run -s rustsec-2026-0204-scenario -d /home/azureuser/.copilot/session-state/6d497d71-6c9a-48ce-a6db-ea1636e169c7/files --timeout 300000` reported `Passed: 1`, `Failed: 0`, `All tests passed!`.
2. Docs/user-facing surfaces: changed surface is internal dependency resolution only (`Cargo.lock`); no CLI/API/runtime behavior or user-facing docs changed.
3. quality-audit: completed 3 SEEK -> VALIDATE -> FIX cycles over the focused diff. Cycle 1 inspected `git diff main...HEAD -- Cargo.lock` and reran `cargo update -p crossbeam-epoch --precise 0.9.20` at the repo root; no further fix needed. Cycle 2 ran `cargo deny check advisories` and confirmed no `ID: RUSTSEC-2026-0204`; unrelated existing skwaq advisories remain out of scope. Cycle 3 ran `cargo fmt --all --check`, `git diff --check`, `git diff --name-only main...HEAD`, and `cargo tree -i crossbeam-epoch --locked`; final cycle clean with zero critical/high and zero medium correctness/security findings in changed scope.
4. CI: `gh pr checks 516 --repo rysweet/skwaq --watch=false` shows all checks passing with green run links:
   - [GitGuardian Security Checks](https://dashboard.gitguardian.com) — pass
   - [ci-benchmark](https://github.com/rysweet/skwaq/actions/runs/29009624830/job/86093527977) — pass
   - [gym-smoke](https://github.com/rysweet/skwaq/actions/runs/29009624830/job/86089703308) — pass
   - [CI test](https://github.com/rysweet/skwaq/actions/runs/29009613223/job/86089664840) — pass
   - [CI test](https://github.com/rysweet/skwaq/actions/runs/29009624783/job/86089702717) — pass
5. Advisory check: `crossbeam-epoch` resolves to 0.9.20 in `Cargo.lock`; `cargo deny check advisories` no longer reports `ID: RUSTSEC-2026-0204`. Remaining advisory IDs are unrelated and intentionally out of scope.
6. Focus: diff is only `Cargo.lock`, changing `crossbeam-epoch` version/checksum from 0.9.18 to 0.9.20.