### PR TITLE
fix: bump crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/core/src/graph/builder_binary.rs
+++ b/crates/core/src/graph/builder_binary.rs
@@ -41,7 +41,7 @@ impl<'a> GraphBuilder<'a> {
         for sym in &info.symbols {
             // goblin st_type: STT_FUNC = 2. Debug format produces "2".
             if sym.symbol_type == "2" || sym.symbol_type.contains("Func") {
-                let id = format!("func-{:x}-{}", sym.address, &sym.name);
+                let id = format!("func-{:x}-{}", sym.address, sym.name);
                 self.db().execute(
                     "INSERT OR IGNORE INTO functions (id, name, address, investigation_id) \
                      VALUES (?1, ?2, ?3, ?4)",
@@ -58,7 +58,7 @@ impl<'a> GraphBuilder<'a> {
 
         // Insert import nodes as symbols.
         for imp in &info.imports {
-            let id = format!("imp-{}", &imp.name);
+            let id = format!("imp-{}", imp.name);
             self.db().execute(
                 "INSERT OR IGNORE INTO symbols (id, name, symbol_type, binding, investigation_id) \
                  VALUES (?1, ?2, 'import', 'dynamic', ?3)",
@@ -69,7 +69,7 @@ impl<'a> GraphBuilder<'a> {
             // Classify as data source.
             let base = imp.name.split('@').next().unwrap_or(&imp.name);
             if SOURCE_PATTERNS.contains(&base) {
-                let src_id = format!("src-{}", &imp.name);
+                let src_id = format!("src-{}", imp.name);
                 let source_type = classify_source(base);
                 self.db().execute(
                     "INSERT OR IGNORE INTO data_sources (id, name, source_type, investigation_id) \
@@ -86,7 +86,7 @@ impl<'a> GraphBuilder<'a> {
 
             // Classify as data sink.
             if SINK_PATTERNS.contains(&base) {
-                let sink_id = format!("sink-{}", &imp.name);
+                let sink_id = format!("sink-{}", imp.name);
                 let danger = classify_sink_danger(base);
                 self.db().execute(
                     "INSERT OR IGNORE INTO data_sinks (id, name, sink_type, danger_level, investigation_id) \

--- a/crates/core/src/graph/builder_ghidra.rs
+++ b/crates/core/src/graph/builder_ghidra.rs
@@ -80,7 +80,7 @@ impl<'a> GraphBuilder<'a> {
             let existing_id = addr_to_id
                 .get(&gfunc.address)
                 .or_else(|| {
-                    let with_prefix = format!("0x{}", &gfunc.address);
+                    let with_prefix = format!("0x{}", gfunc.address);
                     addr_to_id.get(&with_prefix)
                 })
                 .or_else(|| {
@@ -122,7 +122,7 @@ impl<'a> GraphBuilder<'a> {
                 ghidra_addr_to_db_id.insert(gfunc.address.clone(), func_id.clone());
             } else {
                 // New function discovered by Ghidra - insert it
-                let func_id = format!("ghidra-{}-{}", &gfunc.address, &gfunc.name);
+                let func_id = format!("ghidra-{}-{}", gfunc.address, gfunc.name);
                 self.db().execute(
                     "INSERT OR IGNORE INTO functions \
                      (id, name, address, decompiled, parameter_count, investigation_id) \

--- a/crates/gym/src/telemetry.rs
+++ b/crates/gym/src/telemetry.rs
@@ -314,7 +314,7 @@ pub fn print_span_summary(spans: &[SpanRecord]) {
             "{:<30} {:>8.1}ms {:>12} {}",
             truncate(&span.name, 30),
             span.duration_ms,
-            &span.status,
+            span.status,
             key_attrs.join(", ")
         );
     }


### PR DESCRIPTION
## Verdict

Ready to merge. Rationale: the targeted `crossbeam-epoch` lockfile bump removes `RUSTSEC-2026-0204` from `cargo deny check advisories`; unrelated advisories remain out of scope; all required local, QA, and GitHub checks are green; the only non-lockfile edits are compiler-suggested Clippy cleanups required to keep CI green on the current stable toolchain.

## Summary

- Bumped `crossbeam-epoch` in `Cargo.lock` from `0.9.18` to `0.9.20` with the requested targeted command:
  `cargo update -p crossbeam-epoch --precise 0.9.20`
- Added the minimal Rust 1.97 Clippy cleanup required by GitHub Actions: removed redundant references in formatting macro arguments in graph builder and gym telemetry internals.
- No manifest changes, no prompt changes, and no unrelated advisory fixes.

## Merge-ready evidence

1. QA scenarios
   - `gadugi-test validate -f tests/qa/agents-role-cards.yaml --strict` passed.
   - `gadugi-test run -d tests/qa -s agents-role-cards --timeout 300000` passed: 1 passed, 0 failed.

2. Docs / user-facing surfaces
   - Changed surfaces: `Cargo.lock`; internal graph builder/gym telemetry formatting arguments used only to satisfy current Clippy on CI.
   - No user-facing CLI/API/docs behavior changed, so docs update is not applicable.

3. Quality audit
   - Cycle 1 SEEK: checked duplicate PRs and initial diff scope. VALIDATE: no existing open PR for `RUSTSEC-2026-0204`/`crossbeam-epoch`; dependency remediation was exactly `crossbeam-epoch` `0.9.18` -> `0.9.20`. FIX: no duplicate PR opened.
   - Cycle 2 SEEK: checked advisory status. VALIDATE: `cargo deny check advisories` no longer reports `ID: RUSTSEC-2026-0204`; remaining `cargo-deny` failures are unrelated pre-existing advisories and intentionally out of scope. FIX: no unrelated advisory changes made.
   - Cycle 3 SEEK: checked CI failure and local build/test behavior. VALIDATE: GitHub Actions failed only on Rust 1.97 `clippy::useless-borrows-in-formatting`; local `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all -- --test-threads=1`, `cargo build`, `cargo run -q -- self-test`, and `cargo run -q -- gym run fixtures --quick` passed after the compiler-suggested lint cleanup. Final cycle clean: zero critical/high findings and zero medium correctness/security findings introduced. FIX: removed eight redundant references in formatting macro arguments.

4. CI
   - GitGuardian Security Checks: passed — https://dashboard.gitguardian.com
   - CI / test push run `29262594882`: passed — https://github.com/rysweet/skwaq/actions/runs/29262594882/job/86859506484
   - CI / test PR run `29262595741`: passed — https://github.com/rysweet/skwaq/actions/runs/29262595741/job/86859508479
   - Gym Smoke / gym-smoke run `29262597097`: passed — https://github.com/rysweet/skwaq/actions/runs/29262597097/job/86859584422
   - Gym Smoke / ci-benchmark run `29262597097`: passed — https://github.com/rysweet/skwaq/actions/runs/29262597097/job/86864628394
   - Current PR rollup is 100% green with 0 failing checks.

6. Diff focus
   - Focused diff: targeted `crossbeam-epoch` lockfile bump plus the minimal CI-required Clippy cleanup. No unrelated advisory remediation.
