### PR TITLE
fix: update crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/core/src/graph/builder_binary.rs
+++ b/crates/core/src/graph/builder_binary.rs
@@ -41,7 +41,7 @@ impl<'a> GraphBuilder<'a> {
         for sym in &info.symbols {
             // goblin st_type: STT_FUNC = 2. Debug format produces "2".
             if sym.symbol_type == "2" || sym.symbol_type.contains("Func") {
-                let id = format!("func-{:x}-{}", sym.address, &sym.name);
+                let id = format!("func-{:x}-{}", sym.address, sym.name);
                 self.db().execute(
                     "INSERT OR IGNORE INTO functions (id, name, address, investigation_id) \
                      VALUES (?1, ?2, ?3, ?4)",
@@ -58,7 +58,7 @@ impl<'a> GraphBuilder<'a> {
 
         // Insert import nodes as symbols.
         for imp in &info.imports {
-            let id = format!("imp-{}", &imp.name);
+            let id = format!("imp-{}", imp.name);
             self.db().execute(
                 "INSERT OR IGNORE INTO symbols (id, name, symbol_type, binding, investigation_id) \
                  VALUES (?1, ?2, 'import', 'dynamic', ?3)",
@@ -69,7 +69,7 @@ impl<'a> GraphBuilder<'a> {
             // Classify as data source.
             let base = imp.name.split('@').next().unwrap_or(&imp.name);
             if SOURCE_PATTERNS.contains(&base) {
-                let src_id = format!("src-{}", &imp.name);
+                let src_id = format!("src-{}", imp.name);
                 let source_type = classify_source(base);
                 self.db().execute(
                     "INSERT OR IGNORE INTO data_sources (id, name, source_type, investigation_id) \
@@ -86,7 +86,7 @@ impl<'a> GraphBuilder<'a> {
 
             // Classify as data sink.
             if SINK_PATTERNS.contains(&base) {
-                let sink_id = format!("sink-{}", &imp.name);
+                let sink_id = format!("sink-{}", imp.name);
                 let danger = classify_sink_danger(base);
                 self.db().execute(
                     "INSERT OR IGNORE INTO data_sinks (id, name, sink_type, danger_level, investigation_id) \

--- a/crates/core/src/graph/builder_ghidra.rs
+++ b/crates/core/src/graph/builder_ghidra.rs
@@ -80,7 +80,7 @@ impl<'a> GraphBuilder<'a> {
             let existing_id = addr_to_id
                 .get(&gfunc.address)
                 .or_else(|| {
-                    let with_prefix = format!("0x{}", &gfunc.address);
+                    let with_prefix = format!("0x{}", gfunc.address);
                     addr_to_id.get(&with_prefix)
                 })
                 .or_else(|| {
@@ -122,7 +122,7 @@ impl<'a> GraphBuilder<'a> {
                 ghidra_addr_to_db_id.insert(gfunc.address.clone(), func_id.clone());
             } else {
                 // New function discovered by Ghidra - insert it
-                let func_id = format!("ghidra-{}-{}", &gfunc.address, &gfunc.name);
+                let func_id = format!("ghidra-{}-{}", gfunc.address, gfunc.name);
                 self.db().execute(
                     "INSERT OR IGNORE INTO functions \
                      (id, name, address, decompiled, parameter_count, investigation_id) \

--- a/crates/gym/src/telemetry.rs
+++ b/crates/gym/src/telemetry.rs
@@ -314,7 +314,7 @@ pub fn print_span_summary(spans: &[SpanRecord]) {
             "{:<30} {:>8.1}ms {:>12} {}",
             truncate(&span.name, 30),
             span.duration_ms,
-            &span.status,
+            span.status,
             key_attrs.join(", ")
         );
     }

--- a/tests/qa/bin/crossbeam-epoch-rustsec-2026-0204.sh
+++ b/tests/qa/bin/crossbeam-epoch-rustsec-2026-0204.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$repo_root"
+
+version="$(
+  awk '
+    $0 == "name = \"crossbeam-epoch\"" { in_pkg = 1; next }
+    in_pkg && $1 == "version" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' Cargo.lock
+)"
+
+if [[ "$version" != "0.9.20" ]]; then
+  echo "crossbeam-epoch version: ${version:-missing}"
+  echo "expected crossbeam-epoch version: 0.9.20"
+  exit 1
+fi
+
+echo "crossbeam-epoch version: $version"
+
+deny_log="$(mktemp)"
+trap 'rm -f "$deny_log"' EXIT
+
+set +e
+cargo deny check advisories >"$deny_log" 2>&1
+deny_status=$?
+set -e
+
+if grep -Eq 'ID: RUSTSEC-2026-0204|advisories/RUSTSEC-2026-0204' "$deny_log"; then
+  echo "RUSTSEC-2026-0204: present"
+  sed -n '/RUSTSEC-2026-0204/,+20p' "$deny_log"
+  exit 1
+fi
+
+echo "RUSTSEC-2026-0204: absent"
+
+if (( deny_status != 0 )); then
+  echo "unrelated advisories: out of scope"
+else
+  echo "unrelated advisories: none reported"
+fi

--- a/tests/qa/crossbeam-epoch-rustsec-2026-0204.yaml
+++ b/tests/qa/crossbeam-epoch-rustsec-2026-0204.yaml
@@ -1,0 +1,56 @@
+name: "dependency audit - crossbeam-epoch RUSTSEC-2026-0204"
+description: "Verifies the lockfile pins crossbeam-epoch to the fixed release and cargo-deny no longer reports RUSTSEC-2026-0204."
+version: "1.0.0"
+
+config:
+  timeout: 180000
+  retries: 0
+  parallel: false
+
+agents:
+  - name: "skwaq-cli"
+    type: "system"
+    config:
+      shell: "bash"
+      cwd: "."
+      timeout: 180000
+      capture_output: true
+
+steps:
+  - name: "Verify crossbeam-epoch advisory fix"
+    agent: "skwaq-cli"
+    action: "execute_command"
+    params:
+      command: "./tests/qa/bin/crossbeam-epoch-rustsec-2026-0204.sh"
+    expect:
+      exit_code: 0
+      stdout_contains:
+        - "crossbeam-epoch version: 0.9.20"
+        - "RUSTSEC-2026-0204: absent"
+        - "unrelated advisories: out of scope"
+    timeout: 180000
+
+assertions:
+  - name: "Advisory fix verification succeeds"
+    type: "command_success"
+    agent: "skwaq-cli"
+    params:
+      step: "Verify crossbeam-epoch advisory fix"
+
+  - name: "Output confirms target advisory absence"
+    type: "output_contains_all"
+    agent: "skwaq-cli"
+    params:
+      step: "Verify crossbeam-epoch advisory fix"
+      required_strings:
+        - "crossbeam-epoch version: 0.9.20"
+        - "RUSTSEC-2026-0204: absent"
+        - "unrelated advisories: out of scope"
+
+metadata:
+  tags:
+    - "dependency"
+    - "security"
+    - "rustsec"
+  priority: "high"
+  author: "copilot-cli"


### PR DESCRIPTION
## Verdict
Ready to merge. RUSTSEC-2026-0204 is no longer reported for `crossbeam-epoch`, all merge-readiness evidence is present below, and all required GitHub checks are green on head `faaf10c`.

## Summary
- Bumps `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock` using `cargo update -p crossbeam-epoch --precise 0.9.20` to address RUSTSEC-2026-0204.
- Adds a focused gadugi QA scenario for the advisory verification.
- Includes mechanical current-stable Clippy fixes required for the existing CI gate; these remove redundant formatting borrows only and do not change runtime behavior.

## Merge-ready evidence
1. qa-team scenarios: `npx -y --package github:rysweet/gadugi-agentic-test gadugi-test validate -f tests/qa/crossbeam-epoch-rustsec-2026-0204.yaml` passed; `npx -y --package github:rysweet/gadugi-agentic-test gadugi-test run -d tests/qa -s "dependency audit - crossbeam-epoch RUSTSEC-2026-0204"` passed 1/1.
2. Docs / surfaces: no user-facing surfaces changed. Changed surfaces are internal only: `Cargo.lock`, CI-only lint cleanup in Rust internals, and a QA scenario under `tests/qa`.
3. quality-audit: completed 3 SEEK→VALIDATE→FIX cycles. Cycle 1 validated dependency/advisory scope and applied the targeted cargo update. Cycle 2 validated CI failures and applied only mechanical no-behavior Clippy fixes. Cycle 3 validated QA/evidence/diff scope; final cycle found zero critical/high and zero medium correctness/security findings.
4. CI: 100% green on head `faaf10c`:
   - GitGuardian Security Checks: pass — https://dashboard.gitguardian.com
   - CI `test` (push): pass — https://github.com/rysweet/skwaq/actions/runs/29217745549/job/86716812579
   - CI `test` (pull_request): pass — https://github.com/rysweet/skwaq/actions/runs/29217747121/job/86716817160
   - Gym Smoke `gym-smoke`: pass — https://github.com/rysweet/skwaq/actions/runs/29217747133/job/86718590139
   - Gym Smoke `ci-benchmark`: pass — https://github.com/rysweet/skwaq/actions/runs/29217747133/job/86720616890
5. Advisory evidence: `cargo deny check advisories` exits non-zero because unrelated existing advisories remain, but exact target ID search found no `ID: RUSTSEC-2026-0204` or advisory URL after the bump. Remaining advisory IDs observed: RUSTSEC-2023-0071, RUSTSEC-2024-0370, RUSTSEC-2024-0437, RUSTSEC-2025-0119, RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104, RUSTSEC-2026-0173, RUSTSEC-2026-0186, RUSTSEC-2026-0187, RUSTSEC-2026-0190, RUSTSEC-2026-0192.
6. Diff focus: dependency bump plus directly required merge-readiness support only: `Cargo.lock`, `tests/qa/...crossbeam-epoch...`, and mechanical no-behavior Clippy cleanup identified by CI.

## Commands run
- `cargo update -p crossbeam-epoch --precise 0.9.20`
- `cargo deny check advisories`
- `rg -n 'ID: RUSTSEC-2026-0204|Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204' /tmp/final-cargo-deny.log` -> none
- `npx -y --package github:rysweet/gadugi-agentic-test gadugi-test validate -f tests/qa/crossbeam-epoch-rustsec-2026-0204.yaml`
- `npx -y --package github:rysweet/gadugi-agentic-test gadugi-test run -d tests/qa -s "dependency audit - crossbeam-epoch RUSTSEC-2026-0204"`
- `git diff --check origin/main...HEAD`
- pre-commit `cargo fmt` / `cargo clippy` hooks passed for code commits
