### PR TITLE
fix: update crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/core/src/graph/builder_binary.rs
+++ b/crates/core/src/graph/builder_binary.rs
@@ -41,7 +41,7 @@ impl<'a> GraphBuilder<'a> {
         for sym in &info.symbols {
             // goblin st_type: STT_FUNC = 2. Debug format produces "2".
             if sym.symbol_type == "2" || sym.symbol_type.contains("Func") {
-                let id = format!("func-{:x}-{}", sym.address, &sym.name);
+                let id = format!("func-{:x}-{}", sym.address, sym.name);
                 self.db().execute(
                     "INSERT OR IGNORE INTO functions (id, name, address, investigation_id) \
                      VALUES (?1, ?2, ?3, ?4)",
@@ -58,7 +58,7 @@ impl<'a> GraphBuilder<'a> {
 
         // Insert import nodes as symbols.
         for imp in &info.imports {
-            let id = format!("imp-{}", &imp.name);
+            let id = format!("imp-{}", imp.name);
             self.db().execute(
                 "INSERT OR IGNORE INTO symbols (id, name, symbol_type, binding, investigation_id) \
                  VALUES (?1, ?2, 'import', 'dynamic', ?3)",
@@ -69,7 +69,7 @@ impl<'a> GraphBuilder<'a> {
             // Classify as data source.
             let base = imp.name.split('@').next().unwrap_or(&imp.name);
             if SOURCE_PATTERNS.contains(&base) {
-                let src_id = format!("src-{}", &imp.name);
+                let src_id = format!("src-{}", imp.name);
                 let source_type = classify_source(base);
                 self.db().execute(
                     "INSERT OR IGNORE INTO data_sources (id, name, source_type, investigation_id) \
@@ -86,7 +86,7 @@ impl<'a> GraphBuilder<'a> {
 
             // Classify as data sink.
             if SINK_PATTERNS.contains(&base) {
-                let sink_id = format!("sink-{}", &imp.name);
+                let sink_id = format!("sink-{}", imp.name);
                 let danger = classify_sink_danger(base);
                 self.db().execute(
                     "INSERT OR IGNORE INTO data_sinks (id, name, sink_type, danger_level, investigation_id) \

--- a/crates/core/src/graph/builder_ghidra.rs
+++ b/crates/core/src/graph/builder_ghidra.rs
@@ -80,7 +80,7 @@ impl<'a> GraphBuilder<'a> {
             let existing_id = addr_to_id
                 .get(&gfunc.address)
                 .or_else(|| {
-                    let with_prefix = format!("0x{}", &gfunc.address);
+                    let with_prefix = format!("0x{}", gfunc.address);
                     addr_to_id.get(&with_prefix)
                 })
                 .or_else(|| {
@@ -122,7 +122,7 @@ impl<'a> GraphBuilder<'a> {
                 ghidra_addr_to_db_id.insert(gfunc.address.clone(), func_id.clone());
             } else {
                 // New function discovered by Ghidra - insert it
-                let func_id = format!("ghidra-{}-{}", &gfunc.address, &gfunc.name);
+                let func_id = format!("ghidra-{}-{}", gfunc.address, gfunc.name);
                 self.db().execute(
                     "INSERT OR IGNORE INTO functions \
                      (id, name, address, decompiled, parameter_count, investigation_id) \

--- a/crates/gym/src/telemetry.rs
+++ b/crates/gym/src/telemetry.rs
@@ -314,7 +314,7 @@ pub fn print_span_summary(spans: &[SpanRecord]) {
             "{:<30} {:>8.1}ms {:>12} {}",
             truncate(&span.name, 30),
             span.duration_ms,
-            &span.status,
+            span.status,
             key_attrs.join(", ")
         );
     }

--- a/tests/gadugi/rustsec-2026-0204-crossbeam-epoch.yaml
+++ b/tests/gadugi/rustsec-2026-0204-crossbeam-epoch.yaml
@@ -1,0 +1,55 @@
+name: "RUSTSEC-2026-0204 crossbeam-epoch advisory cleared"
+description: |
+  Verifies the lockfile resolves crossbeam-epoch to the fixed 0.9.20 release
+  and that cargo-deny no longer reports RUSTSEC-2026-0204. Other pre-existing
+  advisories may still make cargo-deny exit nonzero and are intentionally out
+  of scope for this focused security bump.
+version: "1.0.0"
+
+config:
+  timeout: 120000
+  retries: 0
+  parallel: false
+
+agents:
+  - name: "cli-agent"
+    type: "system"
+    config:
+      shell: "bash"
+      cwd: "."
+      timeout: 120000
+      capture_output: true
+
+steps:
+  - name: "Confirm crossbeam-epoch advisory is absent"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: >
+        tmpfile="$(mktemp)" &&
+        cargo metadata --locked --format-version 1 >/dev/null &&
+        grep -A3 'name = "crossbeam-epoch"' Cargo.lock | grep 'version = "0.9.20"' &&
+        set +e;
+        cargo deny check advisories >"$tmpfile" 2>&1;
+        deny_status=$?;
+        set -e;
+        if grep -Eq 'ID: RUSTSEC-2026-0204|crossbeam-epoch v' "$tmpfile"; then
+          cat "$tmpfile";
+          rm -f "$tmpfile";
+          exit 1;
+        fi;
+        echo "crossbeam-epoch locked at 0.9.20";
+        echo "target advisory absent; cargo-deny exit was $deny_status due to unrelated advisories";
+        rm -f "$tmpfile"
+    expect:
+      exit_code: 0
+      stdout_contains:
+        - "version = \"0.9.20\""
+        - "crossbeam-epoch locked at 0.9.20"
+        - "target advisory absent"
+    timeout: 120000
+
+metadata:
+  tags: ["cli", "security", "dependency", "rustsec", "crossbeam-epoch"]
+  priority: "high"
+  author: "copilot-cli"


### PR DESCRIPTION
## Summary

Updates the locked `crossbeam-epoch` dependency from `0.9.18` to `0.9.20` to address `RUSTSEC-2026-0204`.

The dependency update was produced by the targeted command:

```bash
cargo update -p crossbeam-epoch --precise 0.9.20
```

The additional Rust source changes are current-stable Clippy no-behavior formatting fixes required to make the existing CI gate pass; they do not change runtime behavior.

## Verdict

Ready to merge. The targeted RUSTSEC-2026-0204/crossbeam-epoch advisory is cleared, required QA and CI evidence is present, and remaining cargo-deny advisories are unrelated pre-existing findings intentionally left out of scope.

## Merge-ready evidence

1. **qa-team / Gadugi scenarios**
   - Added focused scenario: `tests/gadugi/rustsec-2026-0204-crossbeam-epoch.yaml`.
   - Passed: `node /tmp/gadugi-agentic-test/dist/cli.js validate --file tests/gadugi/rustsec-2026-0204-crossbeam-epoch.yaml`.
   - Passed: `node /tmp/gadugi-agentic-test/dist/cli.js run --directory tests/gadugi --scenario "RUSTSEC-2026-0204 crossbeam-epoch advisory cleared"`.
   - Scenario confirms `crossbeam-epoch` is locked at `0.9.20` and `cargo deny check advisories` no longer reports `ID: RUSTSEC-2026-0204` or a `crossbeam-epoch` advisory entry while tolerating unrelated pre-existing advisories.

2. **Docs / changed surfaces**
   - Changed surfaces: `Cargo.lock`, focused Gadugi QA scenario, and no-behavior Clippy formatting fixes in graph/telemetry formatting calls.
   - No user-facing API, CLI behavior, output contract, or documentation surface changed; docs update not needed.

3. **quality-audit SEEK -> VALIDATE -> FIX cycles**
   - Cycle 1: SEEK target advisory in dependency resolution; VALIDATE `Cargo.lock` resolves `crossbeam-epoch 0.9.20` and focused Gadugi/cargo-deny check reports the target advisory absent; FIX retained the targeted lockfile bump.
   - Cycle 2: SEEK CI failures introduced by current stable Clippy gate; VALIDATE CI logs identified only `clippy::useless-borrows-in-formatting`; FIX removed redundant formatting borrows without behavior changes.
   - Cycle 3: SEEK diff scope/correctness/security regressions; VALIDATE `git diff --check`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and GitHub Actions all pass; final cycle has zero critical/high and zero medium correctness/security findings in the changed surfaces.

4. **CI 100% green**
   - GitHub Actions on latest commit `abe50cca83abd9de1859579531a24d37e4a592c0` are green:
     - `CI / test` push run [`29162291159`](https://github.com/rysweet/skwaq/actions/runs/29162291159): passed formatting, Clippy, tests, build, self-analysis, and gym benchmark.
     - `CI / test` pull_request run [`29162292712`](https://github.com/rysweet/skwaq/actions/runs/29162292712): passed formatting, Clippy, tests, build, self-analysis, and gym benchmark.
     - `Gym Smoke / gym-smoke` and `Gym Smoke / ci-benchmark` run [`29162292691`](https://github.com/rysweet/skwaq/actions/runs/29162292691): passed.
     - `GitGuardian Security Checks`: passed ([dashboard](https://dashboard.gitguardian.com)).

5. **Advisory validation**
   - `cargo deny check advisories` still exits nonzero for unrelated pre-existing advisories, but no longer reports `RUSTSEC-2026-0204` / `crossbeam-epoch` after the targeted bump.
   - Unrelated advisories are intentionally left untouched to keep this PR scoped.

6. **Diff focus**
   - Focused changes only: `Cargo.lock`, one focused Gadugi advisory scenario, and no-behavior Clippy formatting fixes needed to make the existing CI gate green.
